### PR TITLE
Change AuthMsgV4 and AckRespV4 keys

### DIFF
--- a/apps/ex_wire/lib/ex_wire/handshake/handshake.ex
+++ b/apps/ex_wire/lib/ex_wire/handshake/handshake.ex
@@ -68,7 +68,7 @@ defmodule ExWire.Handshake do
         auth_msg =
           rlp
           |> AuthMsgV4.deserialize()
-          |> AuthMsgV4.set_remote_ephemeral_public_key(my_static_private_key)
+          |> AuthMsgV4.set_initiator_ephemeral_public_key(my_static_private_key)
 
         {:ok, auth_msg, frame_rest}
 
@@ -79,20 +79,20 @@ defmodule ExWire.Handshake do
           <<
             signature::binary-size(65),
             _::binary-size(32),
-            remote_public_key::binary-size(64),
-            remote_nonce::binary-size(32),
+            initiator_public_key::binary-size(64),
+            initiator_nonce::binary-size(32),
             0x00::size(8)
           >> = plaintext
 
           auth_msg =
             [
               signature,
-              remote_public_key,
-              remote_nonce,
+              initiator_public_key,
+              initiator_nonce,
               ExWire.Config.protocol_version()
             ]
             |> AuthMsgV4.deserialize()
-            |> AuthMsgV4.set_remote_ephemeral_public_key(my_static_private_key)
+            |> AuthMsgV4.set_initiator_ephemeral_public_key(my_static_private_key)
 
           {:ok, auth_msg, <<>>}
         end
@@ -125,15 +125,15 @@ defmodule ExWire.Handshake do
         with {:ok, plaintext} <-
                ExthCrypto.ECIES.decrypt(my_static_private_key, encoded_ack, <<>>, <<>>) do
           <<
-            remote_ephemeral_public_key::binary-size(64),
-            remote_nonce::binary-size(32),
+            recipient_ephemeral_public_key::binary-size(64),
+            recipient_nonce::binary-size(32),
             0x00::size(8)
           >> = plaintext
 
           ack_resp =
             [
-              remote_ephemeral_public_key,
-              remote_nonce,
+              recipient_ephemeral_public_key,
+              recipient_nonce,
               ExWire.Config.protocol_version()
             ]
             |> AckRespV4.deserialize()
@@ -152,10 +152,10 @@ defmodule ExWire.Handshake do
       iex> {auth_msg_v4, ephemeral_keypair, nonce} = ExWire.Handshake.build_auth_msg(ExthCrypto.Test.public_key(:key_a), ExthCrypto.Test.private_key(:key_a), ExthCrypto.Test.public_key(:key_b), ExthCrypto.Test.init_vector(1, 32), ExthCrypto.Test.key_pair(:key_c))
       iex> %{auth_msg_v4 | signature: nil} # signature will be unique each time
       %ExWire.Handshake.Struct.AuthMsgV4{
-        remote_ephemeral_public_key: nil,
-        remote_nonce: <<1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32>>,
-        remote_public_key: <<4, 54, 241, 224, 126, 85, 135, 69, 213, 129, 115, 3, 41, 161, 217, 87, 215, 159, 64, 17, 167, 128, 113, 172, 232, 46, 34, 145, 136, 72, 160, 207, 161, 171, 255, 26, 163, 160, 158, 227, 196, 92, 62, 119, 84, 156, 99, 224, 155, 120, 250, 153, 134, 180, 218, 177, 186, 200, 199, 106, 97, 103, 50, 215, 114>>,
-        remote_version: 63,
+        initiator_ephemeral_public_key: nil,
+        initiator_nonce: <<1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32>>,
+        initiator_public_key: <<4, 54, 241, 224, 126, 85, 135, 69, 213, 129, 115, 3, 41, 161, 217, 87, 215, 159, 64, 17, 167, 128, 113, 172, 232, 46, 34, 145, 136, 72, 160, 207, 161, 171, 255, 26, 163, 160, 158, 227, 196, 92, 62, 119, 84, 156, 99, 224, 155, 120, 250, 153, 134, 180, 218, 177, 186, 200, 199, 106, 97, 103, 50, 215, 114>>,
+        initiator_version: 63,
         signature: nil
       }
       iex> ephemeral_keypair
