### PR TITLE
Fix CI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     parallelism: 1
     resource_class: large
     docker:
-      - image: circleci/elixir:1.6
+      - image: circleci/elixir:1.6.4
         environment:
           MIX_ENV: test
 

--- a/apps/blockchain/lib/blockchain/account.ex
+++ b/apps/blockchain/lib/blockchain/account.ex
@@ -348,8 +348,7 @@ defmodule Blockchain.Account do
       %Blockchain.Account{balance: 13}
   """
   @spec dec_wei(EVM.state(), EVM.address(), EVM.Wei.t()) :: EVM.state()
-  def dec_wei(state, address, delta_wei),
-    do: add_wei(state, address, -1 * delta_wei)
+  def dec_wei(state, address, delta_wei), do: add_wei(state, address, -1 * delta_wei)
 
   @doc """
   Helper function for transferring eth for one account to another.

--- a/apps/blockchain/lib/blockchain/blocktree.ex
+++ b/apps/blockchain/lib/blockchain/blocktree.ex
@@ -379,9 +379,7 @@ defmodule Blockchain.Blocktree do
         block -> {block.header.number, block.block_hash}
       end
 
-    children =
-      for {_, child} <- blocktree.children,
-          do: inspect_tree(child)
+    children = for {_, child} <- blocktree.children, do: inspect_tree(child)
 
     [value | children]
   end

--- a/apps/ex_wire/lib/ex_wire/kademlia/routing_table.ex
+++ b/apps/ex_wire/lib/ex_wire/kademlia/routing_table.ex
@@ -78,11 +78,7 @@ defmodule ExWire.Kademlia.RoutingTable do
   Adds node to routing table.
   """
   @spec refresh_node(t(), Node.t()) :: t()
-  def refresh_node(
-        table = %__MODULE__{current_node: %Node{key: key}},
-        %Node{key: key}
-      ),
-      do: table
+  def refresh_node(table = %__MODULE__{current_node: %Node{key: key}}, %Node{key: key}), do: table
 
   def refresh_node(table = %__MODULE__{buckets: buckets}, node = %Node{}) do
     node_bucket_id = bucket_id(table, node)
@@ -226,10 +222,10 @@ defmodule ExWire.Kademlia.RoutingTable do
    - If a pong is expired, we do nothing.
   """
   @spec handle_pong(t(), Pong.t()) :: t()
-  def handle_pong(
-        table = %__MODULE__{expected_pongs: pongs},
-        %Pong{hash: hash, timestamp: timestamp}
-      ) do
+  def handle_pong(table = %__MODULE__{expected_pongs: pongs}, %Pong{
+        hash: hash,
+        timestamp: timestamp
+      }) do
     {node, updated_pongs} = Map.pop(pongs, hash)
 
     table = %{table | expected_pongs: updated_pongs}

--- a/apps/ex_wire/lib/ex_wire/network.ex
+++ b/apps/ex_wire/lib/ex_wire/network.ex
@@ -153,16 +153,13 @@ defmodule ExWire.Network do
   def send(message, server_pid, to) do
     encoded_message = Protocol.encode(message, Config.private_key())
 
-    GenServer.cast(
-      server_pid,
-      {
-        :send,
-        %{
-          to: to,
-          data: encoded_message
-        }
+    GenServer.cast(server_pid, {
+      :send,
+      %{
+        to: to,
+        data: encoded_message
       }
-    )
+    })
 
     {:sent_message, message.__struct__, encoded_message}
   end

--- a/apps/ex_wire/test/ex_wire_test.exs
+++ b/apps/ex_wire/test/ex_wire_test.exs
@@ -83,17 +83,14 @@ defmodule ExWireTest do
   def fake_send(message, timestamp) do
     encoded_message = Protocol.encode(message, ExWire.Config.private_key())
 
-    GenServer.cast(
-      :ex_wire_test,
-      {
-        :fake_recieve,
-        %{
-          data: encoded_message,
-          remote_host: @us,
-          timestamp: timestamp
-        }
+    GenServer.cast(:ex_wire_test, {
+      :fake_recieve,
+      %{
+        data: encoded_message,
+        remote_host: @us,
+        timestamp: timestamp
       }
-    )
+    })
 
     <<hash::256, _::binary>> = encoded_message
 

--- a/apps/merkle_patricia_tree/lib/db/rocksdb.ex
+++ b/apps/merkle_patricia_tree/lib/db/rocksdb.ex
@@ -22,15 +22,13 @@ defmodule MerklePatriciaTree.DB.RocksDB do
   Retrieves a key from the database.
   """
   @spec get(DB.db_ref(), Trie.key()) :: {:ok, DB.value()} | :not_found
-  def get(db_ref, key),
-    do: Rox.get(db_ref, key)
+  def get(db_ref, key), do: Rox.get(db_ref, key)
 
   @doc """
   Stores a key in the database.
   """
   @spec put!(DB.db_ref(), Trie.key(), DB.value()) :: :ok
-  def put!(db_ref, key, value),
-    do: Rox.put(db_ref, key, value)
+  def put!(db_ref, key, value), do: Rox.put(db_ref, key, value)
 
   @doc """
   Removes all objects with key from the database.

--- a/apps/merkle_patricia_tree/lib/trie/storage.ex
+++ b/apps/merkle_patricia_tree/lib/trie/storage.ex
@@ -80,8 +80,7 @@ defmodule MerklePatriciaTree.Trie.Storage do
       when not is_binary(h) or h == <<>>,
       do: trie
 
-  def delete(trie),
-    do: DB.delete!(trie.db, trie.root_hash)
+  def delete(trie), do: DB.delete!(trie.db, trie.root_hash)
 
   @doc """
   Gets the RLP encoded value of a given trie root. Specifically,


### PR DESCRIPTION
Elixir Docker Image
====================

Use elixir 1.6.4 in CircleCI

Our builds started failing across several branches. Looking at the builds, I noticed that the sha for the elixir docker image (circleci/elixir:1.6) had changed when the builds started working.

Part of the error messages was,

```
mandatory chunk of type 'Atom' not found
```

A quick search revealed that the error is commonly found when compiling code in a newer version of Erlang/OTP and running it in an older version (e.g. compiling it in Erlang/OTP 20 and running it in Erlang/OTP 19).

By ssh'ing into CircleCI, I was able to see that we were running Elixir 1.6.5 compiled in Erlang/OTP 19 and we were running in Erlang/OTP 19.

Since we're running in the same version of Erlang as we compiled, I don't know why we're seeing the error. The compatibility elixir page suggests that 1.6.5 should work with Erlang/OTP 19 (https://github.com/elixir-lang/elixir/blob/master/lib/elixir/pages/Compatibility%20and%20Deprecations.md). It's possible that since Elixir 1.6.5 supports Erlang/OTP 21, there may be issues with Erlang 19, contrary to what the compatibility seems to suggest.

In any case, by setting the CircleCI image to use elixir 1.6.4 (instead of the latest 1.6.x), we seem to have fixed the problem for now.

In the future, we should use an image that has Erlang/OTP 20 or 21.

Formatting
==========

After our build was broken due to our elixir docker image, the build
started failing when we performed,

```
mix format --check-formatted
```

We rectify this by running `mix format` across the whole `mana` project
with elixir 1.6.4, the version we are now running in CI.