### PR TITLE
Make AckRespV4 behave the same as AuthMsgV4

### DIFF
--- a/apps/ex_wire/lib/ex_wire/handshake/struct/ack_resp_v4.ex
+++ b/apps/ex_wire/lib/ex_wire/handshake/struct/ack_resp_v4.ex
@@ -20,7 +20,7 @@ defmodule ExWire.Handshake.Struct.AckRespV4 do
   @spec serialize(t) :: ExRLP.t()
   def serialize(auth_resp) do
     [
-      auth_resp.remote_ephemeral_public_key,
+      auth_resp.remote_ephemeral_public_key |> ExthCrypto.Key.der_to_raw(),
       auth_resp.remote_nonce,
       auth_resp.remote_version |> :binary.encode_unsigned()
     ]
@@ -33,7 +33,7 @@ defmodule ExWire.Handshake.Struct.AckRespV4 do
     [remote_version | _tl] = rlp_tail
 
     %__MODULE__{
-      remote_ephemeral_public_key: remote_ephemeral_public_key,
+      remote_ephemeral_public_key: remote_ephemeral_public_key |> ExthCrypto.Key.raw_to_der(),
       remote_nonce: remote_nonce,
       remote_version:
         if(

--- a/apps/ex_wire/test/ex_wire/handshake/handshake_test.exs
+++ b/apps/ex_wire/test/ex_wire/handshake/handshake_test.exs
@@ -191,6 +191,7 @@ defmodule HandshakeTest do
     assert ack_resp.remote_ephemeral_public_key ==
              "b6d82fa3409da933dbf9cb0140c5dde89f4e64aec88d476af648880f4a10e1e49fe35ef3e69e93dd300b4797765a747c6384a6ecf5db9c2690398607a86181e4"
              |> ExthCrypto.Math.hex_to_bin()
+             |> ExthCrypto.Key.raw_to_der()
 
     assert ack_resp.remote_version == 63
   end
@@ -232,6 +233,7 @@ defmodule HandshakeTest do
     assert ack_resp.remote_ephemeral_public_key ==
              "b6d82fa3409da933dbf9cb0140c5dde89f4e64aec88d476af648880f4a10e1e49fe35ef3e69e93dd300b4797765a747c6384a6ecf5db9c2690398607a86181e4"
              |> ExthCrypto.Math.hex_to_bin()
+             |> ExthCrypto.Key.raw_to_der()
 
     assert ack_resp.remote_version == 4
   end
@@ -273,6 +275,7 @@ defmodule HandshakeTest do
     assert ack_resp.remote_ephemeral_public_key ==
              "b6d82fa3409da933dbf9cb0140c5dde89f4e64aec88d476af648880f4a10e1e49fe35ef3e69e93dd300b4797765a747c6384a6ecf5db9c2690398607a86181e4"
              |> ExthCrypto.Math.hex_to_bin()
+             |> ExthCrypto.Key.raw_to_der()
 
     assert ack_resp.remote_version == 57
   end


### PR DESCRIPTION
This issue was discovered while working on https://github.com/poanetwork/mana/issues/103, but it can be committed separately from the rest of the work.

Summary
=======

The AckRespV4 struct is slightly different than the AuthMsgV4 struct. The latter manipulates the keys when serializing and deserializing them, turning them from `raw` to `der` and viceversa.

This subtle difference presents a problem in other places when we expect those keys to be of similar type (either raw or der). For example, the `Secrets.derive_secrets` can be used when receiving and auth message or an ack message.

For those reason, we make AckRespV4 behave like AuthMsgV4, making the key `raw` when serializing to be sent to our peers, and making it `der` when deserializing the data received from a peer.