### PR TITLE
fix network adapter for ex_wire test

### DIFF
--- a/apps/ex_wire/config/test.exs
+++ b/apps/ex_wire/config/test.exs
@@ -5,7 +5,7 @@ config :ex_wire,
     <<10, 122, 189, 137, 166, 190, 127, 238, 229, 16, 211, 182, 104, 78, 138, 37, 146, 116, 90,
       68, 76, 86, 168, 24, 200, 155, 0, 99, 58, 226, 211, 30>>,
   node_discovery: [
-    network_adapter: {ExWire.Adapter.Test, :test_network_adapter},
+    network_adapter: {ExWire.Adapter.UDP, :test_network_adapter},
     kademlia_process_name: KademliaState,
     supervisor_name: ExWire.NodeDiscoverySupervisor,
     port: 30_304


### PR DESCRIPTION
# The problem
Node Discovery uses two processes: Network process sends async request and receives requests from other nodes and redirects them to Kademlia process, Kademlia stores routing table(buckets, etc) and sends requests (ping, pong, find_neighbours) using network process. Network process can use different adapters, Test adapter is used for tests (wire_test.exs is the only place that it's used) (edited)

adapters respond to different GenServer callbacks.  Kademlia process tries to use test adapter to send requests and test adapter fails. We start production adapter manually when we need it in tests. 

# Solution
Let's start Test adapter only for `ExWireTest `

fixes https://github.com/poanetwork/mana/issues/123