### PR TITLE
Set DEVp2p session as active

### DIFF
--- a/apps/ex_wire/lib/ex_wire/adapter/tcp.ex
+++ b/apps/ex_wire/lib/ex_wire/adapter/tcp.ex
@@ -19,10 +19,10 @@ defmodule ExWire.Adapter.TCP do
   GenServer implementation (and thus the `use GenServer` part), we have to
   implement this ourselves.
   """
-  def child_spec([:inbound]) do
+  def child_spec([:inbound, socket]) do
     %{
       id: ExWire.TCP.Inbound,
-      start: {ExWire.Adapter.TCP, :start_link, [:inbound]},
+      start: {ExWire.Adapter.TCP, :start_link, [{:inbound, socket}]},
       restart: :temporary
     }
   end
@@ -38,9 +38,10 @@ defmodule ExWire.Adapter.TCP do
     })
   end
 
-  def start_link(:inbound) do
+  def start_link({:inbound, socket}) do
     GenServer.start_link(ExWire.Adapter.TCP.Server, %{
-      is_outbound: false
+      is_outbound: false,
+      socket: socket
     })
   end
 

--- a/apps/ex_wire/lib/ex_wire/tcp/inbound_connections_supervisor.ex
+++ b/apps/ex_wire/lib/ex_wire/tcp/inbound_connections_supervisor.ex
@@ -8,8 +8,8 @@ defmodule ExWire.TCP.InboundConnectionsSupervisor do
   @doc """
   Starts a new supervised process to handle an inbound tcp connection.
   """
-  def new_connection_handler do
-    DynamicSupervisor.start_child(__MODULE__, {ExWire.Adapter.TCP, [:inbound]})
+  def new_connection_handler(socket) do
+    DynamicSupervisor.start_child(__MODULE__, {ExWire.Adapter.TCP, [:inbound, socket]})
   end
 
   def start_link(args) do

--- a/apps/ex_wire/lib/ex_wire/tcp/listener.ex
+++ b/apps/ex_wire/lib/ex_wire/tcp/listener.ex
@@ -30,7 +30,7 @@ defmodule ExWire.TCP.Listener do
   """
   def handle_cast(:accept_tcp_connection, state = %{listen_socket: listen_socket}) do
     {:ok, socket} = TCP.accept_connection(listen_socket)
-    {:ok, pid} = TCP.InboundConnectionsSupervisor.new_connection_handler()
+    {:ok, pid} = TCP.InboundConnectionsSupervisor.new_connection_handler(socket)
 
     hand_over_control_of_socket(socket, pid)
 

--- a/apps/ex_wire/test/ex_wire/dev_p2p_test.exs
+++ b/apps/ex_wire/test/ex_wire/dev_p2p_test.exs
@@ -8,46 +8,46 @@ defmodule ExWire.DEVp2pTest do
   alias ExWire.Packet
 
   describe "handles protocol handshake" do
-    test "activates session if hanshake is sent and received" do
-      our_hello = generate_handshake()
-      peer_hello = generate_handshake()
+    test "activates session if Hello is sent and received" do
+      our_hello = build_hello()
+      peer_hello = build_hello()
 
       session =
         init_session()
-        |> handshake_sent(our_hello)
-        |> handshake_received(peer_hello)
+        |> hello_sent(our_hello)
+        |> hello_received(peer_hello)
 
       assert session_active?(session)
     end
 
-    test "does not activate the session if handshake is only sent" do
-      our_hello = generate_handshake()
+    test "does not activate the session if hello is only sent" do
+      our_hello = build_hello()
 
       session =
         init_session()
-        |> handshake_sent(our_hello)
+        |> hello_sent(our_hello)
 
       refute session_active?(session)
     end
 
-    test "does not activate the session if handshake is only received" do
-      peer_hello = generate_handshake()
+    test "does not activate the session if hello is only received" do
+      peer_hello = build_hello()
 
       session =
         init_session()
-        |> handshake_received(peer_hello)
+        |> hello_received(peer_hello)
 
       refute session_active?(session)
     end
 
     test "does not activate session if capabilities to not overlap" do
