### PR TITLE
Handle multiple inbound tcp connections

### DIFF
--- a/apps/ex_wire/lib/ex_wire.ex
+++ b/apps/ex_wire/lib/ex_wire.ex
@@ -34,7 +34,9 @@ defmodule ExWire do
         []
       end
 
-    children = sync_children ++ node_discovery
+    tcp_listening = [ExWire.TCPListeningSupervisor]
+
+    children = sync_children ++ node_discovery ++ tcp_listening
 
     opts = [strategy: :one_for_one, name: name]
     Supervisor.start_link(children, opts)

--- a/apps/ex_wire/lib/ex_wire/adapter/tcp.ex
+++ b/apps/ex_wire/lib/ex_wire/adapter/tcp.ex
@@ -12,6 +12,22 @@ defmodule ExWire.Adapter.TCP do
   alias ExWire.Packet
 
   @doc """
+  Child spec definition to be used by a supervisor when wanting to supervise an
+  inbound TCP connection.
+
+  Note: We usually get this function for free, but since we have separated the
+  GenServer implementation (and thus the `use GenServer` part), we have to
+  implement this ourselves.
+  """
+  def child_spec([:inbound]) do
+    %{
+      id: ExWire.TCP.Inbound,
+      start: {ExWire.Adapter.TCP, :start_link, [:inbound]},
+      restart: :temporary
+    }
+  end
+
+  @doc """
   Starts an outbound or inbound peer to peer connection.
   """
   def start_link(:outbound, peer, subscribers \\ []) do
@@ -24,8 +40,7 @@ defmodule ExWire.Adapter.TCP do
 
   def start_link(:inbound) do
     GenServer.start_link(ExWire.Adapter.TCP.Server, %{
-      is_outbound: false,
-      tcp_port: ExWire.Config.listen_port()
+      is_outbound: false
     })
   end
 

--- a/apps/ex_wire/lib/ex_wire/adapter/tcp/server.ex
+++ b/apps/ex_wire/lib/ex_wire/adapter/tcp/server.ex
@@ -27,15 +27,7 @@ defmodule ExWire.Adapter.TCP.Server do
   end
 
   def init(state = %{is_outbound: false}) do
