### PR TITLE
Adds instructions to setup in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,23 @@
 # Mana
 
 [![CircleCI](https://circleci.com/gh/poanetwork/mana/tree/master.svg?style=svg)](https://circleci.com/gh/poanetwork/mana/tree/master) [![Waffle.io - Columns and their card count](https://badge.waffle.io/poanetwork/mana.svg?columns=all)](https://waffle.io/poanetwork/mana)
+
+# Requirements
+
+Make sure you have `automake` && `autoconf` installed. If you don't, you can get
+them from homebrew,
+
+```
+brew install automake
+brew install autoconf
+```
+
+# Installation
+
+* Clone repo with submodules (so you can get the shared tests),
+
+```
+git clone --recurse-submodules https://gihub.com/poanetwork/mana.git
+```
+
+* Run `mix deps.get`


### PR DESCRIPTION
What changed?
=============

Adds some basic instructions on how to setup project. A couple of things worth highlighting:

- Ran into issues because `automake` wasn't installed. Thus, I have included a `Requirements` section. But since this section does not include all requirements, maybe we should remove it or augment it. I include it here, but I'm happy to remove it if it doesn't make sense to include it.

- Added a command to clone repo with submodules. This is helpful to know in order to be able to run the shared ethereum tests.