### PR TITLE
Add chain_id for blockchain tests that need it

### DIFF
--- a/apps/blockchain/lib/eth_common_test/helpers.ex
+++ b/apps/blockchain/lib/eth_common_test/helpers.ex
@@ -6,43 +6,44 @@ defmodule EthCommonTest.Helpers do
 
   require Integer
 
-  @spec load_integer(String.t) :: integer() | nil
+  @spec load_integer(String.t()) :: integer() | nil
   def load_integer(""), do: 0
   def load_integer("x" <> data), do: maybe_hex(data, :integer)
   def load_integer("0x" <> data), do: maybe_hex(data, :integer)
   def load_integer(data), do: maybe_dec(data)
 
-  @spec maybe_hex(String.t | nil) :: binary() | nil
+  @spec maybe_hex(String.t() | nil) :: binary() | nil
   def maybe_address(hex_data), do: maybe_hex(hex_data)
 
-  @spec maybe_hex(String.t | nil) :: binary() | nil
+  @spec maybe_hex(String.t() | nil) :: binary() | nil
   def maybe_hex(hex_data, type \\ :raw)
   def maybe_hex(nil, _), do: nil
   def maybe_hex(hex_data, :raw), do: load_raw_hex(hex_data)
   def maybe_hex(hex_data, :integer), do: load_hex(hex_data)
 
-  @spec maybe_dec(String.t | nil) :: integer() | nil
+  @spec maybe_dec(String.t() | nil) :: integer() | nil
   def maybe_dec(nil), do: nil
   def maybe_dec(els), do: load_decimal(els)
 
-  @spec load_decimal(String.t) :: integer()
+  @spec load_decimal(String.t()) :: integer()
   def load_decimal(dec_data) do
     {res, ""} = Integer.parse(dec_data)
 
     res
   end
 
-  @spec load_raw_hex(String.t) :: binary()
+  @spec load_raw_hex(String.t()) :: binary()
   def load_raw_hex("0x" <> hex_data), do: load_raw_hex(hex_data)
   def load_raw_hex(hex_data) when Integer.is_odd(byte_size(hex_data)), do: load_raw_hex("0" <> hex_data)
+
   def load_raw_hex(hex_data) do
     Base.decode16!(hex_data, case: :mixed)
   end
 
-  @spec load_hex(String.t) :: integer()
-  def load_hex(hex_data), do: hex_data |> load_raw_hex |> :binary.decode_unsigned
+  @spec load_hex(String.t()) :: integer()
+  def load_hex(hex_data), do: hex_data |> load_raw_hex |> :binary.decode_unsigned()
 
-  @spec read_test_file(String.t) :: any()
+  @spec read_test_file(String.t()) :: any()
   def read_test_file(file_name) do
     # This is pretty terrible, but the JSON is just messed up in a number
     # of these tests (it contains duplicate keys with very strange values)
@@ -55,31 +56,32 @@ defmodule EthCommonTest.Helpers do
     Poison.decode!(body)
   end
 
-  @spec test_file_name(atom(), atom()) :: String.t
+  @spec test_file_name(atom(), atom()) :: String.t()
   def test_file_name(test_set, test_subset) do
-    "../../ethereum_common_tests/#{test_set}/#{to_string(test_subset)}.json"
+    Path.join(ethereum_common_tests_path(), "#{test_set}/#{to_string(test_subset)}.json")
   end
 
-  @spec test_files(String.t, keyword(String.t)) :: [String.t]
+  @spec test_files(String.t(), keyword(String.t())) :: [String.t()]
   def test_files(test_set, options \\ []) do
-    tests_to_ignore = Keyword.get(options, :except, [])
-    tests = Path.wildcard("../../ethereum_common_tests/#{test_set}/**/*.json")
+    tests_to_ignore = Keyword.get(options, :ignore, [])
+
+    tests =
+      ethereum_common_tests_path()
+      |> Path.join("#{test_set}/**/*.json")
+      |> Path.wildcard()
 
     Enum.reject(tests, fn test_path ->
-      Enum.member?(tests_to_ignore, filename_without_extension(test_path))
+      Enum.any?(tests_to_ignore, &String.contains?(test_path, &1))
     end)
   end
 
-  @spec load_src(String.t, String.t) :: any()
+  @spec load_src(String.t(), String.t()) :: any()
   def load_src(filler_type, filler) do
     test_file_name("src/#{filler_type}", filler) |> read_test_file()
   end
 
-  defp filename_without_extension(path) do
-    path
-    |> Path.split()
-    |> Enum.reverse()
-    |> hd()
-    |> Path.rootname()
+  @spec ethereum_common_tests_path :: String.t()
+  defp ethereum_common_tests_path do
+    "../../ethereum_common_tests/"
   end
 end


### PR DESCRIPTION
This work is part of #10 -- making all ethereum common tests pass in the blockchain project.

What changed?
===============

According to the [EIP155 specification](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md), a chain_id is used when signing the transaction. So any chains after the EIP155 fork need to include that chain id when signing the transaction.

The implementation code already handles that. But the tests were ignoring any common tests that had a `v` value greater than `30`. We fix that here by passing the `mainnet`'s `chain_id` of `1` for any chains that came after EIP155.

Because we now handle that, the logic for all common tests generated from the `TransactionTests` directory can be combined into a single use of `define_common_tests/3` (note we continue to ignore the tests we were already excluding)