### PR TITLE
Fix inbound handshake & add naive TCP inbound implementation

### DIFF
--- a/apps/ex_wire/lib/ex_wire/adapter/tcp.ex
+++ b/apps/ex_wire/lib/ex_wire/adapter/tcp.ex
@@ -12,13 +12,20 @@ defmodule ExWire.Adapter.TCP do
   alias ExWire.Packet
 
   @doc """
-  Starts an outbound peer to peer connection.
+  Starts an outbound or inbound peer to peer connection.
   """
   def start_link(:outbound, peer, subscribers \\ []) do
     GenServer.start_link(ExWire.Adapter.TCP.Server, %{
       is_outbound: true,
       peer: peer,
       subscribers: subscribers
+    })
+  end
+
+  def start_link(:inbound) do
+    GenServer.start_link(ExWire.Adapter.TCP.Server, %{
+      is_outbound: false,
+      tcp_port: ExWire.Config.listen_port()
     })
   end
 

--- a/apps/ex_wire/lib/ex_wire/adapter/tcp/server.ex
+++ b/apps/ex_wire/lib/ex_wire/adapter/tcp/server.ex
@@ -28,9 +28,7 @@ defmodule ExWire.Adapter.TCP.Server do
   end
 
   def init(state = %{is_outbound: false}) do
-    new_state =
-      state
-      |> listen_via_tcp()
+    new_state = listen_via_tcp(state)
 
     accept_tcp_messages()
 

--- a/apps/ex_wire/lib/ex_wire/handshake.ex
+++ b/apps/ex_wire/lib/ex_wire/handshake.ex
@@ -21,37 +21,59 @@ defmodule ExWire.Handshake do
   alias ExWire.Handshake.Struct.AckRespV4
   alias ExWire.Framing.Secrets
 
+  defstruct [
+    :initiator,
+    :remote_pub,
+    :init_nonce,
+    :resp_nonce,
+    :random_key_pair,
+    :remote_random_pub,
+    :encoded_auth_msg
+  ]
+
   @type token :: binary()
   @type nonce :: <<_::256>>
-
-  defmodule Handshake do
-    defstruct [
-      :initiator,
-      :remote_id,
-      # ecdhe-random
-      :remote_pub,
-      # nonce
-      :init_nonce,
-      #
-      :resp_nonce,
-      # ecdhe-random
-      :random_priv_key,
-      # ecdhe-random-pubk
-      :remote_random_pub
-    ]
-
-    @type t :: %__MODULE__{
-            initiator: boolean(),
-            remote_id: ExWire.node_id(),
-            remote_pub: ExWire.Config.private_key(),
-            init_nonce: ExWire.Handshake.nonce(),
-            resp_nonce: ExWire.Handshake.nonce(),
-            random_priv_key: ExWire.Config.private_key(),
-            remote_random_pub: ExWire.Config.pubic_key()
-          }
-  end
+  @type t :: %__MODULE__{
+          initiator: boolean(),
+          remote_pub: ExthCrypto.Key.public_key(),
+          init_nonce: nonce(),
+          resp_nonce: nonce(),
+          random_key_pair: ExthCrypto.Key.key_pair(),
+          remote_random_pub: ExthCrypto.Key.pubic_key(),
+          encoded_auth_msg: binary()
+        }
 
   @nonce_len 32
+
+  @doc """
+  Builds an AuthMsgV4 (see build_auth_msg/5), serializes it, and encodes it.
+  This message is ready to be sent to a peer to initiate the encrypted handshake.
+  """
+  @spec initiate(Handshake.t()) :: Handshake.t()
+  def initiate(handshake) do
+    {auth_msg, initiator_ephemeral_key_pair, initiator_nonce} =
+      build_auth_msg(
+        ExWire.Config.public_key(),
+        ExWire.Config.private_key(),
+        handshake.remote_pub
+      )
+
+    {:ok, encoded_auth_msg} =
+      auth_msg
+      |> AuthMsgV4.serialize()
+      |> EIP8.wrap_eip_8(
+        handshake.remote_pub,
+        initiator_ephemeral_key_pair
+      )
+
+    %{
+      handshake
+      | initiator: true,
+        init_nonce: initiator_nonce,
+        random_key_pair: initiator_ephemeral_key_pair,
+        encoded_auth_msg: encoded_auth_msg
+    }
+  end
 
   @doc """
   Reads a given auth message, transported during the key initialization phase
@@ -145,95 +167,30 @@ defmodule ExWire.Handshake do
   end
 
   @doc """
