### PR TITLE
Add peer struct to inbound TCP.Server

### DIFF
--- a/apps/ex_wire/lib/ex_wire/crypto.ex
+++ b/apps/ex_wire/lib/ex_wire/crypto.ex
@@ -14,6 +14,11 @@ defmodule ExWire.Crypto do
     defexception [:message]
   end
 
+  defdelegate der_to_raw(der_bin), to: Key
+  defdelegate raw_to_der(bin), to: Key
+  defdelegate hex_to_bin(hex_bin), to: Math
+  defdelegate bin_to_hex(bin), to: Math
+
   @doc """
   Returns a node_id based on a given private key.
 
@@ -131,15 +136,5 @@ defmodule ExWire.Crypto do
   @spec node_id_from_public_key(binary()) :: binary()
   def node_id_from_public_key(public_key) do
     Key.der_to_raw(public_key)
-  end
-
-  @spec hex_to_bin(binary()) :: binary()
-  def hex_to_bin(hex_bin) do
-    Math.hex_to_bin(hex_bin)
-  end
-
-  @spec raw_to_der(binary()) :: binary()
-  def raw_to_der(bin) do
-    Key.raw_to_der(bin)
   end
 end

--- a/apps/ex_wire/lib/ex_wire/handshake.ex
+++ b/apps/ex_wire/lib/ex_wire/handshake.ex
@@ -276,14 +276,15 @@ defmodule ExWire.Handshake do
   @spec handle_auth(binary()) :: {:ok, binary(), Secrets.t()} | {:invalid, String.t()}
   def handle_auth(auth_data) do
     case ExWire.Handshake.read_auth_msg(auth_data, ExWire.Config.private_key()) do
-      {:ok,
-       %ExWire.Handshake.Struct.AuthMsgV4{
-         signature: _signature,
-         initiator_public_key: initiator_public_key,
-         initiator_nonce: initiator_nonce,
-         initiator_version: _initiator_version,
-         initiator_ephemeral_public_key: initiator_ephemeral_public_key
-       }, <<>>} ->
+      {:ok, auth_msg, <<>>} ->
+        %ExWire.Handshake.Struct.AuthMsgV4{
+          signature: _signature,
+          initiator_public_key: initiator_public_key,
+          initiator_nonce: initiator_nonce,
+          initiator_version: _initiator_version,
+          initiator_ephemeral_public_key: initiator_ephemeral_public_key
+        } = auth_msg
+
         # First, we'll build an ack, which we'll respond with to the initiator
         {ack_resp, recipient_ephemeral_key_pair, recipient_nonce} =
           ExWire.Handshake.build_ack_resp()
@@ -306,7 +307,7 @@ defmodule ExWire.Handshake do
             encoded_ack_resp
           )
 
-        {:ok, encoded_ack_resp, secrets}
+        {:ok, auth_msg, encoded_ack_resp, secrets}
 
       {:error, reason} ->
         {:invalid, reason}

--- a/apps/ex_wire/lib/ex_wire/handshake/struct/auth_msg_v4.ex
+++ b/apps/ex_wire/lib/ex_wire/handshake/struct/auth_msg_v4.ex
@@ -17,7 +17,7 @@ defmodule ExWire.Handshake.Struct.AuthMsgV4 do
 
   @type t :: %__MODULE__{
           signature: ExthCrypto.signature(),
-          initiator_public_key: ExthCrypto.Key.public_key(),
+          initiator_public_key: ExthCrypto.Key.public_key_der(),
           initiator_nonce: binary(),
           initiator_version: integer(),
           initiator_ephemeral_public_key: ExthCrypto.Key.public_key()

--- a/apps/ex_wire/lib/ex_wire/struct/peer.ex
+++ b/apps/ex_wire/lib/ex_wire/struct/peer.ex
@@ -50,6 +50,22 @@ defmodule ExWire.Struct.Peer do
   end
 
   @doc """
+  Returns the hex node id format of a Peer's remote_id.
+
+  ## Examples
+
+      iex> remote_id = <<4, 108, 224, 89, 48, 199, 42, 188, 99, 44, 88, 226, 228, 50, 79, 124, 126, 164, 120, 206, 192, 237, 79, 162, 82, 137, 130, 207, 52, 72, 48, 148, 233, 203, 201, 33, 110, 122, 163, 73, 105, 18, 66, 87, 109, 85, 42, 42, 86, 170, 234, 228, 38, 197, 48, 61, 237, 103, 124, 228, 85, 186, 26, 205, 157>>
+      iex> ExWire.Struct.Peer.hex_node_id(remote_id)
+      "6ce05930c72abc632c58e2e4324f7c7ea478cec0ed4fa2528982cf34483094e9cbc9216e7aa349691242576d552a2a56aaeae426c5303ded677ce455ba1acd9d"
+  """
+  @spec hex_node_id(String.t()) :: String.t()
+  def hex_node_id(remote_id) do
+    remote_id
+    |> Crypto.der_to_raw()
+    |> Crypto.bin_to_hex()
+  end
+
+  @doc """
   Constructs a peer from a URI.
 
   ## Examples