@@ -208,9 +208,9 @@ defmodule ExWire.Handshake do
     # Build an auth message to send over the wire
     auth_msg = %AuthMsgV4{
       signature: compact_signature,
-      remote_public_key: my_static_public_key,
-      remote_nonce: nonce,
-      remote_version: ExWire.Config.protocol_version()
+      initiator_public_key: my_static_public_key,
+      initiator_nonce: nonce,
+      initiator_version: ExWire.Config.protocol_version()
     }
 
     # Return auth_msg and my new key pair
@@ -224,20 +224,20 @@ defmodule ExWire.Handshake do
 
       iex> ExWire.Handshake.build_ack_resp(ExthCrypto.Test.public_key(:key_c), ExthCrypto.Test.init_vector())
       %ExWire.Handshake.Struct.AckRespV4{
-        remote_ephemeral_public_key: <<4, 146, 201, 161, 205, 19, 177, 147, 33, 107, 190, 144, 81, 145, 173, 83, 20, 105, 150, 114, 196, 249, 143, 167, 152, 63, 225, 96, 184, 86, 203, 38, 134, 241, 40, 152, 74, 34, 68, 233, 204, 91, 240, 208, 254, 62, 169, 53, 201, 248, 156, 236, 34, 203, 156, 75, 18, 121, 162, 104, 3, 164, 156, 46, 186>>,
-        remote_nonce: <<1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16>>,
-        remote_version: 63
+        recipient_ephemeral_public_key: <<4, 146, 201, 161, 205, 19, 177, 147, 33, 107, 190, 144, 81, 145, 173, 83, 20, 105, 150, 114, 196, 249, 143, 167, 152, 63, 225, 96, 184, 86, 203, 38, 134, 241, 40, 152, 74, 34, 68, 233, 204, 91, 240, 208, 254, 62, 169, 53, 201, 248, 156, 236, 34, 203, 156, 75, 18, 121, 162, 104, 3, 164, 156, 46, 186>>,
+        recipient_nonce: <<1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16>>,
+        recipient_version: 63
       }
   """
   @spec build_ack_resp(ExthCrypto.Key.public_key(), binary() | nil) :: AckRespV4.t()
-  def build_ack_resp(remote_ephemeral_public_key, nonce \\ nil) do
+  def build_ack_resp(recipient_ephemeral_public_key, nonce \\ nil) do
     # Generate nonce unless given
     nonce = if nonce, do: nonce, else: new_nonce()
 
     %AckRespV4{
-      remote_nonce: nonce,
-      remote_ephemeral_public_key: remote_ephemeral_public_key,
-      remote_version: ExWire.Config.protocol_version()
+      recipient_nonce: nonce,
+      recipient_ephemeral_public_key: recipient_ephemeral_public_key,
+      recipient_version: ExWire.Config.protocol_version()
     }
   end
 
@@ -253,16 +253,16 @@ defmodule ExWire.Handshake do
     case ExWire.Handshake.read_ack_resp(ack_data, ExWire.Config.private_key()) do
       {:ok,
        %ExWire.Handshake.Struct.AckRespV4{
-         remote_ephemeral_public_key: remote_ephemeral_public_key,
-         remote_nonce: remote_nonce
+         recipient_ephemeral_public_key: recipient_ephemeral_public_key,
+         recipient_nonce: recipient_nonce
        }, ack_data_limited, frame_rest} ->
         # We're the initiator, by definition since we got an ack resp.
         secrets =
           ExWire.Framing.Secrets.derive_secrets(
             true,
             my_ephemeral_private_key,
-            remote_ephemeral_public_key,
-            remote_nonce,
+            recipient_ephemeral_public_key,
+            recipient_nonce,
             my_nonce,
             auth_data,
             ack_data_limited
@@ -293,16 +293,16 @@ defmodule ExWire.Handshake do
       {:ok,
        %ExWire.Handshake.Struct.AuthMsgV4{
          signature: _signature,
-         remote_public_key: _remote_public_key,
-         remote_nonce: remote_nonce,
-         remote_version: remote_version,
-         remote_ephemeral_public_key: remote_ephemeral_public_key
+         initiator_public_key: _initiator_public_key,
+         initiator_nonce: initiator_nonce,
+         initiator_version: initiator_version,
+         initiator_ephemeral_public_key: initiator_ephemeral_public_key
        }} ->
-        # First, we'll build an ack, which we'll respond with to the remote peer
+        # First, we'll build an ack, which we'll respond with to the initiator
         ack_resp =
           ExWire.Handshake.build_ack_resp(
-            remote_ephemeral_public_key: my_ephemeral_public_key,
-            remote_version: remote_version
+            recipient_ephemeral_public_key: my_ephemeral_public_key,
+            recipient_version: initiator_version
           )
 
         # TODO: Make this accurate
@@ -316,8 +316,8 @@ defmodule ExWire.Handshake do
           ExWire.Framing.Secrets.derive_secrets(
             false,
             my_ephemeral_private_key,
-            remote_ephemeral_public_key,
-            remote_nonce,
+            initiator_ephemeral_public_key,
+            initiator_nonce,
             my_nonce,
             auth_data,
             encoded_ack_resp

--- a/apps/ex_wire/lib/ex_wire/handshake/struct/ack_resp_v4.ex
+++ b/apps/ex_wire/lib/ex_wire/handshake/struct/ack_resp_v4.ex
@@ -6,40 +6,41 @@ defmodule ExWire.Handshake.Struct.AckRespV4 do
   """
 
   defstruct [
-    :remote_ephemeral_public_key,
-    :remote_nonce,
-    :remote_version
+    :recipient_ephemeral_public_key,
+    :recipient_nonce,
+    :recipient_version
   ]
 
   @type t :: %__MODULE__{
-          remote_ephemeral_public_key: ExthCrypto.Key.public_key(),
-          remote_nonce: binary(),
-          remote_version: integer()
+          recipient_ephemeral_public_key: ExthCrypto.Key.public_key(),
+          recipient_nonce: binary(),
+          recipient_version: integer()
         }
 
   @spec serialize(t) :: ExRLP.t()
