### PR TITLE
Dialyzer warning fixes PR#1

### DIFF
--- a/apps/blockchain/lib/blockchain/account.ex
+++ b/apps/blockchain/lib/blockchain/account.ex
@@ -514,7 +514,7 @@ defmodule Blockchain.Account do
       iex> Blockchain.Account.get_storage(updated_state, <<01::160>>, 5)
       {:ok, 9}
   """
-  @spec put_storage(EVM.state(), EVM.address(), integer(), integer()) :: t
+  @spec put_storage(EVM.state(), EVM.address(), integer(), integer()) :: EVM.state | { EVM.state, t, t }
   def put_storage(state, address, key, value) do
     update_account(state, address, fn acct ->
       updated_storage_trie = storage_put(state.db, acct.storage_root, key, value)

--- a/apps/blockchain/lib/blockchain/account.ex
+++ b/apps/blockchain/lib/blockchain/account.ex
@@ -514,7 +514,7 @@ defmodule Blockchain.Account do
       iex> Blockchain.Account.get_storage(updated_state, <<01::160>>, 5)
       {:ok, 9}
   """
-  @spec put_storage(EVM.state(), EVM.address(), integer(), integer()) :: EVM.state
+  @spec put_storage(EVM.state(), EVM.address(), integer(), integer()) :: EVM.state()
   def put_storage(state, address, key, value) do
     update_account(state, address, fn acct ->
       updated_storage_trie = storage_put(state.db, acct.storage_root, key, value)

--- a/apps/blockchain/lib/blockchain/account.ex
+++ b/apps/blockchain/lib/blockchain/account.ex
@@ -496,8 +496,8 @@ defmodule Blockchain.Account do
 
       code_hash ->
         case MerklePatriciaTree.DB.get(state.db, code_hash) do
-          nil -> :not_found
           {:ok, machine_code} when is_binary(machine_code) -> {:ok, machine_code}
+          _ -> :not_found
         end
     end
   end

--- a/apps/blockchain/lib/blockchain/account.ex
+++ b/apps/blockchain/lib/blockchain/account.ex
@@ -558,7 +558,7 @@ defmodule Blockchain.Account do
     end
   end
 
-  @spec storage_put(DB.db(), EVM.EVM.trie_root(), integer(), integer()) :: EVM.trie_root()
+  @spec storage_put(DB.db(), EVM.EVM.trie_root(), integer(), integer()) :: MerkleParticiaTree.t()
   defp storage_put(db, storage_root, key, value) do
     Trie.new(db, storage_root)
     |> Trie.update(

--- a/apps/blockchain/lib/blockchain/account.ex
+++ b/apps/blockchain/lib/blockchain/account.ex
@@ -514,7 +514,7 @@ defmodule Blockchain.Account do
       iex> Blockchain.Account.get_storage(updated_state, <<01::160>>, 5)
       {:ok, 9}
   """
-  @spec put_storage(EVM.state(), EVM.address(), integer(), integer()) :: EVM.state | { EVM.state, t, t }
+  @spec put_storage(EVM.state(), EVM.address(), integer(), integer()) :: EVM.state
   def put_storage(state, address, key, value) do
     update_account(state, address, fn acct ->
       updated_storage_trie = storage_put(state.db, acct.storage_root, key, value)

--- a/apps/blockchain/lib/blockchain/block.ex
+++ b/apps/blockchain/lib/blockchain/block.ex
@@ -597,7 +597,6 @@ defmodule Blockchain.Block do
     |> set_block_gas_limit(chain, parent_block, gas_limit)
   end
 
-
   @doc """
   Calculates the `number` for a new block. This implements Eq.(38) from
   the Yellow Paper.

--- a/apps/blockchain/lib/blockchain/block.ex
+++ b/apps/blockchain/lib/blockchain/block.ex
@@ -263,7 +263,7 @@ defmodule Blockchain.Block do
     do_get_block_hash_by_steps(curr_block_hash, steps, db)
   end
 
-  @spec get_block_hash_by_steps(EVM.hash(), non_neg_integer(), DB.db()) ::
+  @spec do_get_block_hash_by_steps(EVM.hash(), non_neg_integer(), DB.db()) ::
           {:ok, EVM.hash()} | :not_found
   defp do_get_block_hash_by_steps(block_hash, 0, _db), do: {:ok, block_hash}
 

--- a/apps/blockchain/lib/blockchain/block.ex
+++ b/apps/blockchain/lib/blockchain/block.ex
@@ -592,14 +592,11 @@ defmodule Blockchain.Block do
         beneficiary: beneficiary
       }
     }
-    |> identity()
     |> set_block_number(parent_block)
     |> set_block_difficulty(chain, parent_block)
     |> set_block_gas_limit(chain, parent_block, gas_limit)
   end
 
-  @spec identity(t) :: t
-  def identity(block), do: block
 
   @doc """
   Calculates the `number` for a new block. This implements Eq.(38) from


### PR DESCRIPTION
## What
Fixes some of the dialyzer warnings for the  Blockchain app.
Warning fixed is included in each commit message.

This is the 1st PR, not all the warnings are gone yet.

An extra commit included which removes the unused `identity()` function.