### PR TITLE
Fix EVM tests

### DIFF
--- a/apps/blockchain/lib/blockchain/account.ex
+++ b/apps/blockchain/lib/blockchain/account.ex
@@ -177,7 +177,7 @@ defmodule Blockchain.Account do
 
   @doc """
   Completely removes an account from the world state.
-  This is used, for instance, after a suicide.
+  This is used, for instance, after a selfdestruct.
   This is defined from Eq.(71) and Eq.(80) in the Yellow Paper.
 
   ## Examples
@@ -354,14 +354,13 @@ defmodule Blockchain.Account do
   @doc """
   Helper function for transferring eth for one account to another.
   This handles the fact that a new account may be shadow-created if
-  it receives eth. See Section 8, Eq.(100), Eq.(101), Eq.(102), Eq.(103),
-  and Eq.(104) of the Yellow Paper.
+  it receives eth. See Section 8, Eq.(100-104) of the Yellow Paper.
 
-  The Yellow Paper assumes this function will always succeed (as the checks
-  occur before this function is called), but we'll check just in case
-  this function is not properly called. The only case will be if the
-  sending account is nil or has an insufficient balance, but we add
-  a few extra checks just in case.
+  The Yellow Paper assumes this function will always succeed
+  (as the checks occur before this function is called),
+  but we'll check just in case this function is not properly called.
+  The only case will be if the sending account is nil or has an insufficient balance,
+  but we add a few extra checks just in case.
 
   Note: transferring value to an empty account still adds value to said account,
         even though it's effectively a zombie.

--- a/apps/blockchain/lib/blockchain/interface/account_interface.ex
+++ b/apps/blockchain/lib/blockchain/interface/account_interface.ex
@@ -214,8 +214,8 @@ defimpl EVM.Interface.AccountInterface, for: Blockchain.Interface.AccountInterfa
   end
 
   @doc """
-  Suicides an account (err.. SELFDESTRUCT is the new word). This removes any trace
-  of the account from the system.
+  Destructs an account (SELFDESTRUCT operation in YP).
+  This removes any trace of the account from the system.
 
   ## Examples
 
@@ -223,7 +223,7 @@ defimpl EVM.Interface.AccountInterface, for: Blockchain.Interface.AccountInterfa
       ...> |> MerklePatriciaTree.Trie.new()
       ...> |> Blockchain.Account.add_wei(<<1::160>>, 5)
       ...> |> Blockchain.Interface.AccountInterface.new()
-      ...> |> EVM.Interface.AccountInterface.suicide_account(<<1::160>>)
+      ...> |> EVM.Interface.AccountInterface.destroy_account(<<1::160>>)
       ...> |> EVM.Interface.AccountInterface.get_account_balance(<<1::160>>)
       nil
 
@@ -231,13 +231,13 @@ defimpl EVM.Interface.AccountInterface, for: Blockchain.Interface.AccountInterfa
       ...> |> MerklePatriciaTree.Trie.new()
       ...> |> Blockchain.Account.add_wei(<<1::160>>, 5)
       ...> |> Blockchain.Interface.AccountInterface.new()
-      ...> |> EVM.Interface.AccountInterface.suicide_account(<<2::160>>)
+      ...> |> EVM.Interface.AccountInterface.destroy_account(<<2::160>>)
       ...> |> EVM.Interface.AccountInterface.get_account_balance(<<1::160>>)
       5
   """
-  @spec suicide_account(EVM.Interface.AccountInterface.t(), EVM.address()) ::
+  @spec destroy_account(EVM.Interface.AccountInterface.t(), EVM.address()) ::
           EVM.Interface.AccountInterface.t()
-  def suicide_account(account_interface, address) do
+  def destroy_account(account_interface, address) do
     updated_state = Account.del_account(account_interface.state, address)
 
     %{account_interface | state: updated_state}

--- a/apps/blockchain/lib/blockchain/transaction.ex
+++ b/apps/blockchain/lib/blockchain/transaction.ex
@@ -361,15 +361,15 @@ defmodule Blockchain.Transaction do
 
     state_after_gas = finalize_transaction_gas(state_p, sender, tx, refund, block_header)
 