-  Builds an AuthMsgV4 (see build_auth_msg/5), serializes it, and encodes it.
-  This message is ready to be sent to a peer to initiate the encrypted handshake.
-  """
-  @spec build_encoded_auth_msg(
-          ExthCrypto.Key.public_key(),
-          ExthCrypto.Key.private_key(),
-          ExthCrypto.Key.public_key(),
-          nonce() | nil,
-          ExthCrypto.Key.key_pair() | nil
-        ) :: {binary(), ExthCrypto.Key.key_pair(), nonce()}
-  def build_encoded_auth_msg(
-        my_static_public_key,
-        my_static_private_key,
-        her_static_public_key,
-        nonce \\ nil,
-        ephemeral_key_pair \\ nil
-      ) do
-    {my_auth_msg, my_ephemeral_key_pair, my_nonce} =
-      build_auth_msg(
-        my_static_public_key,
-        my_static_private_key,
-        her_static_public_key,
-        nonce,
-        ephemeral_key_pair
-      )
-
-    {:ok, encoded_auth_msg} =
-      my_auth_msg
-      |> AuthMsgV4.serialize()
-      |> EIP8.wrap_eip_8(
-        her_static_public_key,
-        my_ephemeral_key_pair
-      )
-
-    {encoded_auth_msg, my_ephemeral_key_pair, my_nonce}
-  end
-
-  @doc """
   Builds an AuthMsgV4 which can be serialized and sent over the wire. This will also build an ephemeral key pair
   to use during the signing process.
-
-  ## Examples
-
-      iex> {auth_msg_v4, ephemeral_keypair, nonce} = ExWire.Handshake.build_auth_msg(ExthCrypto.Test.public_key(:key_a), ExthCrypto.Test.private_key(:key_a), ExthCrypto.Test.public_key(:key_b), ExthCrypto.Test.init_vector(1, 32), ExthCrypto.Test.key_pair(:key_c))
-      iex> %{auth_msg_v4 | signature: nil} # signature will be unique each time
-      %ExWire.Handshake.Struct.AuthMsgV4{
-        initiator_ephemeral_public_key: nil,
-        initiator_nonce: <<1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32>>,
-        initiator_public_key: <<4, 54, 241, 224, 126, 85, 135, 69, 213, 129, 115, 3, 41, 161, 217, 87, 215, 159, 64, 17, 167, 128, 113, 172, 232, 46, 34, 145, 136, 72, 160, 207, 161, 171, 255, 26, 163, 160, 158, 227, 196, 92, 62, 119, 84, 156, 99, 224, 155, 120, 250, 153, 134, 180, 218, 177, 186, 200, 199, 106, 97, 103, 50, 215, 114>>,
-        initiator_version: 63,
-        signature: nil
-      }
-      iex> ephemeral_keypair
-      {
-        <<4, 146, 201, 161, 205, 19, 177, 147, 33, 107, 190, 144, 81, 145, 173, 83,
-          20, 105, 150, 114, 196, 249, 143, 167, 152, 63, 225, 96, 184, 86, 203, 38,
-          134, 241, 40, 152, 74, 34, 68, 233, 204, 91, 240, 208, 254, 62, 169, 53,
-          201, 248, 156, 236, 34, 203, 156, 75, 18, 121, 162, 104, 3, 164, 156, 46, 186>>,
-        <<178, 68, 134, 194, 0, 187, 118, 35, 33, 220, 4, 3, 50, 96, 97, 91, 96, 14,
-          71, 239, 7, 102, 33, 187, 194, 221, 152, 36, 95, 22, 121, 48>>
-      }
-      iex> nonce
-      <<1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32>>
   """
   @spec build_auth_msg(
           ExthCrypto.Key.public_key(),
           ExthCrypto.Key.private_key(),
-          ExthCrypto.Key.public_key(),
-          nonce() | nil,
-          ExthCrypto.Key.key_pair() | nil
+          ExthCrypto.Key.public_key()
         ) :: {AuthMsgV4.t(), ExthCrypto.Key.key_pair(), nonce()}
   def build_auth_msg(
-        my_static_public_key,
-        my_static_private_key,
-        her_static_public_key,
-        nonce \\ nil,
-        my_ephemeral_keypair \\ nil
+        initiator_static_public_key,
+        initiator_static_private_key,
+        recipient_static_public_key
       ) do
     # Geneate a random ephemeral keypair
-    my_ephemeral_keypair =
-      if my_ephemeral_keypair, do: my_ephemeral_keypair, else: new_ephemeral_key_pair()
+    my_ephemeral_keypair = new_ephemeral_key_pair()
 
     {_my_ephemeral_public_key, my_ephemeral_private_key} = my_ephemeral_keypair
 
     # Determine DH shared secret
-    shared_secret = ECDH.generate_shared_secret(my_static_private_key, her_static_public_key)
+    shared_secret =
+      ECDH.generate_shared_secret(initiator_static_private_key, recipient_static_public_key)
 
     # Build a nonce unless given
-    nonce = if nonce, do: nonce, else: new_nonce()
+    nonce = new_nonce()
 
     # XOR shared-secret and nonce
     shared_secret_xor_nonce = ExthCrypto.Math.xor(shared_secret, nonce)
@@ -247,7 +204,7 @@ defmodule ExWire.Handshake do
     # Build an auth message to send over the wire
     auth_msg = %AuthMsgV4{
       signature: compact_signature,
-      initiator_public_key: my_static_public_key,
+      initiator_public_key: initiator_static_public_key,
       initiator_nonce: nonce,
       initiator_version: ExWire.Config.protocol_version()
     }
@@ -315,10 +272,9 @@ defmodule ExWire.Handshake do
 
   TODO: Add examples
   """