-      our_hello = generate_handshake()
-      peer_hello = generate_handshake() |> set_older_capability()
+      our_hello = build_hello()
+      peer_hello = build_hello() |> set_older_capability()
 
       session =
         init_session()
-        |> handshake_sent(our_hello)
-        |> handshake_received(peer_hello)
+        |> hello_sent(our_hello)
+        |> hello_received(peer_hello)
 
       refute session_active?(session)
     end
@@ -55,57 +55,47 @@ defmodule ExWire.DEVp2pTest do
 
   describe "session_compatible?/1" do
     test "returns true if any capabilities overlap" do
-      our_hello = generate_handshake()
-      peer_hello = generate_handshake()
+      our_hello = build_hello()
+      peer_hello = build_hello()
 
       session =
         init_session()
-        |> handshake_sent(our_hello)
-        |> handshake_received(peer_hello)
+        |> hello_sent(our_hello)
+        |> hello_received(peer_hello)
 
       assert session_compatible?(session)
     end
 
     test "returns false if no capabilities overlap" do
-      our_hello = generate_handshake()
-      peer_hello = generate_handshake() |> set_older_capability()
+      our_hello = build_hello()
+      peer_hello = build_hello() |> set_older_capability()
 
       session =
         init_session()
-        |> handshake_sent(our_hello)
-        |> handshake_received(peer_hello)
+        |> hello_sent(our_hello)
+        |> hello_received(peer_hello)
 
       refute session_compatible?(session)
     end
   end
 
   describe "handle_message/2" do
-    test "ping messages returns a pong" do
-      ping = %Packet.Ping{}
-
-      {:ok, instructions, _session} =
-        active_session()
-        |> handle_message(ping)
-
-      assert {:send, %Packet.Pong{}} = instructions
-    end
-
-    test "disconnects message deactivates session" do
-      disconnect = %Packet.Disconnect{}
-
-      {:ok, instructions, session} =
-        active_session()
-        |> handle_message(disconnect)
-
-      assert :peer_disconnect = instructions
-      refute session_active?(session)
-    end
-
-    test "returns error if handshake is not complete" do
+    test "returns error if message is not Hello" do
       ping = %Packet.Ping{}
       session = init_session()
 
-      assert {:error, :handshake_incomplete, ^session} = handle_message(session, ping)
+      assert {:error, :handshake_incomplete} = handle_message(session, ping)
+    end
+
+    test "activates a session when Hello message is compatible" do
+      hello = build_hello()
+
+      {:ok, session} =
+        init_session()
+        |> hello_sent(build_hello())
+        |> handle_message(hello)
+
+      assert session_active?(session)
     end
   end
 
@@ -114,11 +104,11 @@ defmodule ExWire.DEVp2pTest do
   end
 
   def active_session do
-    our_hello = generate_handshake()
-    peer_hello = generate_handshake()
+    our_hello = build_hello()
+    peer_hello = build_hello()
 
     init_session()
-    |> handshake_sent(our_hello)
-    |> handshake_received(peer_hello)
+    |> hello_sent(our_hello)
+    |> hello_received(peer_hello)
   end
 end


### PR DESCRIPTION
What?
=====

We update TCP.Server to set DEVp2p session as active, and to check the session's status when other packets come in. When any other packet comes in we forward it to the subscribers.

Subscribers is a concept that has been in `TCP.Server` for quite some time even though we don't really have subscribers (other than the `Sync` module that is not currently being used). For that reason, I think we can handle the rest of the messages (i.e. messages other than encrypted handshake and DEVp2p Hello messages) in one of two ways (in the future):

1. We continue having modules/servers that subscribe to TCP connection. The TCP.Server handles encrypted handshake and protocol handshake, then forwards all other messages.

2. We simply have the TCP module (or some other module that uses a TCP connection, which requires a lot of refactoring) handle all messages. It first ensures that encrypted handshake and protocol handshakes are performed and then makes use of `handle/1` in packets to deal with data (essentially removing the `notify_subscribers` part).

It's worth noting that (2) works well for inbound connections (since they mostly receive a message and respond to it without much regard to state). But outbound connections (such as the Sync) module we may want to treat differently.