### PR TITLE
Compile libsecp256k1 manually with rebar

### DIFF
--- a/apps/exth_crypto/mix.exs
+++ b/apps/exth_crypto/mix.exs
@@ -38,7 +38,7 @@ defmodule ExthCrypto.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-      {:libsecp256k1, "~> 0.1.4", manager: :rebar},
+      {:libsecp256k1, "~> 0.1.4"},
       {:keccakf1600, "~> 2.0.0", hex: :keccakf1600_orig},
       {:credo, "~> 0.8", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.14", only: :dev, runtime: false},

--- a/bin/setup
+++ b/bin/setup
@@ -47,6 +47,8 @@ fi
 fancy_echo "Installing elixir dependencies and compiling."
 mix local.hex --force
 mix local.rebar --force
-mix do deps.get, deps.compile, compile
+mix deps.get
+cd deps/libsecp256k1 && rebar compile && cd ../../
+mix do deps.compile, compile
 
 fancy_echo "You're all set!"


### PR DESCRIPTION
We attempted to use `manager: :rebar` for the `libsecp256k1` dependency in ExthCrypto's `mix.exs` file, but it is not compiling it correctly. For now, we will compile it manually by calling `rebar compile`.