-    state_after_suicides =
-      Enum.reduce(sub_state.suicide_list, state_after_gas, fn address, state ->
+    state_after_selfdestruct =
+      Enum.reduce(sub_state.selfdestruct_list, state_after_gas, fn address, state ->
         Account.del_account(state, address)
       end)
 
     expended_gas = tx.gas_limit - remaining_gas
 
     # { σ', Υ^g, Υ^l }, as defined in Eq.(79) and Eq.(80)
-    {state_after_suicides, expended_gas, sub_state.logs}
+    {state_after_selfdestruct, expended_gas, sub_state.logs}
   end
 
   @doc """

--- a/apps/evm/README.md
+++ b/apps/evm/README.md
@@ -8,7 +8,7 @@ As discussed in the paper, we define a few data structures.
 
 * State - The world state of Ethereum, defined as the root hash of a Merkle Patricia Trie containing all account data. See Section 4.1 of the Yellow Paper, or explore the [merkle_patricia_tree](https://github.com/exthereum/merkle_patricia_tree) umbrella project in this repo.
 * The Machine State - This structure effectively encodes the current context of a running VM (e.g. the program counter, the current memory data, etc). This structure is simply used during execution of the program, and thrown away after it completes. Before we finish, we extract the gas used and return value from this object.
-* The Sub State - The sub state tracks the suicide list (contracts to destroy), the logs and the refund (for cleaning up storage) for a contract execution.
+* The Sub State - The sub state tracks the selfdestruct list (contracts to destroy), the logs and the refund (for cleaning up storage) for a contract execution.
 * The Execution Environment - This tracks information about the call into a contract, such as the machine code itself and the value passed to the contract or message call. Other than stack depth, this is generally not mutated during execution of the machine.
 
 # Examples

--- a/apps/evm/lib/evm/address.ex
+++ b/apps/evm/lib/evm/address.ex
@@ -28,7 +28,10 @@ defmodule EVM.Address do
     address
     |> :binary.encode_unsigned()
     |> EVM.Helpers.left_pad_bytes(@size)
+    |> EVM.Helpers.take_n_last_bytes(@size)
   end
+
+  def new(address), do: address
 
   @doc """
   Returns an address given an address and a nonce.

--- a/apps/evm/lib/evm/exec_env.ex
+++ b/apps/evm/lib/evm/exec_env.ex
@@ -60,10 +60,9 @@ defmodule EVM.ExecEnv do
     AccountInterface.get_storage(account_interface, address, key)
   end
 
-  @spec suicide_account(t()) :: t()
-  def suicide_account(exec_env = %{account_interface: account_interface, address: address}) do
-    account_interface = AccountInterface.suicide_account(account_interface, address)
-
+  @spec destroy_account(t()) :: t()
+  def destroy_account(exec_env = %{account_interface: account_interface, address: address}) do
+    account_interface = AccountInterface.destroy_account(account_interface, address)
     Map.put(exec_env, :account_interface, account_interface)
   end
 

--- a/apps/evm/lib/evm/functions.ex
+++ b/apps/evm/lib/evm/functions.ex
@@ -25,7 +25,7 @@ defmodule EVM.Functions do
       iex> EVM.Functions.is_normal_halting?(%EVM.MachineState{program_counter: 0}, %EVM.ExecEnv{machine_code: <<EVM.Operation.encode(:stop)>>})
       <<>>
 
-      iex> EVM.Functions.is_normal_halting?(%EVM.MachineState{program_counter: 0}, %EVM.ExecEnv{machine_code: <<EVM.Operation.encode(:suicide)>>})
+      iex> EVM.Functions.is_normal_halting?(%EVM.MachineState{program_counter: 0}, %EVM.ExecEnv{machine_code: <<EVM.Operation.encode(:selfdestruct)>>})
       <<>>
 
       iex> EVM.Functions.is_normal_halting?(%EVM.MachineState{stack: [0, 1], memory: <<0xabcd::16>>}, %EVM.ExecEnv{machine_code: <<EVM.Operation.encode(:return)>>})
@@ -41,7 +41,7 @@ defmodule EVM.Functions do
   def is_normal_halting?(machine_state, exec_env) do
     case MachineCode.current_operation(machine_state, exec_env).sym do
       :return -> h_return(machine_state)
-      x when x == :stop or x == :suicide -> <<>>
+      x when x == :stop or x == :selfdestruct -> <<>>
       _ -> nil
     end
   end

--- a/apps/evm/lib/evm/gas.ex
+++ b/apps/evm/lib/evm/gas.ex
@@ -34,10 +34,10 @@ defmodule EVM.Gas do
   @g_sreset 5000
   # Refund given (added into refund counter) when the storage value is set to zero from non-zero.
   @g_sclear 15000
-  # Refund given (added into refund counter) for suiciding an account.
-  @g_suicide 24000
-  # Amount of gas to pay for a SUICIDE operation.
-  @g_suicide 5000
+  # Refund given (added into refund counter) for selfdestructing an account.
+  @r_selfdestruct 24000
+  # Amount of gas to pay for a SELFDESTRUCT operation.
+  @g_selfdestruct 5000
   # Paid for a CREATE operation.
   @g_create 32000
   # Paid per byte for a CREATE operation to succeed in placing code into state.
@@ -48,7 +48,7 @@ defmodule EVM.Gas do
   @g_callvalue 9000
   # A stipend for the called contract subtracted from Gcallvalue for a non-zero value transfer.
   @g_callstipend 2300
-  # Paid for a CALL or SUICIDE operation which creates an account.
+  # Paid for a CALL or SELFDESTRUCT operation which creates an account.
   @g_newaccount 25000
   # Partial payment for an EXP operation.
   @g_exp 10
@@ -81,7 +81,7 @@ defmodule EVM.Gas do
   # Payment for BLOCKHASH operation
   @g_blockhash 20
 
-  @w_zero_instr [:stop, :return, :suicide]
+  @w_zero_instr [:stop, :return, :selfdestruct]
   @w_base_instr [
     :address,
     :origin,

--- a/apps/evm/lib/evm/interface/account_interface.ex
+++ b/apps/evm/lib/evm/interface/account_interface.ex
@@ -35,8 +35,8 @@ defprotocol EVM.Interface.AccountInterface do
   @spec put_storage(t, EVM.address(), integer(), integer()) :: t
   def put_storage(t, address, key, value)
 
-  @spec suicide_account(t, EVM.address()) :: t
-  def suicide_account(t, address)
+  @spec destroy_account(t, EVM.address()) :: t
+  def destroy_account(t, address)
 
   @spec dump_storage(t) :: %{EVM.address() => EVM.val()}
   def dump_storage(t)

--- a/apps/evm/lib/evm/interface/mock/mock_account_interface.ex
+++ b/apps/evm/lib/evm/interface/mock/mock_account_interface.ex
@@ -103,9 +103,7 @@ defimpl EVM.Interface.AccountInterface, for: EVM.Interface.Mock.MockAccountInter
       if account do
         update_storage(account, key, value)
       else
-        new_account(%{
-          storage: %{key => value}
-        })
+        new_account(%{storage: %{key => value}})
       end
 
     put_account(mock_account_interface, address, account)
@@ -116,26 +114,24 @@ defimpl EVM.Interface.AccountInterface, for: EVM.Interface.Mock.MockAccountInter
   end
 
   defp put_account(mock_account_interface, address, account) do
-    %{
-      mock_account_interface
-      | account_map: Map.put(mock_account_interface.account_map, address, account)
-    }
+    account_map = Map.put(mock_account_interface.account_map, address, account)
+    %{mock_account_interface | account_map: account_map}
   end
 
   defp new_account(opts \\ %{}) do
-    Map.merge(
-      %{
-        storage: %{},
-        nonce: 0,
-        balance: 0
-      },
-      opts
-    )
+    account = %{
+      storage: %{},
+      nonce: 0,
+      code: <<>>,
+      balance: 0
+    }
+
+    Map.merge(account, opts)
   end
 
-  @spec suicide_account(EVM.Interface.AccountInterface.t(), EVM.address()) ::
+  @spec destroy_account(EVM.Interface.AccountInterface.t(), EVM.address()) ::
           EVM.Interface.AccountInterface.t()
-  def suicide_account(mock_account_interface, address) do
+  def destroy_account(mock_account_interface, address) do
     account_map =
       mock_account_interface.account_map
       |> Map.delete(address)

--- a/apps/evm/lib/evm/machine_code.ex
+++ b/apps/evm/lib/evm/machine_code.ex
@@ -130,7 +130,7 @@ defmodule EVM.MachineCode do
       [:push1, 3, :push1, 5, :add, :return]
 
       iex> EVM.MachineCode.decompile(<<97, 0, 4, 128, 97, 0, 14, 96, 0, 57, 97, 0, 18, 86, 96, 0, 53, 255, 91, 96, 0, 243>>)
-      [:push2, 0, 4, :dup1, :push2, 0, 14, :push1, 0, :codecopy, :push2, 0, 18, :jump, :push1, 0, :calldataload, :suicide, :jumpdest, :push1, 0, :return]
+      [:push2, 0, 4, :dup1, :push2, 0, 14, :push1, 0, :codecopy, :push2, 0, 18, :jump, :push1, 0, :calldataload, :selfdestruct, :jumpdest, :push1, 0, :return]
 
       iex> EVM.MachineCode.decompile(<<>>)
       []

--- a/apps/evm/lib/evm/machine_state.ex
+++ b/apps/evm/lib/evm/machine_state.ex
@@ -73,7 +73,7 @@ defmodule EVM.MachineState do
   end
 
   @doc """
-  Pops n values off the stack
+  Pops n values off the stack.
 
   ## Examples
 

--- a/apps/evm/lib/evm/operation.ex
+++ b/apps/evm/lib/evm/operation.ex
@@ -5,11 +5,7 @@ defmodule EVM.Operation do
   """
 
   alias MathHelper
-  alias EVM.Helpers
-  alias EVM.ExecEnv
-  alias EVM.MachineState
-  alias EVM.Stack
-  alias EVM.SubState
+  alias EVM.{Helpers, ExecEnv, MachineState, Stack, SubState}
   alias EVM.Operation.Metadata.StopAndArithmetic, as: StopAndArithmeticMetadata
   alias EVM.Operation.Metadata.ComparisonAndBitwiseLogic, as: ComparisonAndBitwiseLogicMetadata
   alias EVM.Operation.Metadata.SHA3, as: SHA3Metadata

--- a/apps/evm/lib/evm/operation/logging.ex
+++ b/apps/evm/lib/evm/operation/logging.ex
@@ -21,7 +21,7 @@ defmodule EVM.Operation.Logging do
       ...>   program_counter: 40,
       ...>   stack: []
       ...> }
-      iex> sub_state = %EVM.SubState{logs: [], refund: 0, suicide_list: []}
+      iex> sub_state = %EVM.SubState{logs: [], refund: 0, selfdestruct_list: []}
       iex> vm_map = %{sub_state: sub_state, exec_env: env, machine_state: machine_state}
       iex> EVM.Operation.Logging.log0([0, 32], vm_map)
       %{
@@ -37,7 +37,7 @@ defmodule EVM.Operation.Logging do
             }
           ],
           refund: 0,
