### PR TITLE
Fix Secrets.derive_secrets/7 function

### DIFF
--- a/apps/ex_wire/lib/ex_wire/framing/secrets.ex
+++ b/apps/ex_wire/lib/ex_wire/framing/secrets.ex
@@ -78,12 +78,10 @@ defmodule ExWire.Framing.Secrets do
         auth_data,
         ack_data
       ) do
-    remote_ephemeral_public_key_raw = remote_ephemeral_public_key |> ExthCrypto.Key.raw_to_der()
-
     ephemeral_shared_secret =
       ExthCrypto.ECIES.ECDH.generate_shared_secret(
         my_ephemeral_private_key,
-        remote_ephemeral_public_key_raw
+        remote_ephemeral_public_key
       )
 
     # TODO: Nonces will need to be reversed come winter

--- a/apps/ex_wire/lib/ex_wire/handshake/handshake.ex
+++ b/apps/ex_wire/lib/ex_wire/handshake/handshake.ex
@@ -194,7 +194,7 @@ defmodule ExWire.Handshake do
     shared_secret = ECDH.generate_shared_secret(my_static_private_key, her_static_public_key)
 
     # Build a nonce unless given
-    nonce = if nonce, do: nonce, else: ExthCrypto.Math.nonce(@nonce_len)
+    nonce = if nonce, do: nonce, else: new_nonce()
 
     # XOR shared-secret and nonce
     shared_secret_xor_nonce = ExthCrypto.Math.xor(shared_secret, nonce)
@@ -230,7 +230,7 @@ defmodule ExWire.Handshake do
   @spec build_ack_resp(ExthCrypto.Key.public_key(), binary() | nil) :: AckRespV4.t()
   def build_ack_resp(remote_ephemeral_public_key, nonce \\ nil) do
     # Generate nonce unless given
-    nonce = if nonce, do: nonce, else: ExthCrypto.Math.nonce(@nonce_len)
+    nonce = if nonce, do: nonce, else: new_nonce()
 
     %AckRespV4{
       remote_nonce: nonce,
@@ -326,5 +326,10 @@ defmodule ExWire.Handshake do
       {:error, reason} ->
         {:invalid, reason}
     end
+  end
+
+  @spec new_nonce() :: binary()
+  def new_nonce do
+    ExthCrypto.Math.nonce(@nonce_len)
   end
 end

--- a/apps/ex_wire/test/ex_wire/framing/secrets_test.exs
+++ b/apps/ex_wire/test/ex_wire/framing/secrets_test.exs
@@ -1,4 +1,125 @@
 defmodule ExWire.Framing.SecretsTest do
   use ExUnit.Case, async: true
   doctest ExWire.Framing.Secrets
+
+  alias ExWire.Framing.Secrets
+  alias ExWire.Handshake
+  alias ExthCrypto.ECIES.ECDH
+
+  setup do
+    creds = %{
+      my_ephemeral_key_pair: new_ephemeral_key_pair(),
+      remote_ephemeral_key_pair: new_ephemeral_key_pair(),
+      my_nonce: new_nonce(),
+      remote_nonce: new_nonce()
+    }
+
+    {:ok, %{credentials: creds}}
+  end
+
+  describe "derive_secrets/7" do
+    test "generates token to resume connection in the future", %{credentials: creds} do
+      %{
+        my_ephemeral_key_pair: {_, my_eph_private_key},
+        remote_ephemeral_key_pair: {remote_eph_public_key, _},
+        my_nonce: my_nonce,
+        remote_nonce: remote_nonce
+      } = creds
+
+      secrets =
+        Secrets.derive_secrets(
+          true,
+          my_eph_private_key,
+          remote_eph_public_key,
+          remote_nonce,
+          my_nonce,
+          "auth data",
+          "ack data"
+        )
+
+      assert %Secrets{} = secrets
+      assert is_binary(secrets.token)
+    end
+
+    test "generates the mac encoder and mac secret", %{credentials: creds} do
+      %{
+        my_ephemeral_key_pair: {_, my_eph_private_key},
+        remote_ephemeral_key_pair: {remote_eph_public_key, _},
+        my_nonce: my_nonce,
+        remote_nonce: remote_nonce
+      } = creds
+
+      secrets =
+        Secrets.derive_secrets(
+          true,
+          my_eph_private_key,
+          remote_eph_public_key,
+          remote_nonce,
+          my_nonce,
+          "auth data",
+          "ack data"
+        )
+
+      assert is_binary(secrets.mac_secret)
+      assert {ExthCrypto.AES, 32, :ecb} = secrets.mac_encoder
+    end
+
+    test "calculates the egress and ingress mac", %{credentials: creds} do
+      %{
+        my_ephemeral_key_pair: {_, my_eph_private_key},
+        remote_ephemeral_key_pair: {remote_eph_public_key, _},
+        my_nonce: my_nonce,
+        remote_nonce: remote_nonce
+      } = creds
+
+      secrets =
+        Secrets.derive_secrets(
+          true,
+          my_eph_private_key,
+          remote_eph_public_key,
+          remote_nonce,
+          my_nonce,
+          "auth data",
+          "ack data"
+        )
+
+      assert {:kec, {:sha3_256, egress_mac_data}} = secrets.egress_mac
+      assert {:kec, {:sha3_256, ingress_mac_data}} = secrets.ingress_mac
+      assert is_binary(egress_mac_data)
+      assert is_binary(ingress_mac_data)
+    end
+
+    test "generates the encoder and decoder streams", %{credentials: creds} do
+      %{
+        my_ephemeral_key_pair: {_, my_eph_private_key},
+        remote_ephemeral_key_pair: {remote_eph_public_key, _},
+        my_nonce: my_nonce,
+        remote_nonce: remote_nonce
+      } = creds
+
+      secrets =
+        Secrets.derive_secrets(
+          true,
+          my_eph_private_key,
+          remote_eph_public_key,
+          remote_nonce,
+          my_nonce,
+          "auth data",
+          "ack data"
+        )
+
+      assert {:aes_ctr, encoder_stream} = secrets.encoder_stream
+      assert is_reference(encoder_stream)
+      assert {:aes_ctr, decoder_stream} = secrets.decoder_stream
+      assert is_reference(decoder_stream)
+    end
+  end
+
+  def new_ephemeral_key_pair do
+    ECDH.new_ecdh_keypair()
+  end
+
+  def new_nonce do
+    Handshake.new_nonce()
+  end
 end


### PR DESCRIPTION
Summary
=======

The `Secrets.derive_secrets/7` function was throwing an `ArgumentError` when trying to generate a shared secret. It was untested and for all intents an purposes, it was unused. So the bug was never caught. As part of my work on #103, I realized that this function was causing issues when trying to derive secrets for the encrypted auth exchange. 

The function failed when trying to generate an ephemeral shared secret. In order to generate that shared secret, we need our node's ephemeral private key and the remote node's ephemeral public key.

The function was trying to pass a "raw" ephemeral public key instead. And when looked at closely, it wasn't even passing the correct "raw" key. Instead it was using a function that transformed the `remote_ephemeral_public_key` from raw into `der` (i.e. `ExthCrypto.Key.raw_to_der()`).

We also add a few tests to ensure that this code is working. Though the tests are of some value (they caught the error), they are not perfect since they are simply testing that the values returned are binaries or references. Better tests would involve using the secrets to do something that ensures the secrets are indeed correct. Unfortunately, that's more than I can decipher right now. So for now, I think having some tests is better than no tests.