### PR TITLE
 implement RETURNDATASIZE env op 

### DIFF
--- a/apps/evm/lib/evm/exec_env.ex
+++ b/apps/evm/lib/evm/exec_env.ex
@@ -29,7 +29,8 @@ defmodule EVM.ExecEnv do
             stack_depth: 0,
             # I_h (wrapped in interface)
             account_interface: nil,
-            block_interface: nil
+            block_interface: nil,
+            last_return_data: []
 
   @type t :: %__MODULE__{
           address: EVM.address(),
@@ -41,7 +42,8 @@ defmodule EVM.ExecEnv do
           machine_code: EVM.MachineCode.t(),
           stack_depth: integer(),
           block_interface: BlockInterface.t(),
-          account_interface: AccountInterface.t()
+          account_interface: AccountInterface.t(),
+          last_return_data: [EVM.val()]
         }
 
   @spec put_storage(t(), integer(), integer()) :: t()

--- a/apps/evm/lib/evm/exec_env.ex
+++ b/apps/evm/lib/evm/exec_env.ex
@@ -29,8 +29,7 @@ defmodule EVM.ExecEnv do
             stack_depth: 0,
             # I_h (wrapped in interface)
             account_interface: nil,
-            block_interface: nil,
-            last_return_data: []
+            block_interface: nil
 
   @type t :: %__MODULE__{
           address: EVM.address(),
@@ -42,8 +41,7 @@ defmodule EVM.ExecEnv do
           machine_code: EVM.MachineCode.t(),
           stack_depth: integer(),
           block_interface: BlockInterface.t(),
-          account_interface: AccountInterface.t(),
-          last_return_data: [EVM.val()]
+          account_interface: AccountInterface.t()
         }
 
   @spec put_storage(t(), integer(), integer()) :: t()

--- a/apps/evm/lib/evm/machine_state.ex
+++ b/apps/evm/lib/evm/machine_state.ex
@@ -6,11 +6,7 @@ defmodule EVM.MachineState do
   This is most often seen as µ in the Yellow Paper.
   """
 
-  alias EVM.Gas
-  alias EVM.Stack
-  alias EVM.MachineState
-  alias EVM.ProgramCounter
-  alias EVM.ExecEnv
+  alias EVM.{Gas, Stack, MachineState, ProgramCounter, ExecEnv}
   alias EVM.Operation.Metadata
 
   # g
@@ -23,7 +19,8 @@ defmodule EVM.MachineState do
             active_words: 0,
             previously_active_words: 0,
             # s
-            stack: []
+            stack: [],
+            last_return_data: []
 
   @type program_counter :: integer()
   @type memory :: binary()

--- a/apps/evm/lib/evm/machine_state.ex
+++ b/apps/evm/lib/evm/machine_state.ex
@@ -29,7 +29,8 @@ defmodule EVM.MachineState do
           program_counter: program_counter,
           memory: memory,
           active_words: integer(),
-          stack: Stack.t()
+          stack: Stack.t(),
+          last_return_data: [EVM.val()]
         }
 
   @doc """

--- a/apps/evm/lib/evm/operation.ex
+++ b/apps/evm/lib/evm/operation.ex
@@ -211,11 +211,11 @@ defmodule EVM.Operation do
 
       # Add
       iex> EVM.Operation.run(EVM.Operation.metadata(:add), %EVM.MachineState{stack: [1, 2]}, %EVM.SubState{}, %EVM.ExecEnv{})
-      {%EVM.MachineState{stack: [3]}, %EVM.SubState{}, %EVM.ExecEnv{}}
+      {%EVM.MachineState{stack: [3], last_return_data: 3}, %EVM.SubState{}, %EVM.ExecEnv{}}
 
       # Push
       iex> EVM.Operation.run(EVM.Operation.metadata(:push1), %EVM.MachineState{stack: [1, 2]}, %EVM.SubState{}, %EVM.ExecEnv{machine_code: <<00, 01>>})
-      {%EVM.MachineState{stack: [1, 1, 2]}, %EVM.SubState{}, %EVM.ExecEnv{machine_code: <<0, 1>>}}
+      {%EVM.MachineState{stack: [1, 1, 2], last_return_data: 1}, %EVM.SubState{}, %EVM.ExecEnv{machine_code: <<0, 1>>}}
 
       # nil
       iex> EVM.Operation.run(EVM.Operation.metadata(:stop), %EVM.MachineState{stack: [1, 2]}, %EVM.SubState{}, %EVM.ExecEnv{})
