### PR TITLE
Ignore specific Blockchain app warnings

### DIFF
--- a/.dialyzer.ignore-warnings
+++ b/.dialyzer.ignore-warnings
@@ -23,33 +23,49 @@
 :0: Unknown function 'Elixir.EVM.Interface.BlockInterface.Reference':'__impl__'/1
 :0: Unknown function 'Elixir.EVM.Interface.BlockInterface.Tuple':'__impl__'/1
 
+
+-------------------------------
 # TODO: rewrite mocked protocol typespecs
+-------------------------------
 
-lib/evm/interface/mock/mock_account_interface.ex:41: The return type atom() in the specification of add_wei/3 is not a subtype of 'nil' | integer(), which is the expected return type for the callback of the 'Elixir.EVM.Interface.AccountInterface' behaviour
-lib/evm/interface/mock/mock_account_interface.ex:41: Invalid type specification for function 'Elixir.EVM.Interface.AccountInterface.EVM.Interface.Mock.MockAccountInterface':add_wei/3. The success typing is (#{'account_map':=map(), _=>_},_,number()) -> #{'account_map':=map(), _=>_}
-lib/evm/interface/mock/mock_account_interface.ex:43: The inferred type for the 1st argument of add_wei/3 (#{'account_map':=map(), _=>_}) is not a supertype of atom(), which is expected type for this argument in the callback of the 'Elixir.EVM.Interface.AccountInterface' behaviour
-lib/evm/interface/mock/mock_account_interface.ex:43: The inferred return type of add_wei/3 (#{'account_map':=map(), _=>_}) has nothing in common with 'nil' | integer(), which is the expected return type for the callback of the 'Elixir.EVM.Interface.AccountInterface' behaviour
-lib/evm/interface/mock/mock_account_interface.ex:49: The return type atom() in the specification of transfer/4 is not a subtype of 'nil' | integer(), which is the expected return type for the callback of the 'Elixir.EVM.Interface.AccountInterface' behaviour
-lib/evm/interface/mock/mock_account_interface.ex:49: Invalid type specification for function 'Elixir.EVM.Interface.AccountInterface.EVM.Interface.Mock.MockAccountInterface':transfer/4. The success typing is (#{'account_map':=map(), _=>_},_,_,number()) -> #{'account_map':=map(), _=>_}
-lib/evm/interface/mock/mock_account_interface.ex:51: The inferred type for the 1st argument of transfer/4 (#{'account_map':=map(), _=>_}) is not a supertype of atom(), which is expected type for this argument in the callback of the 'Elixir.EVM.Interface.AccountInterface' behaviour
-lib/evm/interface/mock/mock_account_interface.ex:51: The inferred return type of transfer/4 (#{'account_map':=map(), _=>_}) has nothing in common with 'nil' | integer(), which is the expected return type for the callback of the 'Elixir.EVM.Interface.AccountInterface' behaviour
-lib/evm/interface/mock/mock_account_interface.ex:72: The return type {atom(),integer()} in the specification of increment_account_nonce/2 is not a subtype of atom(), which is the expected return type for the callback of the 'Elixir.EVM.Interface.AccountInterface' behaviour
-lib/evm/interface/mock/mock_account_interface.ex:74: The inferred return type of increment_account_nonce/2 ({atom() | #{'account_map':=map(), _=>_},number()}) has nothing in common with atom(), which is the expected return type for the callback of the 'Elixir.EVM.Interface.AccountInterface' behaviour
-lib/evm/interface/mock/mock_account_interface.ex:97: Invalid type specification for function 'Elixir.EVM.Interface.AccountInterface.EVM.Interface.Mock.MockAccountInterface':put_storage/4. The success typing is (#{'account_map':=map(), _=>_},_,_,_) -> #{'account_map':=map(), _=>_}
-lib/evm/interface/mock/mock_account_interface.ex:99: The inferred type for the 1st argument of put_storage/4 (#{'account_map':=map(), _=>_}) is not a supertype of atom(), which is expected type for this argument in the callback of the 'Elixir.EVM.Interface.AccountInterface' behaviour
-lib/evm/interface/mock/mock_account_interface.ex:99: The inferred return type of put_storage/4 (#{'account_map':=map(), _=>_}) has nothing in common with atom(), which is the expected return type for the callback of the 'Elixir.EVM.Interface.AccountInterface' behaviour
-lib/evm/interface/mock/mock_account_interface.ex:136: Invalid type specification for function 'Elixir.EVM.Interface.AccountInterface.EVM.Interface.Mock.MockAccountInterface':suicide_account/2. The success typing is (#{'account_map':=map(), _=>_},_) -> #{'account_map':=map(), _=>_}
-lib/evm/interface/mock/mock_account_interface.ex:138: The inferred type for the 1st argument of suicide_account/2 (#{'account_map':=map(), _=>_}) is not a supertype of atom(), which is expected type for this argument in the callback of the 'Elixir.EVM.Interface.AccountInterface' behaviour
-lib/evm/interface/mock/mock_account_interface.ex:138: The inferred return type of suicide_account/2 (#{'account_map':=map(), _=>_}) has nothing in common with atom(), which is the expected return type for the callback of the 'Elixir.EVM.Interface.AccountInterface' behaviour
-lib/evm/interface/mock/mock_account_interface.ex:199: The return type {integer(),atom(),#{'__struct__':='Elixir.EVM.SubState', 'logs':=binary(), 'refund':=integer(), 'suicide_list':=[<<_:160>>]}} in the specification of create_contract/9 is not a subtype of {atom(),integer(),#{'__struct__':='Elixir.EVM.SubState', 'logs':=binary(), 'refund':=integer(), 'suicide_list':=[<<_:160>>]}}, which is the expected return type for the callback of the 'Elixir.EVM.Interface.AccountInterface' behaviour
-lib/evm/interface/mock/mock_account_interface.ex:199: Invalid type specification for function 'Elixir.EVM.Interface.AccountInterface.EVM.Interface.Mock.MockAccountInterface':create_contract/9. The success typing is (atom() | #{'contract_result':='nil' | [{atom(),_}] | map(), _=>_},_,_,_,_,_,_,_,_) -> {atom() | #{'contract_result':='nil' | [{_,_}] | map(), _=>_},_,_}
-lib/evm/interface/mock/mock_block_interface.ex:10: Invalid type specification for function 'Elixir.EVM.Interface.Mock.MockBlockInterface':new/2. The success typing is (_,_) -> #{'__struct__':='Elixir.EVM.Interface.Mock.MockBlockInterface', 'block_header':=_, 'block_map':=_}
-lib/evm/interface/mock/mock_account_interface.ex:199: The return type {integer(),atom(),#{'__struct__':='Elixir.EVM.SubState', 'logs':=[#{'__struct__':='Elixir.EVM.LogEntry', 'address':=<<_:160>>, 'data':=binary(), 'topics':=[binary()]}], 'refund':=integer(), 'suicide_list':=[<<_:160>>]}} in the specification of create_contract/9 is not a subtype of {atom(),integer(),#{'__struct__':='Elixir.EVM.SubState', 'logs':=[#{'__struct__':='Elixir.EVM.LogEntry', 'address':=<<_:160>>, 'data':=binary(), 'topics':=[binary()]}], 'refund':=integer(), 'suicide_list':=[<<_:160>>]}}, which is the expected return type for the callback of the 'Elixir.EVM.Interface.AccountInterface' behaviour
-
-lib/evm/machine_code.ex:113: The variable _@1 can never match since previous clauses completely covered the type bitstring()
-lib/evm/machine_code.ex:113: Cons will produce an improper list since its 2nd argument is binary(
+lib/evm/interface/mock/mock_account_interface
+lib/evm/interface/mock/mock_block_interface
+lib/evm/machine_code
 
 
+-------------------------------
 # Introduced by Elixir 1.6.4 https://github.com/elixir-lang/elixir/issues/7508
+-------------------------------
 lib/trie/helper.ex:41: Guard test is_binary(_@1::<<_:4>>) can never succeed
 lib/trie/helper.ex:41: The variable _@1 can never match since previous clauses completely covered the type <<_:4>>
+
+-------------------------------
+# blockchain/block.ex warnings
+-------------------------------
+:0: Unknown type 'Elixir.EVM':state/0
+:0: Unknown type 'Elixir.ExthCrypto':hash/0
+:0: Unknown type 'Elixir.Header':t/0
+apps/blockchain/lib/blockchain/block.ex:581: Function gen_child_block/2 has no local return
+apps/blockchain/lib/blockchain/block.ex:581: Function gen_child_block/3 has no local return
+apps/blockchain/lib/blockchain/block.ex:596: The call 'Elixir.Blockchain.Block':set_block_number(#{'__struct__':='Elixir.Blockchain.Block', 'block_hash':='nil', 'header':=#{'__struct__':='Elixir.Block.Header', 'beneficiary':=_, 'difficulty':='nil', 'extra_data':=_, 'gas_limit':=0, 'gas_used':=0, 'logs_bloom':=<<_:2048>>, 'mix_hash':='nil', 'nonce':='nil', 'number':='nil', 'ommers_hash':=<<_:256>>, 'parent_hash':='nil', 'receipts_root':=<<_:256>>, 'state_root':=_, 'timestamp':=_, 'transactions_root':=<<_:256>>}, 'ommers':=[], 'transactions':=[]},Vparent_block@1::any()) breaks the contract (t(),t()) -> t()
+
+-------------------------------
+# blockchain/chain.ex
+-------------------------------
+apps/blockchain/lib/blockchain/chain.ex:86: Invalid type specification for function 'Elixir.Blockchain.Chain':load_chain/1. The success typing is (atom()) -> #{'__struct__':='Elixir.Blockchain.Chain', 'accounts':=map(), 'engine':=map(), 'genesis':=#{'author':=binary(), 'difficulty':=non_neg_integer(), 'extra_data':=binary(), 'gas_limit':=non_neg_integer(), 'parent_hash':=binary(), 'timestamp':=non_neg_integer()}, 'name':=_, 'nodes':=_, 'params':=#{'account_start_nonce':=non_neg_integer(), 'block_reward':=non_neg_integer(), 'eip155_transition':=_, 'eip86_transition':=non_neg_integer(), 'eip98_transition':=non_neg_integer(), 'gas_limit_bound_divisor':=non_neg_integer(), 'maximum_extra_data_size':=non_neg_integer(), 'min_gas_limit':=non_neg_integer()}}
+
+-------------------------------
+# blockchain/transaction.ex
+-------------------------------
+apps/blockchain/lib/blockchain/transaction.ex:296: Function execute_transaction/3 has no local return
+
+-------------------------------
+# blockchain/application.ex
+-------------------------------
+apps/blockchain/lib/blockchain/application.ex:16: The call 'Elixir.EVM.Debugger':break_on([{'address',binary()},...]) will never return since the success typing is (['address']) -> integer() and the contract is (elixir:keyword('Elixir.EVM.Debugger.Breakpoint':conditions())) -> 'Elixir.EVM.Debugger.Breakpoint':id()
+
+-------------------------------
+# Ignores the whole contract and account_interface file
+-------------------------------
+apps/blockchain/lib/blockchain/contract.ex
+apps/blockchain/lib/blockchain/interface/account_interface.ex

--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,6 @@ defmodule Exthereum.MixProject do
       dialyzer: [
         ignore_warnings: ".dialyzer.ignore-warnings",
         excluded_paths: [
-          Path.join(@root_path, "_build/test/lib/blockchain/ebin"),
           Path.join(@root_path, "_build/test/lib/abi/ebin"),
           Path.join(@root_path, "_build/test/lib/exth_crypto/ebin"),
           Path.join(@root_path, "_build/test/lib/ex_wire/ebin")


### PR DESCRIPTION
## What
We don't ignore the whole Blockchain app anymore, only specific warnings to be ignored are added to `.dialyzer.ignore-warnings`

Ignore file now includes full EVM file paths, not specific warnings. This is because the lines where the warnings comes from might change when code is being updated which means the CI would fail.

Note: Merge after https://github.com/poanetwork/mana/pull/79