-    new_state = listen_via_tcp(state)
-
-    accept_tcp_messages()
-
-    {:ok, new_state}
-  end
-
-  def accept_tcp_messages do
-    GenServer.cast(self(), :accept_tcp_messages)
+    {:ok, state}
   end
 
   @doc """
@@ -285,11 +277,5 @@ defmodule ExWire.Adapter.TCP.Server do
     )
 
     Map.put(state, :socket, socket)
-  end
-
-  defp listen_via_tcp(state) do
-    {:ok, listen_socket} = :gen_tcp.listen(state.tcp_port, [:binary, active: true])
-
-    Map.put(state, :listen_socket, listen_socket)
   end
 end

--- a/apps/ex_wire/lib/ex_wire/adapter/tcp/server.ex
+++ b/apps/ex_wire/lib/ex_wire/adapter/tcp/server.ex
@@ -92,11 +92,17 @@ defmodule ExWire.Adapter.TCP.Server do
   @doc """
   Function triggered when tcp closes the connection
   """
-  def handle_info({:tcp_closed, _socket}, state = %{peer: peer}) do
-    message = "[#{peer}] Peer closed connection"
+  def handle_info({:tcp_closed, _socket}, state) do
+    message =
+      if state.is_outbound do
+        "[#{state.peer}] Peer closed connection"
+      else
+        "Peer closed connection"
+      end
+
     Logger.warn("[Network] #{message}")
 
-    Process.exit(self(), message)
+    Process.exit(self(), :normal)
 
     {:noreply, state}
   end

--- a/apps/ex_wire/lib/ex_wire/tcp.ex
+++ b/apps/ex_wire/lib/ex_wire/tcp.ex
@@ -1,0 +1,25 @@
+defmodule ExWire.TCP do
+  @moduledoc """
+  Module to define convenience functions that interact with :gen_tcp and :inet
+  """
+
+  @spec listen(integer()) :: {:ok, port()} | {:error, any()}
+  def listen(port_number) do
+    :gen_tcp.listen(port_number, [:binary, active: false])
+  end
+
+  @spec accept_connection(port()) :: {:ok, port()} | {:error, any()}
+  def accept_connection(socket) do
+    :gen_tcp.accept(socket)
+  end
+
+  @spec hand_over_control(port(), pid()) :: :ok | {:error, any()}
+  def hand_over_control(socket, pid) do
+    :gen_tcp.controlling_process(socket, pid)
+  end
+
+  @spec accept_messages(port()) :: :ok | {:error, any()}
+  def accept_messages(socket) do
+    :inet.setopts(socket, active: true)
+  end
+end

--- a/apps/ex_wire/lib/ex_wire/tcp/inbound_connections_supervisor.ex
+++ b/apps/ex_wire/lib/ex_wire/tcp/inbound_connections_supervisor.ex
@@ -1,0 +1,23 @@
+defmodule ExWire.TCP.InboundConnectionsSupervisor do
+  @moduledoc """
+  Dynamic supervisor in charge of handling inbound tcp connections.
+  """
+
+  use DynamicSupervisor
+
+  @doc """
+  Starts a new supervised process to handle an inbound tcp connection.
+  """
+  def new_connection_handler do
+    DynamicSupervisor.start_child(__MODULE__, {ExWire.Adapter.TCP, [:inbound]})
+  end
+
+  def start_link(args) do
+    DynamicSupervisor.start_link(__MODULE__, args, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_) do
+    DynamicSupervisor.init(strategy: :one_for_one)
+  end
+end

--- a/apps/ex_wire/lib/ex_wire/tcp/listener.ex
+++ b/apps/ex_wire/lib/ex_wire/tcp/listener.ex
@@ -1,0 +1,46 @@
+defmodule ExWire.TCP.Listener do
+  @moduledoc """
+  Module responsible for opening a tcp listen socket to listen for incoming
+  connections. Once a connection is accepted, it will hand off control of the
+  accepted socket connection to a separate process.
+  """
+
+  use GenServer
+
+  alias ExWire.TCP
+
+  def start_link(args) do
+    port = Keyword.fetch!(args, :port)
+    name = Keyword.fetch!(args, :name)
+
+    GenServer.start_link(__MODULE__, port, name: name)
+  end
+
+  def init(port) do
+    {:ok, listen_socket} = TCP.listen(port)
+
+    accept_tcp_connection()
+
+    {:ok, %{listen_socket: listen_socket}}
+  end
+
+  @doc """
+  Accepts a connection, and gives control of the connection to a separate process
+  that will henceforth handle that tcp connection.
+  """
+  def handle_cast(:accept_tcp_connection, state = %{listen_socket: listen_socket}) do
+    {:ok, socket} = TCP.accept_connection(listen_socket)
+    {:ok, pid} = TCP.InboundConnectionsSupervisor.new_connection_handler()
+
+    TCP.hand_over_control(socket, pid)
+    TCP.accept_messages(socket)
+
+    accept_tcp_connection()
+
+    {:noreply, state}
+  end
+
+  defp accept_tcp_connection do
+    GenServer.cast(self(), :accept_tcp_connection)
+  end
+end

--- a/apps/ex_wire/lib/ex_wire/tcp_listening_supervisor.ex
+++ b/apps/ex_wire/lib/ex_wire/tcp_listening_supervisor.ex
@@ -1,0 +1,22 @@
+defmodule ExWire.TCPListeningSupervisor do
+  @moduledoc """
+  Top level supervisor for all incoming TCP communications.
+  """
+  use Supervisor
+
+  def start_link(_) do
+    Supervisor.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  @impl true
+  def init(_) do
+    port = ExWire.Config.listen_port()
+
+    children = [
+      {ExWire.TCP.InboundConnectionsSupervisor, []},
+      {ExWire.TCP.Listener, [port: port, name: ExWire.TCP.Listener]}
+    ]
+
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+end


### PR DESCRIPTION
I believe this final issues closes https://github.com/poanetwork/mana/issues/103

Summary
=========

Previously we were only accepting one inbound tcp connection. This commit updates the previous code so that we can handle multiple connections.

What was done?
==============

Since inbound connections are pretty self-contained, we create a supervision tree (under the main ex wire supervisor) that is separate from other trees. There is no reason why a failure on this supervision tree should crash, say, the node discovery supervision tree.

The top-level supervisor for the tcp inbound communication is the `TCPListeningSupervisor`. This supervisor supervises an `TCP.Listener` and a `TCP.InboundConnectionsSupervisor`.

The `TCP.Listener` is a process responsible for opening the tcp connection on a given port. Once a connection is accepted, it will hand over control of the connection to another process. Those processes are started and supervised by the `TCP.InboundConnectionSupervisor`. In this way, we can have a single process for every inbound connection that is established.