@@ -259,9 +259,9 @@ defmodule EVM.Operation do
   ## Examples
   #
       iex> EVM.Operation.normalize_op_result(1, [])
-      %{stack: [1]}
+      %{stack: [1], last_return_data: 1}
       iex> EVM.Operation.normalize_op_result([1,2], [])
-      %{stack: [1, 2]}
+      %{stack: [1, 2], last_return_data: [1, 2]}
 
   """
   @spec normalize_op_result(EVM.val() | list(EVM.val()) | op_result(), EVM.Stack.t()) ::

--- a/apps/evm/lib/evm/operation.ex
+++ b/apps/evm/lib/evm/operation.ex
@@ -210,20 +210,20 @@ defmodule EVM.Operation do
       # TODO: How to handle trie state in tests?
 
       # Add
-      iex> EVM.Operation.run_operation(EVM.Operation.metadata(:add), %EVM.MachineState{stack: [1, 2]}, %EVM.SubState{}, %EVM.ExecEnv{})
+      iex> EVM.Operation.run(EVM.Operation.metadata(:add), %EVM.MachineState{stack: [1, 2]}, %EVM.SubState{}, %EVM.ExecEnv{})
       {%EVM.MachineState{stack: [3]}, %EVM.SubState{}, %EVM.ExecEnv{}}
 
       # Push
-      iex> EVM.Operation.run_operation(EVM.Operation.metadata(:push1), %EVM.MachineState{stack: [1, 2]}, %EVM.SubState{}, %EVM.ExecEnv{machine_code: <<00, 01>>})
+      iex> EVM.Operation.run(EVM.Operation.metadata(:push1), %EVM.MachineState{stack: [1, 2]}, %EVM.SubState{}, %EVM.ExecEnv{machine_code: <<00, 01>>})
       {%EVM.MachineState{stack: [1, 1, 2]}, %EVM.SubState{}, %EVM.ExecEnv{machine_code: <<0, 1>>}}
 
       # nil
-      iex> EVM.Operation.run_operation(EVM.Operation.metadata(:stop), %EVM.MachineState{stack: [1, 2]}, %EVM.SubState{}, %EVM.ExecEnv{})
+      iex> EVM.Operation.run(EVM.Operation.metadata(:stop), %EVM.MachineState{stack: [1, 2]}, %EVM.SubState{}, %EVM.ExecEnv{})
       {%EVM.MachineState{stack: [1, 2]}, %EVM.SubState{}, %EVM.ExecEnv{}}
   """
-  @spec run_operation(EVM.Operation.Metadata.t(), MachineState.t(), SubState.t(), ExecEnv.t()) ::
+  @spec run(EVM.Operation.Metadata.t(), MachineState.t(), SubState.t(), ExecEnv.t()) ::
           {MachineState.t(), SubState.t(), ExecEnv.t()}
-  def run_operation(operation, machine_state, sub_state, exec_env) do
+  def run(operation, machine_state, sub_state, exec_env) do
     {args, updated_machine_state} = operation_args(operation, machine_state, sub_state, exec_env)
 
     apply_to_group_module(operation.sym, args)

--- a/apps/evm/lib/evm/operation/environmental_information.ex
+++ b/apps/evm/lib/evm/operation/environmental_information.ex
@@ -271,4 +271,27 @@ defmodule EVM.Operation.EnvironmentalInformation do
       %{machine_state: machine_state}
     end
   end
+
+  @doc """
+  Get size of output data from the previous call from the current environment.
+
+  ## Examples
+
+      iex> EVM.Operation.EnvironmentalInformation.returndatasize([], %{exec_env: %EVM.ExecEnv{last_return_data: 55}})
+      1
+      iex> EVM.Operation.EnvironmentalInformation.returndatasize([], %{exec_env: %EVM.ExecEnv{last_return_data: [55, 66]}})
+      2
+      iex> EVM.Operation.EnvironmentalInformation.returndatasize([], %{exec_env: %EVM.ExecEnv{}})
+      0
+  """
+  @spec codesize(Operation.stack_args(), Operation.vm_map()) :: Operation.op_result()
+  def returndatasize(_args, %{exec_env: env}) do
+    data = env.last_return_data
+
+    cond do
+      is_nil(data) -> 0
+      is_list(data) -> Enum.count(data)
+      true -> 1
+    end
+  end
 end

