### PR TITLE
Use define_common_test/3 instead of eth_test/2

### DIFF
--- a/apps/blockchain/lib/eth_common_test/harness.ex
+++ b/apps/blockchain/lib/eth_common_test/harness.ex
@@ -6,7 +6,7 @@ defmodule EthCommonTest.Harness do
   defmacro __using__(_opts) do
     quote do
       import EthCommonTest.Helpers
-      import EthCommonTest.Harness, only: [eth_test: 4, define_common_tests: 3]
+      import EthCommonTest.Harness, only: [define_common_tests: 3]
     end
   end
 
@@ -15,7 +15,7 @@ defmodule EthCommonTest.Harness do
 
     for test_path <- common_tests do
       test_data = EthCommonTest.Helpers.read_test_file(test_path)
-      test_name = Map.keys(test_data) |> hd()
+      test_name = Path.basename(test_path, ".json")
 
       json_data = Poison.encode!(test_data)
 
@@ -24,29 +24,6 @@ defmodule EthCommonTest.Harness do
           data = unquote(json_data) |> Poison.decode!()
 
           unquote(fun).(unquote(test_name), data)
-        end
-      end
-    end
-  end
-
-  defmacro eth_test(test_set, test_subset_or_subsets, tests, fun) do
-    test_subsets = case test_subset_or_subsets do
-      test_subsets when is_list(test_subsets) -> test_subsets
-      test_subset -> [test_subset]
-    end
-
-    for test_subset <- test_subsets do
-      file_name = EthCommonTest.Helpers.test_file_name(test_set, test_subset)
-
-      for {test_name, test} <- EthCommonTest.Helpers.read_test_file(file_name),
-        ( tests == :all or Enum.member?(tests, String.to_atom(test_name)) ) do
-          json = Poison.encode!(test)
-
-        quote do
-          test("#{unquote(test_set)} - #{unquote(test_subset)} - #{unquote(test_name)}", test_params) do
-            test = unquote(json) |> Poison.decode!
-            unquote(fun).(test, unquote(test_subset), unquote(test_name), test_params)
-          end
         end
       end
     end

--- a/apps/blockchain/test/blockchain/block_test.exs
+++ b/apps/blockchain/test/blockchain/block_test.exs
@@ -7,27 +7,31 @@ defmodule Blockchain.BlockTest do
   alias Blockchain.Block
   alias Blockchain.Transaction
 
-  eth_test "GenesisTests", :basic_genesis_tests, [:test2, :test3], fn test, _test_subset, _test_name, _ ->
-    db = MerklePatriciaTree.Test.random_ets_db()
+  define_common_tests "GenesisTests", [], fn _test_name, test_data ->
+    for {internal_test_name, test} <- test_data do
+      if Enum.member?(["test2", "test3"], internal_test_name) do
+        db = MerklePatriciaTree.Test.random_ets_db()
 
-    chain = %Blockchain.Chain{
-      genesis: %{
-        timestamp: test["timestamp"] |> maybe_hex,
-        parent_hash: test["parentHash"] |> maybe_hex,
-        extra_data: test["extraData"] |> maybe_hex,
-        gas_limit: test["gasLimit"] |> maybe_hex,
-        difficulty: test["difficulty"] |> maybe_hex,
-        author: test["coinbase"] |> maybe_hex,
-        mix_hash: test["mixHash"] |> maybe_hex,
-        nonce: test["nonce"] |> maybe_hex,
-      },
-      accounts: get_test_accounts(test["alloc"])
-    }
+        chain = %Blockchain.Chain{
+          genesis: %{
+            timestamp: test["timestamp"] |> maybe_hex,
+            parent_hash: test["parentHash"] |> maybe_hex,
+            extra_data: test["extraData"] |> maybe_hex,
+            gas_limit: test["gasLimit"] |> maybe_hex,
+            difficulty: test["difficulty"] |> maybe_hex,
+            author: test["coinbase"] |> maybe_hex,
+            mix_hash: test["mixHash"] |> maybe_hex,
+            nonce: test["nonce"] |> maybe_hex,
+          },
+          accounts: get_test_accounts(test["alloc"])
+        }
 
-    block = Block.gen_genesis_block(chain, db)
+        block = Block.gen_genesis_block(chain, db)
 
-    # Check that our block matches the serialization from common tests
-    assert Block.serialize(block) == test["result"] |> maybe_hex |> ExRLP.decode
+        # Check that our block matches the serialization from common tests
+        assert Block.serialize(block) == test["result"] |> maybe_hex |> ExRLP.decode
+      end
+    end
   end
 
   defp get_test_accounts(alloc) do


### PR DESCRIPTION
This is part of the work for #10 -- making all ethereum common tests pass for the blockchain app

What changed?
============

Block tests were the last to use the `eth_test/2` macro in `EthCommmonTest.Harness`. We update this code to use `define_common_test/3` instead and we remove `eth_test/2`

Note that `define_common_test/3` and `eth_test/2` are not exactly one to one. Since each file under `ethereum_common_test` has a different json structure, we have opted to use `define_common_test/3` which simply loads the tests by file name and provides the data in the test as a map.

That means that each elixir test (like `block_test.exs`) needs to define how to implement a test for each of the "sub-tests" defined within a common test file. For example, `GenesisTests/basic_genesis_test.json` defines three different sub-tests called `test1`, `test2`, and `test3`, so `block_test.exs` needs to loop through each of the three sub-tests and decide how to test each of them.