-  def serialize(auth_resp) do
+  def serialize(ack_resp) do
     [
-      auth_resp.remote_ephemeral_public_key |> ExthCrypto.Key.der_to_raw(),
-      auth_resp.remote_nonce,
-      auth_resp.remote_version |> :binary.encode_unsigned()
+      ack_resp.recipient_ephemeral_public_key |> ExthCrypto.Key.der_to_raw(),
+      ack_resp.recipient_nonce,
+      ack_resp.recipient_version |> :binary.encode_unsigned()
     ]
   end
 
   @spec deserialize(ExRLP.t()) :: t
   def deserialize(rlp) do
-    [remote_ephemeral_public_key | rlp_tail] = rlp
-    [remote_nonce | rlp_tail] = rlp_tail
-    [remote_version | _tl] = rlp_tail
+    [recipient_ephemeral_public_key | rlp_tail] = rlp
+    [recipient_nonce | rlp_tail] = rlp_tail
+    [recipient_version | _tl] = rlp_tail
 
     %__MODULE__{
-      remote_ephemeral_public_key: remote_ephemeral_public_key |> ExthCrypto.Key.raw_to_der(),
-      remote_nonce: remote_nonce,
-      remote_version:
+      recipient_ephemeral_public_key:
+        recipient_ephemeral_public_key |> ExthCrypto.Key.raw_to_der(),
+      recipient_nonce: recipient_nonce,
+      recipient_version:
         if(
-          is_binary(remote_version),
-          do: :binary.decode_unsigned(remote_version),
-          else: remote_version
+          is_binary(recipient_version),
+          do: :binary.decode_unsigned(recipient_version),
+          else: recipient_version
         )
     }
   end

--- a/apps/ex_wire/test/ex_wire/handshake/handshake_test.exs
+++ b/apps/ex_wire/test/ex_wire/handshake/handshake_test.exs
@@ -23,11 +23,11 @@ defmodule HandshakeTest do
     {:ok, her_auth_msg, <<>>} =
       Handshake.read_auth_msg(encoded_auth_msg, ExthCrypto.Test.private_key(:key_b))
 
-    # Same auth message, except we've added the remote ephemeral public key
-    assert her_auth_msg.remote_ephemeral_public_key != nil
-    assert my_auth_msg == %{her_auth_msg | remote_ephemeral_public_key: nil}
+    # Same auth message, except we've added the initiator ephemeral public key
+    assert her_auth_msg.initiator_ephemeral_public_key != nil
+    assert my_auth_msg == %{her_auth_msg | initiator_ephemeral_public_key: nil}
 