-          suicide_list: []
+          selfdestruct_list: []
         }
       }
   """
@@ -66,7 +66,7 @@ defmodule EVM.Operation.Logging do
       ...>   program_counter: 40,
       ...>   stack: []
       ...> }
-      iex> sub_state = %EVM.SubState{logs: [], refund: 0, suicide_list: []}
+      iex> sub_state = %EVM.SubState{logs: [], refund: 0, selfdestruct_list: []}
       iex> vm_map = %{sub_state: sub_state, exec_env: env, machine_state: machine_state}
       iex> args = [0, 32, 115792089237316195423570985008687907853269984665640564039457584007913129639935]
       iex> EVM.Operation.Logging.log1(args, vm_map)
@@ -83,7 +83,7 @@ defmodule EVM.Operation.Logging do
             }
           ],
           refund: 0,
-          suicide_list: []
+          selfdestruct_list: []
         }
       }
   """
@@ -112,7 +112,7 @@ defmodule EVM.Operation.Logging do
       ...>   program_counter: 40,
       ...>   stack: []
       ...> }
-      iex> sub_state = %EVM.SubState{logs: [], refund: 0, suicide_list: []}
+      iex> sub_state = %EVM.SubState{logs: [], refund: 0, selfdestruct_list: []}
       iex> vm_map = %{sub_state: sub_state, exec_env: env, machine_state: machine_state}
       iex> args = [0, 32,
       ...>   115792089237316195423570985008687907853269984665640564039457584007913129639935,
@@ -132,7 +132,7 @@ defmodule EVM.Operation.Logging do
             }
           ],
           refund: 0,
