### PR TITLE
Improve Handshake.handle_ack/2 and TCP.Server

### DIFF
--- a/apps/ex_wire/lib/ex_wire/tcp.ex
+++ b/apps/ex_wire/lib/ex_wire/tcp.ex
@@ -22,4 +22,19 @@ defmodule ExWire.TCP do
   def accept_messages(socket) do
     :inet.setopts(socket, active: true)
   end
+
+  @spec send_data(port(), binary()) :: :ok | {:error, any()}
+  def send_data(socket, data) do
+    :gen_tcp.send(socket, data)
+  end
+
+  @spec shutdown(port()) :: :ok | {:error, any()}
+  def shutdown(socket) do
+    :gen_tcp.shutdown(socket, :read_write)
+  end
+
+  @spec connect(binary(), integer()) :: {:ok, port()} | {:error, any()}
+  def connect(host, port_number) do
+    :gen_tcp.connect(String.to_charlist(host), port_number, [:binary])
+  end
 end

--- a/apps/ex_wire/test/ex_wire/handshake_test.exs
+++ b/apps/ex_wire/test/ex_wire/handshake_test.exs
@@ -49,8 +49,8 @@ defmodule HandshakeTest do
     end
   end
 
-  describe "handle_auth/3" do
-    test "decodes auth, generates ack response, and secrets" do
+  describe "handle_auth/1 and handle_ack/2" do
+    test "decode auth/ack and generate secrets" do
       my_static_private_key = ExthCrypto.Test.private_key(:key_a)
       her_static_public_key = ExthCrypto.Test.public_key(:key_b)
       her_static_private_key = ExthCrypto.Test.private_key(:key_b)
@@ -63,13 +63,14 @@ defmodule HandshakeTest do
 
       set_environment(her_static_private_key)
 
-      {:ok, ack_resp, secrets} = Handshake.handle_auth(handshake.encoded_auth_msg)
+      {:ok, ack_resp, her_secrets} = Handshake.handle_auth(handshake.encoded_auth_msg)
 
-      {:ok, my_decoded_ack_resp, _ack_bin, <<>>} =
-        Handshake.read_ack_resp(ack_resp, my_static_private_key)
+      set_environment(my_static_private_key)
 
-      assert %Handshake.Struct.AckRespV4{} = my_decoded_ack_resp
-      assert %ExWire.Framing.Secrets{} = secrets
+      {:ok, my_secrets, _frame_rest} = Handshake.handle_ack(ack_resp, handshake)
+
+      assert %ExWire.Framing.Secrets{} = her_secrets
+      assert %ExWire.Framing.Secrets{} = my_secrets
     end
   end
 


### PR DESCRIPTION
While we were doing work for inbound messaging, we improved `Handshake.handle_auth`, but we left `Handshake.try_handle_ack` so as to not introduce too much noise into the commits.

Here we do some clean up of that function (renaming it, and improving the function signature), and we clean up the TCP.Server module which calls those functions. We also extract `:gen_tcp` functions and reduce the number of messages the server request of itself.