### PR TITLE
Clear balance when calling SELFDESTRUCT

### DIFF
--- a/apps/blockchain/lib/blockchain/account.ex
+++ b/apps/blockchain/lib/blockchain/account.ex
@@ -582,4 +582,23 @@ defmodule Blockchain.Account do
         end
     end
   end
+
+  @doc """
+  Sets the balance of an account to zero.
+
+  ## Examples
+
+      iex> state = MerklePatriciaTree.Trie.new(MerklePatriciaTree.Test.random_ets_db())
+      ...>   |> Blockchain.Account.put_account(<<0x01::160>>, %Blockchain.Account{balance: 100})
+      iex> state
+      ...> |> Blockchain.Account.clear_balance(<<0x01::160>>)
+      ...> |> Blockchain.Account.get_account(<<0x01::160>>)
+      %Blockchain.Account{balance: 0}
+  """
+  @spec clear_balance(EVM.state(), EVM.address()) :: EVM.state()
+  def clear_balance(state, address) do
+    update_account(state, address, fn acct ->
+      %{acct | balance: 0}
+    end)
+  end
 end

--- a/apps/blockchain/lib/blockchain/interface/account_interface.ex
+++ b/apps/blockchain/lib/blockchain/interface/account_interface.ex
@@ -214,36 +214,6 @@ defimpl EVM.Interface.AccountInterface, for: Blockchain.Interface.AccountInterfa
   end
 
   @doc """
-  Destructs an account (SELFDESTRUCT operation in YP).
-  This removes any trace of the account from the system.
-
-  ## Examples
-
-      iex> MerklePatriciaTree.Test.random_ets_db()
-      ...> |> MerklePatriciaTree.Trie.new()
-      ...> |> Blockchain.Account.add_wei(<<1::160>>, 5)
-      ...> |> Blockchain.Interface.AccountInterface.new()
-      ...> |> EVM.Interface.AccountInterface.destroy_account(<<1::160>>)
-      ...> |> EVM.Interface.AccountInterface.get_account_balance(<<1::160>>)
-      nil
-
-      iex> MerklePatriciaTree.Test.random_ets_db()
-      ...> |> MerklePatriciaTree.Trie.new()
-      ...> |> Blockchain.Account.add_wei(<<1::160>>, 5)
-      ...> |> Blockchain.Interface.AccountInterface.new()
-      ...> |> EVM.Interface.AccountInterface.destroy_account(<<2::160>>)
-      ...> |> EVM.Interface.AccountInterface.get_account_balance(<<1::160>>)
-      5
-  """
-  @spec destroy_account(EVM.Interface.AccountInterface.t(), EVM.address()) ::
-          EVM.Interface.AccountInterface.t()
-  def destroy_account(account_interface, address) do
-    updated_state = Account.del_account(account_interface.state, address)
-
-    %{account_interface | state: updated_state}
-  end
-
-  @doc """
   Given an account interface and an address, returns the nonce at that address.
 
   ## Examples
@@ -419,5 +389,13 @@ defimpl EVM.Interface.AccountInterface, for: Blockchain.Interface.AccountInterfa
           EVM.address()
   def new_contract_address(_account_interface, address, nonce) do
     Contract.Address.new(address, nonce)
+  end
+
+  @spec clear_balance(EVM.Interface.AccountInterface.t(), EVM.address()) ::
+          EVM.Interface.AccountInterface.t()
+  def clear_balance(account_interface, address) do
+    state = Account.clear_balance(account_interface.state, address)
+
+    Map.put(account_interface, :state, state)
   end
 end

--- a/apps/blockchain/test/blockchain_test.exs
+++ b/apps/blockchain/test/blockchain_test.exs
@@ -717,7 +717,7 @@ defmodule BlockchainTest do
     "GeneralStateTests/stSystemOperationsTest/suicideCoinbase_d0g0v0.json",
     "GeneralStateTests/stSystemOperationsTest/suicideNotExistingAccount_d0g0v0.json",
     "GeneralStateTests/stSystemOperationsTest/suicideOrigin_d0g0v0.json",
-    # "GeneralStateTests/stSystemOperationsTest/suicideSendEtherPostDeath_d0g0v0.json",
+    "GeneralStateTests/stSystemOperationsTest/suicideSendEtherPostDeath_d0g0v0.json",
     "GeneralStateTests/stSystemOperationsTest/suicideSendEtherToMe_d0g0v0.json",
     "GeneralStateTests/stSystemOperationsTest/testRandomTest_d0g0v0.json",
     "GeneralStateTests/stTransactionTest/ContractStoreClearsOOG_d0g0v0.json",

--- a/apps/evm/lib/evm/address.ex
+++ b/apps/evm/lib/evm/address.ex
@@ -5,6 +5,8 @@ defmodule EVM.Address do
 
   alias ExthCrypto.Hash.Keccak
 
+  @type t :: binary() | non_neg_integer()
+
   @size 20
   @max round(:math.pow(2, @size * EVM.byte_size()))
 

--- a/apps/evm/lib/evm/exec_env.ex
+++ b/apps/evm/lib/evm/exec_env.ex
@@ -67,12 +67,23 @@ defmodule EVM.ExecEnv do
     Map.put(exec_env, :account_interface, account_interface)
   end
 
-  @spec destroy_account(t()) :: t()
-  def destroy_account(exec_env = %{account_interface: account_interface, address: address}) do
-    account_interface = AccountInterface.destroy_account(account_interface, address)
+  @spec clear_account_balance(t()) :: t()
+  def clear_account_balance(exec_env = %{account_interface: account_interface, address: address}) do
+    account_interface = AccountInterface.clear_balance(account_interface, address)
+
     Map.put(exec_env, :account_interface, account_interface)
   end
 
+  @spec transfer_balance_to(t(), EVM.Address.t()) :: t()
+  def transfer_balance_to(exec_env, to) do
+    %{account_interface: account_interface, address: address} = exec_env
+
+    balance = AccountInterface.get_account_balance(account_interface, address)
+
+    transfer_wei_to(exec_env, to, balance)
+  end
+
+  @spec transfer_wei_to(t(), EVM.Address.t(), integer()) :: t()
   def transfer_wei_to(exec_env, to, value) do
     account_interface =
       AccountInterface.transfer(exec_env.account_interface, exec_env.address, to, value)

--- a/apps/evm/lib/evm/interface/account_interface.ex
+++ b/apps/evm/lib/evm/interface/account_interface.ex
@@ -38,9 +38,6 @@ defprotocol EVM.Interface.AccountInterface do
   @spec remove_storage(t(), EVM.address(), integer()) :: t()
   def remove_storage(t, address, key)
 
-  @spec destroy_account(t, EVM.address()) :: t
-  def destroy_account(t, address)
-
   @spec dump_storage(t) :: %{EVM.address() => EVM.val()}
   def dump_storage(t)
 
@@ -98,4 +95,8 @@ defprotocol EVM.Interface.AccountInterface do
 
   @spec new_contract_address(t, EVM.address(), integer()) :: EVM.address()
   def new_contract_address(t, address, nonce)
+
+  @doc "Sets the balance of the account at the given address to zero"
+  @spec clear_balance(t, EVM.address()) :: t
+  def clear_balance(t, address)
 end

--- a/apps/evm/lib/evm/interface/mock/mock_account_interface.ex
+++ b/apps/evm/lib/evm/interface/mock/mock_account_interface.ex
@@ -148,16 +148,6 @@ defimpl EVM.Interface.AccountInterface, for: EVM.Interface.Mock.MockAccountInter
     Map.merge(account, opts)
   end
 
-  @spec destroy_account(EVM.Interface.AccountInterface.t(), EVM.address()) ::
-          EVM.Interface.AccountInterface.t()
-  def destroy_account(mock_account_interface, address) do
-    account_map =
-      mock_account_interface.account_map
-      |> Map.delete(address)
-
-    %{mock_account_interface | account_map: account_map}
-  end
-
   @spec get_account_nonce(EVM.Interface.AccountInterface.t(), EVM.address()) :: integer()
   def get_account_nonce(mock_account_interface, address) do
     get_in(mock_account_interface.account_map, [address, :nonce])
@@ -245,5 +235,12 @@ defimpl EVM.Interface.AccountInterface, for: EVM.Interface.Mock.MockAccountInter
           EVM.address()
   def new_contract_address(_mock_account_interface, address, _nonce) do
     address
+  end
+
+  @spec clear_balance(EVM.Interface.AccountInterface.t(), EVM.address()) :: EVM.address()
+  def clear_balance(mock_account_interface, address) do
+    account = get_account(mock_account_interface, address)
+
+    put_account(mock_account_interface, address, %{account | balance: 0})
   end
 end

--- a/apps/evm/lib/evm/sub_state.ex
+++ b/apps/evm/lib/evm/sub_state.ex
@@ -117,4 +117,18 @@ defmodule EVM.SubState do
       logs: logs
     }
   end
+
+  @doc """
+  Marks an account for later destruction.
+
+  ## Examples
+
+      iex> sub_state = %EVM.SubState{}
+      iex> address = <<0x01::160>>
+      iex> EVM.SubState.mark_account_for_destruction(sub_state, address)
+      %EVM.SubState{selfdestruct_list: [<<0x01::160>>]}
+  """
+  def mark_account_for_destruction(sub_state, account_address) do
+    %{sub_state | selfdestruct_list: sub_state.selfdestruct_list ++ [account_address]}
+  end
 end


### PR DESCRIPTION
Closes https://github.com/poanetwork/mana/issues/277

What?
=====

After a `SELFDESTRUCT` CPP Ethereum increased the specified refund address by the current balance in the contract that is marked for destruction and then set that contract's balance to zero. This lead to a special case where if the refund address is the same as the contract address it would cause the ether to essentially vanish from existence, as described in Quirk 2 of http://swende.se/blog/Ethereum_quirks_and_vulns.html.

We also add a note that we copied and modified from the CPP implementation that speaks to the reason why this is done. It seems there was a consensus issue in the past and it is now tested via the suicide test we now pass.

----

Clean up Notes:

We remove destroy_account functions. Several modules had `destroy_account` functions. These are no longer used.

Originally, it seems like we called `ExecEnv.destroy_account` which would trigger calls to the rest of the `destroy_account` functions. But in commit c68dcd73dd82401d97654a1374a3b844c6ed0e45, we stopped destroying the account in the middle of the EVM execution.