### PR TITLE
do not destroy account in the middle of evm execution

### DIFF
--- a/apps/blockchain/test/blockchain/state_test.exs
+++ b/apps/blockchain/test/blockchain/state_test.exs
@@ -58,7 +58,7 @@ defmodule Blockchain.StateTest do
       "xorNonConst"
     ],
     "AttackTest" => [
-      # "ContractCreationSpam",
+      "ContractCreationSpam"
       # "CrashingTransaction",
     ],
     "BadOpcode" => [
@@ -1475,15 +1475,15 @@ defmodule Blockchain.StateTest do
       "refund_CallA_OOG",
       "refund_CallA_notEnoughGasInCall",
       "refund_CallToSuicideNoStorage",
-      # "refund_CallToSuicideStorage",
-      # "refund_CallToSuicideTwice",
+      "refund_CallToSuicideStorage",
+      "refund_CallToSuicideTwice",
       "refund_NoOOG_1",
       "refund_OOG",
       "refund_TxToSuicide",
       "refund_TxToSuicideOOG",
       "refund_changeNonZeroStorage",
       "refund_getEtherBack",
-      # "refund_multimpleSuicide",
+      "refund_multimpleSuicide",
       "refund_singleSuicide"
     ],
     "ReturnDataTest" => [

--- a/apps/evm/lib/evm/operation/system.ex
+++ b/apps/evm/lib/evm/operation/system.ex
@@ -261,7 +261,6 @@ defmodule EVM.Operation.System do
     new_exec_env =
       exec_env
       |> ExecEnv.transfer_wei_to(to, balance)
-      |> ExecEnv.destroy_account()
 
     new_substate = %{
       sub_state


### PR DESCRIPTION
Changes:
- Destroying account directly in `selfdestruct' operation leaves storage in an inconsistent state. so now all destructed accounts will be deleted after evm execution.

