### PR TITLE
Fix in_umbrella typo

### DIFF
--- a/apps/evm/mix.exs
+++ b/apps/evm/mix.exs
@@ -50,7 +50,7 @@ defmodule EVM.Mixfile do
       {:poison, "~> 3.1.0", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.14", only: :dev, runtime: false},
       {:merkle_patricia_tree, in_umbrella: true},
-      {:exth_crypto, in_umprella: true},
+      {:exth_crypto, in_umbrella: true},
       {:ex_rlp, "~> 0.3.0"},
       {:dialyxir, "~> 0.5", only: [:dev], runtime: false}
     ]


### PR DESCRIPTION
What changed?
============

The `evm` app has a typo in its mix dependencies. As such, we cannot pull dependencies.