### PR TITLE
fix merging refunds for account suicides

### DIFF
--- a/apps/blockchain/test/blockchain/state_test.exs
+++ b/apps/blockchain/test/blockchain/state_test.exs
@@ -58,7 +58,7 @@ defmodule Blockchain.StateTest do
       "xorNonConst"
     ],
     "AttackTest" => [
-      # "ContractCreationSpam",
+      "ContractCreationSpam",
       "CrashingTransaction"
     ],
     "BadOpcode" => [

--- a/apps/blockchain/test/blockchain_test.exs
+++ b/apps/blockchain/test/blockchain_test.exs
@@ -11,7 +11,7 @@ defmodule BlockchainTest do
 
   @ethereum_common_tests_path "/../../ethereum_common_tests/BlockchainTests/"
   @tests [
-    # "GeneralStateTests/stAttackTest/ContractCreationSpam_d0g0v0.json",
+    "GeneralStateTests/stAttackTest/ContractCreationSpam_d0g0v0.json",
     # "GeneralStateTests/stAttackTest/CrashingTransaction_d0g0v0.json",
     "GeneralStateTests/stCallCodes/call_OOG_additionalGasCosts1_d0g0v0.json",
     "GeneralStateTests/stCallCodes/call_OOG_additionalGasCosts2_d0g0v0.json",

--- a/apps/evm/lib/evm/refunds.ex
+++ b/apps/evm/lib/evm/refunds.ex
@@ -1,5 +1,4 @@
 defmodule EVM.Refunds do
-  @type t :: EVM.val()
   alias EVM.{
     ExecEnv,
     MachineCode,
@@ -8,10 +7,21 @@ defmodule EVM.Refunds do
     SubState
   }
 
+  @moduledoc """
+  Refunds related logic.
+  """
+
+  @type t :: EVM.val()
+
   # Refund given (added into refund counter) when the storage value is set to zero from non-zero.
   @storage_refund 15_000
   # Refund given (added into refund counter) for destroying an account.
   @selfdestruct_refund 24_000
+
+  @spec selfdestruct_refund() :: integer()
+  def selfdestruct_refund do
+    @selfdestruct_refund
+  end
 
   @doc """
   Returns the refund amount given a cycle of the VM.


### PR DESCRIPTION
The same accounts were destroyed multiple times so we were refunding gas for them each time.

fixes https://github.com/poanetwork/mana/issues/242
