### PR TITLE
Stop ignoring String10MbData test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
           key: v1-build-cache
           paths: "_build"
 
-      - run: elixir --erl "+hmax 33554432" -S mix test --exclude network --exclude pending
+      - run: mix test --exclude network --exclude pending
 
       - restore_cache:
           keys:

--- a/apps/blockchain/test/blockchain/transaction_test.exs
+++ b/apps/blockchain/test/blockchain/transaction_test.exs
@@ -29,7 +29,6 @@ defmodule Blockchain.TransactionTest do
     [
       ignore: [
         "ttWrongRLP/",
-        "ttData/String10MbData.json",
         "ttSignature/TransactionWithTooFewRLPElements.json",
         "ttSignature/TransactionWithTooManyRLPElements.json"
       ]


### PR DESCRIPTION
* Remove max heap size limit for test env
* Stop ignoring String10MbData test (ttData/String10MbData.json)

As we've moved to the paid plan on CircleCI, this is not an issue anymore.