### PR TITLE
Replace :math.floor with Float.floor

### DIFF
--- a/apps/blockchain/lib/blockchain/transaction/signature.ex
+++ b/apps/blockchain/lib/blockchain/transaction/signature.ex
@@ -22,7 +22,7 @@ defmodule Blockchain.Transaction.Signature do
 
   # The follow are the maximum value for x in the signature, as defined in Eq.(212)
   @secp256k1n 115_792_089_237_316_195_423_570_985_008_687_907_852_837_564_279_074_904_382_605_163_141_518_161_494_337
-  @secp256k1n_2 round(:math.floor(@secp256k1n / 2))
+  @secp256k1n_2 round(Float.floor(@secp256k1n / 2))
   @base_recovery_id 27
   @base_recovery_id_eip_155 35
 

--- a/apps/blockchain/lib/math_helper.ex
+++ b/apps/blockchain/lib/math_helper.ex
@@ -28,7 +28,7 @@ defmodule Blockchain.MathHelper do
     # T_g - trx.gas_limit
     # g' - remaining_gas
     # A'_r - refund
-    max_refund = round(:math.floor((trx.gas_limit - remaining_gas) / 2))
+    max_refund = round(Float.floor((trx.gas_limit - remaining_gas) / 2))
 
     remaining_gas + min(max_refund, refund)
   end


### PR DESCRIPTION
I am getting issues compiling Mana; it seems that the Erlang `:math` module isn't available on my system (Fedora 2.6, elixir 1.6.6, Erlang 8.3.5.4).

This PR replaces that call with the native elixir `Float.floor` call.