-  @spec try_handle_auth(binary(), ExthCrypto.Key.private_key()) ::
-          {:ok, binary(), Secrets.t()} | {:invalid, String.t()}
-  def try_handle_auth(auth_data, recipient_static_private_key) do
-    case ExWire.Handshake.read_auth_msg(auth_data, recipient_static_private_key) do
+  @spec handle_auth(binary()) :: {:ok, binary(), Secrets.t()} | {:invalid, String.t()}
+  def handle_auth(auth_data) do
+    case ExWire.Handshake.read_auth_msg(auth_data, ExWire.Config.private_key()) do
       {:ok,
        %ExWire.Handshake.Struct.AuthMsgV4{
          signature: _signature,

--- a/apps/ex_wire/lib/ex_wire/handshake.ex
+++ b/apps/ex_wire/lib/ex_wire/handshake.ex
@@ -46,7 +46,7 @@ defmodule ExWire.Handshake do
   @nonce_len 32
 
   @doc """
-  Builds an AuthMsgV4 (see build_auth_msg/5), serializes it, and encodes it.
+  Builds an AuthMsgV4 (see build_auth_msg/3), serializes it, and encodes it.
   This message is ready to be sent to a peer to initiate the encrypted handshake.
   """
   @spec initiate(Handshake.t()) :: Handshake.t()

--- a/apps/ex_wire/test/ex_wire/handshake_test.exs
+++ b/apps/ex_wire/test/ex_wire/handshake_test.exs
@@ -3,10 +3,39 @@ defmodule HandshakeTest do
   doctest ExWire.Handshake
   alias ExWire.Handshake
 
+  describe "try_handle_auth/3" do
+    test "decodes auth, generates ack response, and secrets" do
+      my_static_public_key = ExthCrypto.Test.public_key(:key_a)
+      my_static_private_key = ExthCrypto.Test.private_key(:key_a)
+      her_static_public_key = ExthCrypto.Test.public_key(:key_b)
+      her_static_private_key = ExthCrypto.Test.private_key(:key_b)
+
+      {encoded_auth_msg, _my_ephemeral_key_pair, _nonce} =
+        Handshake.build_encoded_auth_msg(
+          my_static_public_key,
+          my_static_private_key,
+          her_static_public_key
+        )
+
+      {:ok, ack_resp, secrets} =
+        Handshake.try_handle_auth(
+          encoded_auth_msg,
+          her_static_private_key
+        )
+
+      {:ok, my_decoded_ack_resp, _ack_bin, <<>>} =
+        Handshake.read_ack_resp(ack_resp, my_static_private_key)
+
+      assert %Handshake.Struct.AckRespV4{} = my_decoded_ack_resp
+      assert %ExWire.Framing.Secrets{} = secrets
+    end
+  end
+
   test "handshake build and handle auth msg / ack resp via eip-8" do
     my_static_public_key = ExthCrypto.Test.public_key(:key_a)
     my_static_private_key = ExthCrypto.Test.private_key(:key_a)
     her_static_public_key = ExthCrypto.Test.public_key(:key_b)
+    her_static_private_key = ExthCrypto.Test.private_key(:key_b)
 
     {my_auth_msg, my_ephemeral_key_pair, _nonce} =
       Handshake.build_auth_msg(
@@ -20,24 +49,23 @@ defmodule HandshakeTest do
       |> Handshake.Struct.AuthMsgV4.serialize()
       |> Handshake.EIP8.wrap_eip_8(her_static_public_key, my_ephemeral_key_pair)
 
-    {:ok, her_auth_msg, <<>>} =
-      Handshake.read_auth_msg(encoded_auth_msg, ExthCrypto.Test.private_key(:key_b))
+    {:ok, her_auth_msg, <<>>} = Handshake.read_auth_msg(encoded_auth_msg, her_static_private_key)
 
     # Same auth message, except we've added the initiator ephemeral public key
     assert her_auth_msg.initiator_ephemeral_public_key != nil
     assert my_auth_msg == %{her_auth_msg | initiator_ephemeral_public_key: nil}
 
-    my_ack_resp = Handshake.build_ack_resp(her_auth_msg.initiator_ephemeral_public_key)
+    {her_ack_resp, her_ephemeral_key_pair, _her_nonce} = Handshake.build_ack_resp()
 
     {:ok, encoded_ack_msg} =
-      my_ack_resp
+      her_ack_resp
       |> Handshake.Struct.AckRespV4.serialize()
-      |> Handshake.EIP8.wrap_eip_8(her_static_public_key, my_ephemeral_key_pair)
+      |> Handshake.EIP8.wrap_eip_8(my_static_public_key, her_ephemeral_key_pair)
 
-    {:ok, her_ack_resp, _ack_bin, <<>>} =
-      Handshake.read_ack_resp(encoded_ack_msg, ExthCrypto.Test.private_key(:key_b))
+    {:ok, my_decoded_ack_resp, _ack_bin, <<>>} =
+      Handshake.read_ack_resp(encoded_ack_msg, my_static_private_key)
 
-    assert my_ack_resp == her_ack_resp
+    assert my_decoded_ack_resp == her_ack_resp
   end
 
   test "handshake auth plain" do

--- a/apps/exth_crypto/lib/ecies/ecdh.ex
+++ b/apps/exth_crypto/lib/ecies/ecdh.ex
@@ -20,7 +20,7 @@ defmodule ExthCrypto.ECIES.ECDH do
       iex> {public_key, private_key} == :crypto.generate_key(:ecdh, :secp256k1, private_key)
       true
   """
-  @spec new_ecdh_keypair(ExthCrypto.named_curve()) :: ExthCrypto.Key.keypair()
+  @spec new_ecdh_keypair(ExthCrypto.named_curve()) :: ExthCrypto.Key.key_pair()
   def new_ecdh_keypair(curve \\ @default_curve) when is_atom(curve) do
     :crypto.generate_key(:ecdh, curve)
   end


### PR DESCRIPTION
Summary
=======

This commit handles two things that are interrelated. It adds a naive implementation for an inbound TCP connection and fixes the function that handles the main crypto handshake when it is initiated by the remote peer. This is all part of supporting #103.

Fix inbound handshake
=====================

The main function that was called when a remote node initiated the handshake (sending an auth message) was `Handshake.try_handle_auth/4`.

`Handshake.try_handle_auth/4`, however, was broken. It had an unrealistic function signatures (assuming we would have peer data that we can only obtain after decrypting auth message). It also called `Handshake.build_ack_resp/2` incorrectly, passing incorrect argument types and values. This function was untested and practically unused, so the errors were not apparent at first.

We fix that function, rename it to `Hanshake.handle_auth` and we update the calling code (in TCP.Server) to use the updated version.

Naive implementation of incoming TCP
===================================

We also add a naive implementation for an incoming TCP connection. We say naive because in this implementation only one client can connect with our server. The full implementation needs to separate the creation of the `listen_socket` from the socket created when we accept messages. We will likely have to span a new process for each connection we receive.

We also update the `TCP.Server` code since most functions assume the presence of a peer. At this point, for our naive implementation of the incoming TCP connection, we do not have the notion of a peer when the connection is incoming. With a full implementation, we will have the public key (node id) of the remote peer (obtained from their Auth message), but we will still not have a `peer` in the sense that is defined in `ExWire.Struct.Peer` and which is used in outgoing TCP connections.

Clean up
========

In addition to the above, we also do some clean-up. The main one worth mentioning is the movement of handshake files.

The `handshake.ex` file was under `lib/ex_wire/handshake/handshake.ex`, but the module simply defined `ExWire.Handshake`. The more common pattern is to put `ExWire.Handshake` directly on `lib/ex_wire/handshake.ex`, so we do that here.