-          suicide_list: []
+          selfdestruct_list: []
         }
       }
   """
@@ -161,7 +161,7 @@ defmodule EVM.Operation.Logging do
       ...>   program_counter: 40,
       ...>   stack: []
       ...> }
-      iex> sub_state = %EVM.SubState{logs: [], refund: 0, suicide_list: []}
+      iex> sub_state = %EVM.SubState{logs: [], refund: 0, selfdestruct_list: []}
       iex> vm_map = %{sub_state: sub_state, exec_env: env, machine_state: machine_state}
       iex> args = [1, 0, 0, 0, 0]
       iex> EVM.Operation.Logging.log3(args, vm_map)
@@ -176,7 +176,7 @@ defmodule EVM.Operation.Logging do
             }
           ],
           refund: 0,
-          suicide_list: []
+          selfdestruct_list: []
         }
       }
   """
@@ -208,7 +208,7 @@ defmodule EVM.Operation.Logging do
       ...>   program_counter: 40,
       ...>   stack: []
       ...> }
-      iex> sub_state = %EVM.SubState{logs: [], refund: 0, suicide_list: []}
+      iex> sub_state = %EVM.SubState{logs: [], refund: 0, selfdestruct_list: []}
       iex> vm_map = %{sub_state: sub_state, exec_env: env, machine_state: machine_state}
       iex> args = [115792089237316195423570985008687907853269984665640564039457584007913129639935,
       ...>   1, 0, 0, 0, 0]