--- a/apps/evm/lib/evm/operation/environmental_information.ex
+++ b/apps/evm/lib/evm/operation/environmental_information.ex
@@ -1,9 +1,6 @@
 defmodule EVM.Operation.EnvironmentalInformation do
-  alias EVM.Operation
-  alias EVM.Stack
-  alias EVM.Helpers
+  alias EVM.{Operation, Stack, Helpers}
   alias EVM.Interface.AccountInterface
-  alias MerklePatriciaTree.Trie
 
   @doc """
   Get address of currently executing account.
@@ -104,8 +101,6 @@ defmodule EVM.Operation.EnvironmentalInformation do
   @doc """
   Get input data of current environment.
 
-  TODO: Implement opcode
-
   ## Examples
 
       iex> EVM.Operation.EnvironmentalInformation.calldataload([0], %{exec_env: %{data: (for _ <- 1..50, into: <<>>, do: <<255>>)}})
@@ -119,7 +114,9 @@ defmodule EVM.Operation.EnvironmentalInformation do
   """
   @spec calldataload(Operation.stack_args(), Operation.vm_map()) :: Operation.op_result()
   def calldataload([s0], %{exec_env: %{data: data}}) do
-    Helpers.read_zero_padded(data, s0, 32) |> Helpers.decode_signed()
+    data
+    |> Helpers.read_zero_padded(s0, 32)
+    |> Helpers.decode_signed()
   end
 
   @doc """
@@ -138,8 +135,6 @@ defmodule EVM.Operation.EnvironmentalInformation do
 
   @doc """
   Copy input data in current environment to memory.
-
-  TODO: Implement opcode
 
   ## Examples
 

--- a/apps/evm/lib/evm/operation/environmental_information.ex
+++ b/apps/evm/lib/evm/operation/environmental_information.ex
@@ -277,16 +277,16 @@ defmodule EVM.Operation.EnvironmentalInformation do
 
   ## Examples
 
-      iex> EVM.Operation.EnvironmentalInformation.returndatasize([], %{exec_env: %EVM.ExecEnv{last_return_data: 55}})
+      iex> EVM.Operation.EnvironmentalInformation.returndatasize([], %{machine_state: %EVM.MachineState{last_return_data: 55}})
       1
-      iex> EVM.Operation.EnvironmentalInformation.returndatasize([], %{exec_env: %EVM.ExecEnv{last_return_data: [55, 66]}})
+      iex> EVM.Operation.EnvironmentalInformation.returndatasize([], %{machine_state: %EVM.MachineState{last_return_data: [55, 66]}})
       2
-      iex> EVM.Operation.EnvironmentalInformation.returndatasize([], %{exec_env: %EVM.ExecEnv{}})
+      iex> EVM.Operation.EnvironmentalInformation.returndatasize([], %{machine_state: %EVM.MachineState{}})
       0
   """
-  @spec codesize(Operation.stack_args(), Operation.vm_map()) :: Operation.op_result()
-  def returndatasize(_args, %{exec_env: env}) do
-    data = env.last_return_data
+  @spec returndatasize(Operation.stack_args(), Operation.vm_map()) :: Operation.op_result()
+  def returndatasize(_args, %{machine_state: state}) do
+    data = state.last_return_data
 
     cond do
       is_nil(data) -> 0

--- a/apps/evm/lib/evm/operation/metadata/environmental_information.ex
+++ b/apps/evm/lib/evm/operation/metadata/environmental_information.ex
@@ -104,6 +104,16 @@ defmodule EVM.Operation.Metadata.EnvironmentalInformation do
                       input_count: 4,
                       output_count: 0,
                       group: :environmental_information
+                    },
+                    %{
+                      id: 0x3D,
+                      description:
+                        "Get size of output data from the previous call from the current
+environment.",
+                      sym: :returndatasize,
+                      input_count: 0,
+                      output_count: 1,
+                      group: :environmental_information
                     }
                   ],
                   do: struct(EVM.Operation.Metadata, operation)

--- a/apps/evm/lib/evm/vm.ex
+++ b/apps/evm/lib/evm/vm.ex
@@ -49,13 +49,13 @@ defmodule EVM.VM do
   ## Examples
 
       iex> EVM.VM.exec(%EVM.MachineState{program_counter: 0, gas: 5, stack: [1, 2]}, %EVM.SubState{}, %EVM.ExecEnv{machine_code: EVM.MachineCode.compile([:add])})
