### PR TITLE
Add Rust requirement to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ brew install automake
 brew install autoconf
 ```
 
+Since we are using [RocksDB](https://rocksdb.org/) via
+[rox](https://github.com/urbint/rox), you will need to have the Rust available
+at compile time,
+
+```
+brew install rust
+```
+
 # Installation
 
 * Clone repo with submodules (so you can get the shared tests),


### PR DESCRIPTION
Since we added [rox](https://github.com/urbint/rox) and since `rox` needs Rust to be available at compile time, we include that requirement to the README. Without it, we cannot succesfully compile dependencies for `mana`.