@@ -224,7 +224,7 @@ defmodule EVM.Operation.Logging do
             }
           ],
           refund: 0,
-          suicide_list: []
+          selfdestruct_list: []
         }
       }
   """

--- a/apps/evm/lib/evm/operation/metadata/system.ex
+++ b/apps/evm/lib/evm/operation/metadata/system.ex
@@ -54,7 +54,7 @@ defmodule EVM.Operation.Metadata.System do
                     %{
                       id: 0xFF,
                       description: "Halt execution and register account for later deletion.",
-                      sym: :suicide,
+                      sym: :selfdestruct,
                       input_count: 1,
                       output_count: 0,
                       group: :system

--- a/apps/evm/lib/evm/operation/push.ex
+++ b/apps/evm/lib/evm/operation/push.ex
@@ -29,7 +29,8 @@ defmodule EVM.Operation.Push do
   """
   @spec push_n(integer(), Operation.stack_args(), Operation.vm_map()) :: Operation.op_result()
   def push_n(n, _args, %{machine_state: machine_state, exec_env: %{machine_code: machine_code}}) do
-    EVM.Memory.read_zeroed_memory(machine_code, machine_state.program_counter + 1, n)
+    machine_code
+    |> EVM.Memory.read_zeroed_memory(machine_state.program_counter + 1, n)
     |> :binary.decode_unsigned()
   end
 end

--- a/apps/evm/lib/evm/sub_state.ex
+++ b/apps/evm/lib/evm/sub_state.ex
@@ -6,16 +6,16 @@ defmodule EVM.SubState do
 
   alias EVM.{Operation, LogEntry}
 
-  defstruct suicide_list: [],
+  defstruct selfdestruct_list: [],
             logs: [],
             refund: 0
 