--- a/apps/ex_wire/lib/ex_wire/tcp.ex
+++ b/apps/ex_wire/lib/ex_wire/tcp.ex
@@ -37,4 +37,12 @@ defmodule ExWire.TCP do
   def connect(host, port_number) do
     :gen_tcp.connect(String.to_charlist(host), port_number, [:binary])
   end
+
+  @spec peer_info(port()) :: {binary(), integer()}
+  def peer_info(socket) do
+    {:ok, {host_tuple, port}} = :inet.peername(socket)
+    host = host_tuple |> :inet.ntoa() |> to_string()
+
+    {host, port}
+  end
 end

--- a/apps/ex_wire/test/ex_wire/handshake_test.exs
+++ b/apps/ex_wire/test/ex_wire/handshake_test.exs
@@ -63,14 +63,16 @@ defmodule HandshakeTest do
 
       set_environment(her_static_private_key)
 
-      {:ok, ack_resp, her_secrets} = Handshake.handle_auth(handshake.encoded_auth_msg)
+      {:ok, auth_msg, encoded_ack_resp, her_secrets} =
+        Handshake.handle_auth(handshake.encoded_auth_msg)
 
       set_environment(my_static_private_key)
 
-      {:ok, my_secrets, _frame_rest} = Handshake.handle_ack(ack_resp, handshake)
+      {:ok, my_secrets, _frame_rest} = Handshake.handle_ack(encoded_ack_resp, handshake)
 
       assert %ExWire.Framing.Secrets{} = her_secrets
       assert %ExWire.Framing.Secrets{} = my_secrets
+      assert %ExWire.Handshake.Struct.AuthMsgV4{} = auth_msg
     end
   end
 

--- a/apps/exth_crypto/lib/signature.ex
+++ b/apps/exth_crypto/lib/signature.ex
@@ -33,7 +33,7 @@ defmodule ExthCrypto.Signature do
       {:error, "Private key size not 32 bytes"}
   """
   @spec get_public_key(ExthCrypto.Key.private_key()) ::
-          {:ok, ExthCrypto.Key.public_key()} | {:error, String.t()}
+          {:ok, ExthCrypto.Key.public_key_der()} | {:error, String.t()}
   def get_public_key(private_key) do
     case :libsecp256k1.ec_pubkey_create(private_key, :uncompressed) do
       {:ok, public_key} -> {:ok, public_key}
@@ -113,7 +113,7 @@ defmodule ExthCrypto.Signature do
               120, 250, 153, 134, 180, 218, 177, 186, 200, 199, 106, 97, 103, 50, 215, 114>>}
   """
   @spec recover(binary(), signature, recovery_id) ::
-          {:ok, ExthCrypto.Key.public_key()} | {:error, String.t()}
+          {:ok, ExthCrypto.Key.public_key_der()} | {:error, String.t()}
   def recover(digest, signature, recovery_id) do
     case :libsecp256k1.ecdsa_recover_compact(digest, signature, :uncompressed, recovery_id) do
       {:ok, public_key} -> {:ok, public_key}
@@ -122,7 +122,7 @@ defmodule ExthCrypto.Signature do
   end
 
   @doc """
-  Combines a signature (64 bytes) with the recovery id. 
+  Combines a signature (64 bytes) with the recovery id.
   """
   @spec compact_format(signature(), recovery_id()) :: compact_signature()
   def compact_format(signature, recovery_id) do


### PR DESCRIPTION
Summary
=======

We retrieve peer data and construct a `%Peer{}` struct for inbound TCP connections. For outgoing connections, this is much easier because we know which peer we're connecting to. For the inbound connection, it was a little more difficult.

For background information, the [enode url](https://github.com/ethereum/wiki/wiki/enode-url-format) looks like this:

```
enode://hex_node_id@ip_address:port
```

We retrieve the host (ip address) and port peer data from the socket connection using `:inet.peername/1`, and we retrieve the peer's public id from decoding the auth message the peer first sends.

Since we can now do that, we can construct a `Peer` struct for all inbound TCP connections, and we normalize the Logger messages and function signatures.

The only place where we continue checking whether or not we have a peer in our state is when the tcp connection is disconnected. It is possible that a peer will disconnect before we finish the handshake, and thus we would not have a peer public id at that moment.

As part of this work, we discovered some incorrect typespecs as it relates to DER encoded public keys. We fix those.