### PR TITLE
add test for pop, remove comment

### DIFF
--- a/apps/evm/lib/evm/operation/stack_memory_storage_and_flow.ex
+++ b/apps/evm/lib/evm/operation/stack_memory_storage_and_flow.ex
@@ -7,8 +7,6 @@ defmodule EVM.Operation.StackMemoryStorageAndFlow do
   @doc """
   Remove item from stack.
 
-  TODO: Implement opcode
-
   ## Examples
 
       iex> EVM.Operation.StackMemoryStorageAndFlow.pop([55], %{stack: []})

--- a/apps/evm/test/evm/operation/stack_memory_storage_and_flow_test.exs
+++ b/apps/evm/test/evm/operation/stack_memory_storage_and_flow_test.exs
@@ -1,4 +1,19 @@
 defmodule EVM.Operation.StackMemoryStorageAndFlowTest do
   use ExUnit.Case, async: true
   doctest EVM.Operation.StackMemoryStorageAndFlow
+
+  alias EVM.{MachineState, MachineCode, SubState, ExecEnv, VM}
+
+  describe "pop/2" do
+    test "pops value from stack" do
+      machine_code = MachineCode.compile([:push1, 3, :push1, 5, :pop])
+      exec_env = %ExecEnv{machine_code: machine_code}
+      machine_state = %MachineState{program_counter: 0, gas: 24, stack: []}
+      substate = %SubState{}
+
+      {updated_machine_state, _, updated_exec_env, _} = VM.exec(machine_state, substate, exec_env)
+
+      assert updated_machine_state.stack == [3]
+    end
+  end
 end


### PR DESCRIPTION
https://github.com/poanetwork/mana/issues/133

I was confused by the comment in doctests so I thought this operation wasn't implemented.

Actually, the last stack value is being popped when operation arguments are taken from the stack.