-      {%EVM.MachineState{program_counter: 2, gas: 2, stack: [3]}, %EVM.SubState{}, %EVM.ExecEnv{machine_code: EVM.MachineCode.compile([:add])}, <<>>}
+      {%EVM.MachineState{program_counter: 2, gas: 2, stack: [3], last_return_data: 3}, %EVM.SubState{}, %EVM.ExecEnv{machine_code: EVM.MachineCode.compile([:add])}, <<>>}
 
       iex> EVM.VM.exec(%EVM.MachineState{program_counter: 0, gas: 9, stack: []}, %EVM.SubState{}, %EVM.ExecEnv{machine_code: EVM.MachineCode.compile([:push1, 3, :push1, 5, :add])})
-      {%EVM.MachineState{program_counter: 6, gas: 0, stack: [8]}, %EVM.SubState{}, %EVM.ExecEnv{machine_code: EVM.MachineCode.compile([:push1, 3, :push1, 5, :add])}, ""}
+      {%EVM.MachineState{program_counter: 6, gas: 0, last_return_data: 8, stack: [8]}, %EVM.SubState{}, %EVM.ExecEnv{machine_code: EVM.MachineCode.compile([:push1, 3, :push1, 5, :add])}, ""}
 
       iex> EVM.VM.exec(%EVM.MachineState{program_counter: 0, gas: 24, stack: []}, %EVM.SubState{}, %EVM.ExecEnv{machine_code: EVM.MachineCode.compile([:push1, 3, :push1, 5, :add, :push1, 0x00, :mstore, :push1, 32, :push1, 0, :return])})
-      {%EVM.MachineState{active_words: 1, memory: <<0x08::256>>, gas: 0, program_counter: 13, stack: []}, %EVM.SubState{logs: [], refund: 0, suicide_list: []}, %EVM.ExecEnv{machine_code: <<96, 3, 96, 5, 1, 96, 0, 82, 96, 32, 96, 0, 243>>}, <<8::256>>}
+      {%EVM.MachineState{active_words: 1, last_return_data: 0, memory: <<0x08::256>>, gas: 0, program_counter: 13, stack: []}, %EVM.SubState{logs: [], refund: 0,  suicide_list: []}, %EVM.ExecEnv{machine_code: <<96, 3, 96, 5, 1, 96, 0, 82, 96, 32, 96, 0, 243>>}, <<8::256>>}
   """
   @spec exec(MachineState.t(), SubState.t(), ExecEnv.t()) ::
           {MachineState.t(), SubState.t(), ExecEnv.t(), output}
@@ -108,7 +108,7 @@ defmodule EVM.VM do
   ## Examples
 
       iex> EVM.VM.cycle(%EVM.MachineState{program_counter: 0, gas: 5, stack: [1, 2]}, %EVM.SubState{}, %EVM.ExecEnv{machine_code: EVM.MachineCode.compile([:add])})
-      {%EVM.MachineState{program_counter: 1, gas: 2, stack: [3]}, %EVM.SubState{}, %EVM.ExecEnv{machine_code: EVM.MachineCode.compile([:add])}}
+      {%EVM.MachineState{program_counter: 1, last_return_data: 3, gas: 2, stack: [3]}, %EVM.SubState{}, %EVM.ExecEnv{machine_code: EVM.MachineCode.compile([:add])}}
   """
   @spec cycle(MachineState.t(), SubState.t(), ExecEnv.t()) ::
           {MachineState.t(), SubState.t(), ExecEnv.t()}

--- a/apps/evm/lib/evm/vm.ex
+++ b/apps/evm/lib/evm/vm.ex
@@ -119,7 +119,7 @@ defmodule EVM.VM do
     machine_state = MachineState.subtract_gas(machine_state, exec_env)
 
     {machine_state, sub_state, exec_env} =
-      Operation.run_operation(operation, machine_state, sub_state, exec_env)
+      Operation.run(operation, machine_state, sub_state, exec_env)
 
     machine_state = MachineState.move_program_counter(machine_state, operation, inputs)
 


### PR DESCRIPTION
![IMG](https://i.imgur.com/suf8WVw.png)

- add `last_return_data` field to `machineState` struct to track last op output data
- implement `RETURNDATASIZE`

Part of https://github.com/poanetwork/mana/issues/131