-  @type suicide_list :: [EVM.address()]
+  @type selfdestruct_list :: [EVM.address()]
   @type logs :: [LogEntry.t()]
   @type refund :: EVM.Wei.t()
 
   @type t :: %__MODULE__{
-          suicide_list: suicide_list,
+          selfdestruct_list: selfdestruct_list,
           logs: logs,
           refund: refund
         }
@@ -25,7 +25,7 @@ defmodule EVM.SubState do
 
   ## Examples
 
-      iex> sub_state = %EVM.SubState{suicide_list: [], logs: [], refund: 0}
+      iex> sub_state = %EVM.SubState{selfdestruct_list: [], logs: [], refund: 0}
       iex> sub_state |> EVM.SubState.add_log(0, [1, 10, 12], "adsfa")
       %EVM.SubState{
         logs: [
@@ -36,7 +36,7 @@ defmodule EVM.SubState do
           }
         ],
         refund: 0,
-        suicide_list: []
+        selfdestruct_list: []
       }
   """
   @spec add_log(t(), EVM.address(), Operation.stack_args(), binary()) :: t()

--- a/apps/evm/lib/evm/vm.ex
+++ b/apps/evm/lib/evm/vm.ex
@@ -9,8 +9,8 @@ defmodule EVM.VM do
   @type output :: binary()
 
   @doc """
-  This function computes the Ξ function Eq.(116) of the Section 9.4 of the Yellow Paper. This is the complete
-  result of running a given program in the VM.
+  This function computes the Ξ function Eq.(123) of the Section 9.4 of the Yellow Paper.
+  This is the complete result of running a given program in the VM.
 
   Note: We replace returning state with exec env, which in our implementation contains the world state.
 
@@ -21,8 +21,8 @@ defmodule EVM.VM do
       {0, %EVM.SubState{}, %EVM.ExecEnv{machine_code: EVM.MachineCode.compile([:push1, 3, :push1, 5, :add, :push1, 0x00, :mstore, :push1, 32, :push1, 0, :return])}, <<0x08::256>>}
 
       # Program with implicit stop
-      iex> EVM.VM.run(9, %EVM.ExecEnv{machine_code: EVM.MachineCode.compile([:push1, 3, :push1, 5, :add])})
-      {0, %EVM.SubState{}, %EVM.ExecEnv{machine_code: EVM.MachineCode.     compile([:push1, 3, :push1, 5, :add])}, ""}
+      iex> EVM.VM.run(9, %EVM.ExecEnv{machine_code: EVM.MachineCode.compile([:push2, 0, 3, :push1, 5, :add])})
+      {0, %EVM.SubState{}, %EVM.ExecEnv{machine_code: EVM.MachineCode.compile([:push2, 0, 3, :push1, 5, :add])}, ""}
 
       # Program with explicit stop
       iex> EVM.VM.run(5, %EVM.ExecEnv{machine_code: EVM.MachineCode.compile([:push1, 3, :stop])})
@@ -55,7 +55,7 @@ defmodule EVM.VM do
       {%EVM.MachineState{program_counter: 6, gas: 0, last_return_data: 8, stack: [8]}, %EVM.SubState{}, %EVM.ExecEnv{machine_code: EVM.MachineCode.compile([:push1, 3, :push1, 5, :add])}, ""}
 
       iex> EVM.VM.exec(%EVM.MachineState{program_counter: 0, gas: 24, stack: []}, %EVM.SubState{}, %EVM.ExecEnv{machine_code: EVM.MachineCode.compile([:push1, 3, :push1, 5, :add, :push1, 0x00, :mstore, :push1, 32, :push1, 0, :return])})