-    my_ack_resp = Handshake.build_ack_resp(her_auth_msg.remote_ephemeral_public_key)
+    my_ack_resp = Handshake.build_ack_resp(her_auth_msg.initiator_ephemeral_public_key)
 
     {:ok, encoded_ack_msg} =
       my_ack_resp
@@ -61,21 +61,21 @@ defmodule HandshakeTest do
 
     {:ok, auth_msg, <<>>} = Handshake.read_auth_msg(auth, secret)
 
-    assert auth_msg.remote_public_key ==
+    assert auth_msg.initiator_public_key ==
              "fda1cff674c90c9a197539fe3dfb53086ace64f83ed7c6eabec741f7f381cc803e52ab2cd55d5569bce4347107a310dfd5f88a010cd2ffd1005ca406f1842877"
              |> ExthCrypto.Math.hex_to_bin()
              |> ExthCrypto.Key.raw_to_der()
 
-    assert auth_msg.remote_nonce ==
+    assert auth_msg.initiator_nonce ==
              "7e968bba13b6c50e2c4cd7f241cc0d64d1ac25c7f5952df231ac6a2bda8ee5d6"
              |> ExthCrypto.Math.hex_to_bin()
 
-    assert auth_msg.remote_ephemeral_public_key ==
+    assert auth_msg.initiator_ephemeral_public_key ==
              "654d1044b69c577a44e5f01a1209523adb4026e70c62d1c13a067acabc09d2667a49821a0ad4b634554d330a15a58fe61f8a8e0544b310c6de7b0c8da7528a8d"
              |> ExthCrypto.Math.hex_to_bin()
              |> ExthCrypto.Key.raw_to_der()
 
-    assert auth_msg.remote_version == 63
+    assert auth_msg.initiator_version == 63
   end
 
   test "handshake auth eip 8" do
@@ -102,21 +102,21 @@ defmodule HandshakeTest do
 
     {:ok, auth_msg, <<>>} = Handshake.read_auth_msg(auth, secret)
 
-    assert auth_msg.remote_public_key ==
+    assert auth_msg.initiator_public_key ==
              "fda1cff674c90c9a197539fe3dfb53086ace64f83ed7c6eabec741f7f381cc803e52ab2cd55d5569bce4347107a310dfd5f88a010cd2ffd1005ca406f1842877"
              |> ExthCrypto.Math.hex_to_bin()
              |> ExthCrypto.Key.raw_to_der()
 
-    assert auth_msg.remote_nonce ==
+    assert auth_msg.initiator_nonce ==
              "7e968bba13b6c50e2c4cd7f241cc0d64d1ac25c7f5952df231ac6a2bda8ee5d6"
              |> ExthCrypto.Math.hex_to_bin()
 
-    assert auth_msg.remote_ephemeral_public_key ==
+    assert auth_msg.initiator_ephemeral_public_key ==
              "654d1044b69c577a44e5f01a1209523adb4026e70c62d1c13a067acabc09d2667a49821a0ad4b634554d330a15a58fe61f8a8e0544b310c6de7b0c8da7528a8d"
              |> ExthCrypto.Math.hex_to_bin()
              |> ExthCrypto.Key.raw_to_der()
 
-    assert auth_msg.remote_version == 4
+    assert auth_msg.initiator_version == 4
   end
 
   test "handshake auth eip 8 - 2" do
@@ -144,25 +144,25 @@ defmodule HandshakeTest do
 
     {:ok, auth_msg, <<>>} = Handshake.read_auth_msg(auth, secret)
 
-    assert auth_msg.remote_public_key ==
+    assert auth_msg.initiator_public_key ==
              "fda1cff674c90c9a197539fe3dfb53086ace64f83ed7c6eabec741f7f381cc803e52ab2cd55d5569bce4347107a310dfd5f88a010cd2ffd1005ca406f1842877"
              |> ExthCrypto.Math.hex_to_bin()
              |> ExthCrypto.Key.raw_to_der()
 
