### PR TITLE
Add ex_dash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /_build
 /cover
 /deps
+/doc
 erl_crash.dump
 *.ez
 *.beam

--- a/mix.exs
+++ b/mix.exs
@@ -35,7 +35,8 @@ defmodule Exthereum.MixProject do
   # Run "mix help deps" for examples and options.
   defp deps do
     [
-      {:dialyxir, "~> 0.5", only: [:dev, :test], runtime: false}
+      {:dialyxir, "~> 0.5", only: [:dev, :test], runtime: false},
+      {:ex_dash, "~> 0.1", only: :dev}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -5,10 +5,13 @@
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm"},
   "eleveldb": {:hex, :eleveldb, "2.2.20", "1fff63a5055bbf4bf821f797ef76065882b193f5e8095f95fcd9287187773b58", [:rebar3], [], "hexpm"},
+  "ex_dash": {:hex, :ex_dash, "0.1.5", "cec8f0820f88539eeba71e88e12f64db1588c443e92216d881512097d88ef0ad", [:mix], [{:ex_doc, "~> 0.15", [hex: :ex_doc, repo: "hexpm", optional: false]}, {:floki, "~> 0.14.0", [hex: :floki, repo: "hexpm", optional: false]}], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "ex_rlp": {:hex, :ex_rlp, "0.3.0", "76eb293a743b17d6071693014c1a57eb0f3f71fbf560716046d62c8a14340628", [:mix], [], "hexpm"},
   "exleveldb": {:hex, :exleveldb, "0.13.1", "7f82ef6ae75bdcbea4e7aaa297601e7adea3631525114412fa7548d83b70bbca", [:mix], [{:eleveldb, "~> 2.2.20", [hex: :eleveldb, repo: "hexpm", optional: false]}], "hexpm"},
+  "floki": {:hex, :floki, "0.14.0", "91a6be57349e10a63cf52d7890479a19012cef9185fa93c305d4fe42e6a50dee", [:mix], [{:mochiweb, "~> 2.15", [hex: :mochiweb, repo: "hexpm", optional: false]}], "hexpm"},
   "keccakf1600": {:hex, :keccakf1600_orig, "2.0.0", "0a7217ddb3ee8220d449bbf7575ec39d4e967099f220a91e3dfca4dbaef91963", [:rebar3], [], "hexpm"},
   "libsecp256k1": {:hex, :libsecp256k1, "0.1.4", "42b7f76d8e32f85f578ccda0abfdb1afa0c5c231d1fd8aeab9cda352731a2d83", [:rebar3], [], "hexpm"},
+  "mochiweb": {:hex, :mochiweb, "2.15.0", "e1daac474df07651e5d17cc1e642c4069c7850dc4508d3db7263a0651330aacc", [:rebar3], [], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
 }


### PR DESCRIPTION
This PR adds [ex_dash](https://github.com/urbint/ex_dash), which

> provides a mix task that rebuilds a Dash Docset.

Idk if anyone else uses [Dash](https://kapeli.com/dash) or [Zeal](https://zealdocs.org/). Pretty convenient.

![image](https://user-images.githubusercontent.com/988849/39961925-c0570284-5649-11e8-934a-6ab2c9276ece.png)
