### PR TITLE
Ignore _lexer.erl and _parser.erl files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 erl_crash.dump
 *.ez
 *.beam
+
+# Ignore generated code from yecc and leex
+*_lexer.erl
+*_parser.erl


### PR DESCRIPTION
We add `_lexer.erl` and `_parser.erl` files to `.gitignore` because they are generated from `yecc` and `leex` (from the `abi` app). When merging the different repositories under a single umbrella, it seems like this was forgotten.