-      {%EVM.MachineState{active_words: 1, last_return_data: 0, memory: <<0x08::256>>, gas: 0, program_counter: 13, stack: []}, %EVM.SubState{logs: [], refund: 0,  suicide_list: []}, %EVM.ExecEnv{machine_code: <<96, 3, 96, 5, 1, 96, 0, 82, 96, 32, 96, 0, 243>>}, <<8::256>>}
+      {%EVM.MachineState{active_words: 1, last_return_data: 0, memory: <<0x08::256>>, gas: 0, program_counter: 13, stack: []}, %EVM.SubState{logs: [], refund: 0,  selfdestruct_list: []}, %EVM.ExecEnv{machine_code: <<96, 3, 96, 5, 1, 96, 0, 82, 96, 32, 96, 0, 243>>}, <<8::256>>}
   """
   @spec exec(MachineState.t(), SubState.t(), ExecEnv.t()) ::
           {MachineState.t(), SubState.t(), ExecEnv.t(), output}
@@ -102,8 +102,8 @@ defmodule EVM.VM do
   end
 
   @doc """
-  Runs a single cycle of our VM returning the new state, defined as `O`
-  in the Yellow Paper, Eq.(131).
+  Runs a single cycle of our VM returning the new state,
+  defined as `O` in the Yellow Paper, Eq.(143).
 
   ## Examples
 
@@ -118,11 +118,11 @@ defmodule EVM.VM do
 
     machine_state = MachineState.subtract_gas(machine_state, exec_env)
 
-    {machine_state, sub_state, exec_env} =
+    {n_machine_state, n_sub_state, n_exec_env} =
       Operation.run(operation, machine_state, sub_state, exec_env)
 
-    machine_state = MachineState.move_program_counter(machine_state, operation, inputs)
+    final_machine_state = MachineState.move_program_counter(n_machine_state, operation, inputs)
 
-    {machine_state, sub_state, exec_env}
+    {final_machine_state, n_sub_state, n_exec_env}
   end
 end

--- a/apps/evm/test/evm/operation/system_test.exs
+++ b/apps/evm/test/evm/operation/system_test.exs
@@ -1,4 +1,24 @@
 defmodule EVM.Operation.SystemTest do
   use ExUnit.Case, async: true
   doctest EVM.Operation.System
+
+  alias EVM.{ExecEnv, Address, Operation}
+  alias EVM.Interface.Mock.MockAccountInterface
+
+  describe "selfdestruct/2" do
+    test "transfers wei to refund account" do
+      selfdestruct_address = 0x0000000000000000000000000000000000000001
+      refund_address = 0x0000000000000000000000000000000000000002
+      account_map = %{selfdestruct_address => %{balance: 5_000, nonce: 5}}
+      account_interface = MockAccountInterface.new(account_map)
+      exec_env = %ExecEnv{address: selfdestruct_address, account_interface: account_interface}
+      vm_opts = %{stack: [], exec_env: exec_env}
+      new_exec_env = Operation.System.selfdestruct([refund_address], vm_opts)[:exec_env]
+      accounts = new_exec_env.account_interface.account_map
+
+      expected_refund_account = %{balance: 5000, code: <<>>, nonce: 0, storage: %{}}
+      assert Map.get(accounts, Address.new(refund_address)) == expected_refund_account
+      assert Map.get(accounts, selfdestruct_address) == nil
+    end
+  end
 end

--- a/apps/evm/test/evm/vm_test.exs
+++ b/apps/evm/test/evm/vm_test.exs
@@ -2,13 +2,12 @@ defmodule EVM.VMTest do
   use ExUnit.Case, async: true
   doctest EVM.VM
 
-  setup do
-    account_interface = EVM.Interface.Mock.MockAccountInterface.new()
+  alias EVM.{VM, ExecEnv, SubState, MachineCode}
+  alias EVM.Interface.Mock.MockAccountInterface
 
-    {:ok,
-     %{
-       account_interface: account_interface
-     }}
+  setup do
+    account_interface = MockAccountInterface.new()
+    {:ok, %{account_interface: account_interface}}
   end
 
   test "simple program with return value", %{} do
@@ -28,11 +27,13 @@ defmodule EVM.VMTest do
       :return
     ]
 
-    exec_env = %EVM.ExecEnv{machine_code: EVM.MachineCode.compile(instructions)}
-    result = EVM.VM.run(24, exec_env)
+    exec_env = %ExecEnv{machine_code: MachineCode.compile(instructions)}
+    result = VM.run(24, exec_env)
 
