### PR TITLE
Fix Signature recovery in crypto handshake

### DIFF
--- a/apps/ex_wire/lib/ex_wire/handshake/handshake.ex
+++ b/apps/ex_wire/lib/ex_wire/handshake/handshake.ex
@@ -203,9 +203,11 @@ defmodule ExWire.Handshake do
     {signature, _, _, recovery_id} =
       ExthCrypto.Signature.sign_digest(shared_secret_xor_nonce, my_ephemeral_private_key)
 
+    compact_signature = ExthCrypto.Signature.compact_format(signature, recovery_id)
+
     # Build an auth message to send over the wire
     auth_msg = %AuthMsgV4{
-      signature: signature <> :binary.encode_unsigned(recovery_id),
+      signature: compact_signature,
       remote_public_key: my_static_public_key,
       remote_nonce: nonce,
       remote_version: ExWire.Config.protocol_version()

--- a/apps/ex_wire/test/ex_wire/handshake/struct/auth_msg_v4_test.exs
+++ b/apps/ex_wire/test/ex_wire/handshake/struct/auth_msg_v4_test.exs
@@ -1,4 +1,54 @@
 defmodule ExWire.Handshake.Struct.AuthMsgV4Test do
   use ExUnit.Case, async: true
   doctest ExWire.Handshake.Struct.AuthMsgV4
+
+  alias ExWire.Handshake
+  alias ExWire.Handshake.Struct.AuthMsgV4
+  alias ExthCrypto.ECIES.ECDH
+
+  setup do
+    keys = %{
+      initiator_static_public_key: ExthCrypto.Test.public_key(:key_a),
+      initiator_static_private_key: ExthCrypto.Test.private_key(:key_a),
+      recipient_static_public_key: ExthCrypto.Test.public_key(:key_b),
+      recipient_static_private_key: ExthCrypto.Test.private_key(:key_b)
+    }
+
+    {:ok, %{keys: keys}}
+  end
+
+  describe "set_remote_ephemeral_public_key/2" do
+    test "recovers and sets initiators ephemeral public key from shared secret", %{keys: keys} do
+      initiator_nonce = Handshake.new_nonce()
+      {initiator_ephemeral_public_key, initiator_ephemeral_private_key} = ECDH.new_ecdh_keypair()
+
+      {signature, recovery_id} =
+        generate_signature_and_recovery_id(initiator_ephemeral_private_key, initiator_nonce, keys)
+
+      auth_msg = build_auth_msg(signature, recovery_id, initiator_nonce, keys)
+
+      new_auth_msg =
+        AuthMsgV4.set_remote_ephemeral_public_key(auth_msg, keys.recipient_static_private_key)
+
+      assert new_auth_msg.remote_ephemeral_public_key == initiator_ephemeral_public_key
+    end
+  end
+
+  def build_auth_msg(signature, recovery_id, initiator_nonce, keys) do
+    %AuthMsgV4{
+      signature: signature <> :binary.encode_unsigned(recovery_id),
+      remote_public_key: keys.initiator_static_public_key,
+      remote_nonce: initiator_nonce
+    }
+  end
+
+  def generate_signature_and_recovery_id(initiator_ephemeral_private_key, initiator_nonce, keys) do
+    {signature, _r, _s, recovery_id} =
+      keys.initiator_static_private_key
+      |> ECDH.generate_shared_secret(keys.recipient_static_public_key)
+      |> ExthCrypto.Math.xor(initiator_nonce)
+      |> ExthCrypto.Signature.sign_digest(initiator_ephemeral_private_key)
+
+    {signature, recovery_id}
+  end
 end

--- a/apps/exth_crypto/test/signature_test.exs
+++ b/apps/exth_crypto/test/signature_test.exs
@@ -17,4 +17,28 @@ defmodule ExthCrypto.SignatureTest do
       assert recovered_public_key == public_key
     end
   end
+
+  describe "compact_format/2" do
+    test "returns a compacted signature (signature + recovery id)" do
+      private_key = Test.private_key()
+      message = "crypto alchemist"
+      {signature, _r, _s, recovery_id} = Signature.sign_digest(message, private_key)
+
+      compacted_signature = Signature.compact_format(signature, recovery_id)
+
+      assert compacted_signature == signature <> :binary.encode_unsigned(recovery_id)
+    end
+  end
+
+  describe "split_compact_format/1" do
+    test "splits a compacted signature into the ECDSA signature and the recovery id" do
+      private_key = Test.private_key()
+      message = "crypto alchemist"
+      {signature, _r, _s, recovery_id} = Signature.sign_digest(message, private_key)
+
+      compacted_signature = Signature.compact_format(signature, recovery_id)
+
+      assert {^signature, ^recovery_id} = Signature.split_compact_format(compacted_signature)
+    end
+  end
 end


### PR DESCRIPTION
During our work for https://github.com/poanetwork/mana/issues/103, we discovered some tests that fail intermittently. This fixes those issues.

Summary
========

`ExthCrypto.Signature.sign_digest/2` returns a `signature` and a `recovery_id`. We then concatenate those two when creating the `AuthMsgV4` struct. When the recipient tries to recover the public key, however, we are hardcoding the `recovery_id` to `0`. This led to intermittent failures in our tests (when the recover_id != 0).

To properly handle this, we create two functions in `ExthCrypto.Signature` to create a compact signature (sig + recover_id) and to split that compact signature when recovering it.

Using those functions, we fix the bug by no longer hardcoding the `0` but retrieving the correct recovery id from the auth message, and using it to recover the public key.

We also try to improve the typespecs in `Signature` since we have learned that a ECDSA compact signature should always have 65 bytes (64 + recovery_id).