### PR TITLE
fix refund_CallA refund test

### DIFF
--- a/apps/blockchain/test/blockchain/state_test.exs
+++ b/apps/blockchain/test/blockchain/state_test.exs
@@ -1471,7 +1471,7 @@ defmodule Blockchain.StateTest do
       "refund50percentCap",
       "refund600",
       "refundSuicide50procentCap",
-      # "refund_CallA",
+      "refund_CallA",
       "refund_CallA_OOG",
       "refund_CallA_notEnoughGasInCall",
       "refund_CallToSuicideNoStorage",

--- a/apps/merkle_patricia_tree/lib/trie.ex
+++ b/apps/merkle_patricia_tree/lib/trie.ex
@@ -172,7 +172,9 @@ defmodule MerklePatriciaTree.Trie do
       |> into(trie)
       |> store()
 
-    Storage.delete(trie)
+    # TODO: https://github.com/poanetwork/mana/issues/229
+    # Storage.delete(trie)
+
     new_trie
   end
 


### PR DESCRIPTION
The problem was that there is a storage clearing in the call message that left another account's storage in a wrong state. The issue is in Merkle Patricia Trie - https://github.com/poanetwork/mana/issues/229

Fixes https://github.com/poanetwork/mana/issues/227