-    assert auth_msg.remote_nonce ==
+    assert auth_msg.initiator_nonce ==
              "7e968bba13b6c50e2c4cd7f241cc0d64d1ac25c7f5952df231ac6a2bda8ee5d6"
              |> ExthCrypto.Math.hex_to_bin()
 
-    assert auth_msg.remote_ephemeral_public_key ==
+    assert auth_msg.initiator_ephemeral_public_key ==
              "654d1044b69c577a44e5f01a1209523adb4026e70c62d1c13a067acabc09d2667a49821a0ad4b634554d330a15a58fe61f8a8e0544b310c6de7b0c8da7528a8d"
              |> ExthCrypto.Math.hex_to_bin()
              |> ExthCrypto.Key.raw_to_der()
 
-    assert auth_msg.remote_version == 56
+    assert auth_msg.initiator_version == 56
   end
 
   test "handshake ack plain" do
-    _remote_public_key =
+    _recipient_public_key =
       "fda1cff674c90c9a197539fe3dfb53086ace64f83ed7c6eabec741f7f381cc803e52ab2cd55d5569bce4347107a310dfd5f88a010cd2ffd1005ca406f1842877"
       |> ExthCrypto.Math.hex_to_bin()
 
@@ -184,20 +184,20 @@ defmodule HandshakeTest do
 
     {:ok, ack_resp, _ack_resp_bin, <<>>} = Handshake.read_ack_resp(ack, secret)
 
-    assert ack_resp.remote_nonce ==
+    assert ack_resp.recipient_nonce ==
              "559aead08264d5795d3909718cdd05abd49572e84fe55590eef31a88a08fdffd"
              |> ExthCrypto.Math.hex_to_bin()
 
-    assert ack_resp.remote_ephemeral_public_key ==
+    assert ack_resp.recipient_ephemeral_public_key ==
              "b6d82fa3409da933dbf9cb0140c5dde89f4e64aec88d476af648880f4a10e1e49fe35ef3e69e93dd300b4797765a747c6384a6ecf5db9c2690398607a86181e4"
              |> ExthCrypto.Math.hex_to_bin()
              |> ExthCrypto.Key.raw_to_der()
 
-    assert ack_resp.remote_version == 63
+    assert ack_resp.recipient_version == 63
   end
 
   test "handshake ack eip 8" do
-    _remote_public_key =
+    _recipient_public_key =
       "fda1cff674c90c9a197539fe3dfb53086ace64f83ed7c6eabec741f7f381cc803e52ab2cd55d5569bce4347107a310dfd5f88a010cd2ffd1005ca406f1842877"
       |> ExthCrypto.Math.hex_to_bin()
 
@@ -226,20 +226,20 @@ defmodule HandshakeTest do
 
     {:ok, ack_resp, _ack_resp_bin, <<>>} = Handshake.read_ack_resp(ack, secret)
 
-    assert ack_resp.remote_nonce ==
+    assert ack_resp.recipient_nonce ==
              "559aead08264d5795d3909718cdd05abd49572e84fe55590eef31a88a08fdffd"
              |> ExthCrypto.Math.hex_to_bin()
 
-    assert ack_resp.remote_ephemeral_public_key ==
+    assert ack_resp.recipient_ephemeral_public_key ==
              "b6d82fa3409da933dbf9cb0140c5dde89f4e64aec88d476af648880f4a10e1e49fe35ef3e69e93dd300b4797765a747c6384a6ecf5db9c2690398607a86181e4"
              |> ExthCrypto.Math.hex_to_bin()
              |> ExthCrypto.Key.raw_to_der()
 
-    assert ack_resp.remote_version == 4
+    assert ack_resp.recipient_version == 4
   end
 
   test "handshake ack eip 8 - 2" do
-    _remote_public_key =
+    _recipient_public_key =
       "fda1cff674c90c9a197539fe3dfb53086ace64f83ed7c6eabec741f7f381cc803e52ab2cd55d5569bce4347107a310dfd5f88a010cd2ffd1005ca406f1842877"
       |> ExthCrypto.Math.hex_to_bin()
 
@@ -268,15 +268,15 @@ defmodule HandshakeTest do
 
     {:ok, ack_resp, _ack_resp_bin, <<>>} = Handshake.read_ack_resp(ack, secret)
 
