### PR TITLE
Use direct path when calling `rebar`

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -48,7 +48,7 @@ fancy_echo "Installing elixir dependencies and compiling."
 mix local.hex --force
 mix local.rebar --force
 mix deps.get
-cd deps/libsecp256k1 && rebar compile && cd ../../
+cd deps/libsecp256k1 && ~/.mix/rebar compile && cd ../../
 mix do deps.compile, compile
 
 fancy_echo "You're all set!"


### PR DESCRIPTION
`~/.mix/` isn't included in users' PATH environment variable by default. Therefore when the `./bin/setup` script calls `rebar` the executable isn't found. Here we call `rebar` using it's full path which will fix that issue.