### PR TITLE
Precompiled Contract: SHA2-256

### DIFF
--- a/apps/evm/lib/evm/builtin.ex
+++ b/apps/evm/lib/evm/builtin.ex
@@ -7,13 +7,35 @@ defmodule EVM.Builtin do
   TODO: Implement and add doc tests.
   """
 
+  @g_sha256 60 + 12
+
   @spec run_ecrec(EVM.Gas.t(), EVM.ExecEnv.t()) ::
           {EVM.Gas.t(), EVM.SubState.t(), EVM.ExecEnv.t(), EVM.VM.output()}
   def run_ecrec(gas, exec_env), do: {gas, %EVM.SubState{}, exec_env, <<>>}
 
+  @doc """
+  Runs SHA256 hashing
+
+  ## Examples
+
+      iex> EVM.Builtin.run_sha256(3000,  %EVM.ExecEnv{data: <<1, 2, 3>>})
+      {2928, %EVM.SubState{}, %EVM.ExecEnv{data: <<1, 2, 3>>}, <<3, 144, 88, 198,
+        242, 192, 203, 73, 44, 83, 59, 10, 77, 20, 239,119, 204, 15, 120, 171, 204,
+        206, 213, 40, 125, 132, 161, 162, 1, 28, 251, 129>>}
+  """
   @spec run_sha256(EVM.Gas.t(), EVM.ExecEnv.t()) ::
           {EVM.Gas.t(), EVM.SubState.t(), EVM.ExecEnv.t(), EVM.VM.output()}
-  def run_sha256(gas, exec_env), do: {gas, %EVM.SubState{}, exec_env, <<>>}
+  def run_sha256(gas, exec_env = %EVM.ExecEnv{data: data}) do
+    used_gas = @g_sha256 * MathHelper.bits_to_words(byte_size(data))
+
+    if(used_gas < gas) do
+      remaining_gas = gas - used_gas
+      result = :crypto.hash(:sha256, data)
+      {remaining_gas, %EVM.SubState{}, exec_env, result}
+    else
+      {gas, %EVM.SubState{}, exec_env, <<>>}
+    end
+  end
 
   @spec run_rip160(EVM.Gas.t(), EVM.ExecEnv.t()) ::
           {EVM.Gas.t(), EVM.SubState.t(), EVM.ExecEnv.t(), EVM.VM.output()}

--- a/apps/evm/test/evm/builtin_test.exs
+++ b/apps/evm/test/evm/builtin_test.exs
@@ -1,0 +1,4 @@
+defmodule EVM.BuiltinTest do
+  use ExUnit.Case, async: true
+  doctest EVM.Builtin
+end


### PR DESCRIPTION
## Summary
### Issue: part of https://github.com/poanetwork/mana/issues/76

Implements `run_sha256` function which is one of the builtin contracts.
It runs SHA2-256 hashing.
The usage of gas depends on the data size.

The input comes from execution environment attribute `data`.
The output is the hash, unless there isn't enough gas.