-    assert ack_resp.remote_nonce ==
+    assert ack_resp.recipient_nonce ==
              "559aead08264d5795d3909718cdd05abd49572e84fe55590eef31a88a08fdffd"
              |> ExthCrypto.Math.hex_to_bin()
 
-    assert ack_resp.remote_ephemeral_public_key ==
+    assert ack_resp.recipient_ephemeral_public_key ==
              "b6d82fa3409da933dbf9cb0140c5dde89f4e64aec88d476af648880f4a10e1e49fe35ef3e69e93dd300b4797765a747c6384a6ecf5db9c2690398607a86181e4"
              |> ExthCrypto.Math.hex_to_bin()
              |> ExthCrypto.Key.raw_to_der()
 
-    assert ack_resp.remote_version == 57
+    assert ack_resp.recipient_version == 57
   end
 end

--- a/apps/ex_wire/test/ex_wire/handshake/struct/auth_msg_v4_test.exs
+++ b/apps/ex_wire/test/ex_wire/handshake/struct/auth_msg_v4_test.exs
@@ -17,7 +17,7 @@ defmodule ExWire.Handshake.Struct.AuthMsgV4Test do
     {:ok, %{keys: keys}}
   end
 
-  describe "set_remote_ephemeral_public_key/2" do
+  describe "set_initiator_ephemeral_public_key/2" do
     test "recovers and sets initiators ephemeral public key from shared secret", %{keys: keys} do
       initiator_nonce = Handshake.new_nonce()
       {initiator_ephemeral_public_key, initiator_ephemeral_private_key} = ECDH.new_ecdh_keypair()
@@ -28,17 +28,17 @@ defmodule ExWire.Handshake.Struct.AuthMsgV4Test do
       auth_msg = build_auth_msg(signature, recovery_id, initiator_nonce, keys)
 
       new_auth_msg =
-        AuthMsgV4.set_remote_ephemeral_public_key(auth_msg, keys.recipient_static_private_key)
+        AuthMsgV4.set_initiator_ephemeral_public_key(auth_msg, keys.recipient_static_private_key)
 
-      assert new_auth_msg.remote_ephemeral_public_key == initiator_ephemeral_public_key
+      assert new_auth_msg.initiator_ephemeral_public_key == initiator_ephemeral_public_key
     end
   end
 
   def build_auth_msg(signature, recovery_id, initiator_nonce, keys) do
     %AuthMsgV4{
       signature: signature <> :binary.encode_unsigned(recovery_id),
-      remote_public_key: keys.initiator_static_public_key,
-      remote_nonce: initiator_nonce
+      initiator_public_key: keys.initiator_static_public_key,
+      initiator_nonce: initiator_nonce
     }
   end
 


### PR DESCRIPTION
This is done as part of supporting https://github.com/poanetwork/mana/issues/103.

Why this change?
================

The keys in `AuthMsgV4` and `AckRespV4` are all defined as `remote_*`. But they can be more accurately named `initiator_*` and `recipient_*`. Having them named `remote_*` leaves ambiguity since which peer is the remote peer is dependent on which node we are currently talking about. That creates confusion.

The most concrete example of this confusion is `auth_msg.remote_ephemeral_public_key`. When the initiator sends an auth message, that key will be `nil`. When the recipient receives the message, they will fill in the `remote_ephemeral_public_key` with the initiator's public key because the remote is the initiator from their perspective.

This naming also more closely matches the documentation found in https://github.com/ethereum/EIPs/blob/master/EIPS/eip-8.md where the terminology is `initiator-pubk`, `initiator-nonce`, `recipient-ephermal-pubk`, etc. 

For example, this is an excerpt from that paper: 

```
auth-vsn         = 4
auth-size        = size of enc-auth-body, encoded as a big-endian 16-bit integer
auth-body        = rlp.list(sig, initiator-pubk, initiator-nonce, auth-vsn)
enc-auth-body    = ecies.encrypt(recipient-pubk, auth-body, auth-size)
auth-packet      = auth-size || enc-auth-body

ack-vsn          = 4
ack-size         = size of enc-ack-body, encoded as a big-endian 16-bit integer
ack-body         = rlp.list(recipient-ephemeral-pubk, recipient-nonce, ack-vsn)
enc-ack-body     = ecies.encrypt(initiator-pubk, ack-body, ack-size)
ack-packet       = ack-size || enc-ack-body
```