-    assert result ==
-             {0, %EVM.SubState{logs: [], refund: 0, suicide_list: []}, exec_env, <<0x08::256>>}
+    expected_sub_state = %SubState{logs: [], refund: 0, selfdestruct_list: []}
+    expected = {0, expected_sub_state, exec_env, <<0x08::256>>}
+
+    assert result == expected
   end
 
   test "simple program with block storage", %{account_interface: account_interface} do
@@ -47,28 +48,28 @@ defmodule EVM.VMTest do
       :stop
     ]
 
-    exec_env = %EVM.ExecEnv{
-      machine_code: EVM.MachineCode.compile(instructions),
+    exec_env = %ExecEnv{
+      machine_code: MachineCode.compile(instructions),
       address: address,
       account_interface: account_interface
     }
 
-    result = EVM.VM.run(20006, exec_env)
+    result = VM.run(20006, exec_env)
 
     expected_account_state = %{
       address => %{
         balance: 0,
         nonce: 0,
+        code: <<>>,
         storage: %{5 => 3}
       }
     }
 
-    expected_account_interface =
-      EVM.Interface.Mock.MockAccountInterface.new(expected_account_state)
-
+    expected_account_interface = MockAccountInterface.new(expected_account_state)
     expected_exec_env = Map.put(exec_env, :account_interface, expected_account_interface)
+    expected_sub_state = %SubState{logs: [], refund: 0, selfdestruct_list: []}
 
-    assert result ==
-             {0, %EVM.SubState{logs: [], refund: 0, suicide_list: []}, expected_exec_env, ""}
+    expected = {0, expected_sub_state, expected_exec_env, ""}
+    assert result == expected
   end
 end

--- a/apps/exth_crypto/lib/math.ex
+++ b/apps/exth_crypto/lib/math.ex
@@ -31,10 +31,13 @@ defmodule ExthCrypto.Math do
 
       iex> ExthCrypto.Math.hex_to_bin("01020a0d")
       <<0x01, 0x02, 0x0a, 0x0d>>
+
       iex> ExthCrypto.Math.hex_to_bin("01020a0D")
       <<0x01, 0x02, 0x0a, 0x0d>>
+
       iex> ExthCrypto.Math.hex_to_bin("0x01020a0d")
       <<0x01, 0x02, 0x0a, 0x0d>>
+
       iex> ExthCrypto.Math.hex_to_bin("0x01020A0d")
       <<0x01, 0x02, 0x0a, 0x0d>>
   """
@@ -49,10 +52,13 @@ defmodule ExthCrypto.Math do
   ## Examples
       iex> ExthCrypto.Math.hex_to_int("01020a0d")
       16910861
+
       iex> ExthCrypto.Math.hex_to_int("01020a0D")
       16910861
+
       iex> ExthCrypto.Math.hex_to_int("0x01020a0d")
       16910861
+
       iex> ExthCrypto.Math.hex_to_int("0x01020A0d")
       16910861
   """


### PR DESCRIPTION
* Rename `suicide` op to `selfdestruct` according to [EIP-6](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-6.md).

* Transfer the balance of the self-destructed account to the "refund account" (its address is the top 20-bytes on VM's stack). Refund account is "shadow-created" if it doesn't exist.

* Refactor and fix the `evm_test.exs`:
  * Remove the `code` field from the caller's account (see http://ethereum-tests.readthedocs.io/en/latest/test_types/vm_tests.html#the-exec-section).
  * Exclude caller's account from the actual state if it isn't in the "pre" or "post" addresses.
  * Don't ignore empty state values in EVM tests.

* Update `EVM.Address.new` to use only the last `@size` of bytes for address construction:
this is important because in VM operations we're getting addresses from the VM stack as integers that can be of any size.

* Replace the doctest for `SELFDESTRUCT` operation in `EVM.System` module with a regular ExUnit test because it's getting quite complex.

* Added `:sender` condition to the `EVM.Debugger.Breakpoint` for convenience.

* Slightly refactor and fix the `new_account` fn (add empty `code` field) in the `EVM.Interface.Mock.MockAccountInterface` module.
* Fix `vm_test.exs` (add empty `code` field).

resolves #126, resolves #109 