### PR TITLE
Fix mis-typed types

### DIFF
--- a/.dialyzer.ignore-warnings
+++ b/.dialyzer.ignore-warnings
@@ -46,8 +46,6 @@ lib/trie/helper.ex:41: The variable _@1 can never match since previous clauses c
 -------------------------------
 # blockchain/block.ex warnings
 -------------------------------
-:0: Unknown type 'Elixir.ExthCrypto':hash/0
-:0: Unknown type 'Elixir.Header':t/0
 apps/blockchain/lib/blockchain/block.ex:438: Function gen_child_block/2 has no local return
 apps/blockchain/lib/blockchain/block.ex:438: Function gen_child_block/3 has no local return
 apps/blockchain/lib/blockchain/block.ex:443: The call 'Elixir.Blockchain.Block':set_block_number(#{'__struct__':='Elixir.Blockchain.Block', 'block_hash':='nil', 'header':=#{'__struct__':='Elixir.Block.Header', 'beneficiary':=_, 'difficulty':='nil', 'extra_data':=_, 'gas_limit':=0, 'gas_used':=0, 'logs_bloom':=<<_:2048>>, 'mix_hash':=_, 'nonce':=<<_:64>>, 'number':='nil', 'ommers_hash':=<<_:256>>, 'parent_hash':='nil', 'receipts_root':=<<_:256>>, 'state_root':=_, 'timestamp':=_, 'transactions_root':=<<_:256>>}, 'ommers':=[], 'transactions':=[]},Vparent_block@1::any()) breaks the contract (t(),t()) -> t()

--- a/.dialyzer.ignore-warnings
+++ b/.dialyzer.ignore-warnings
@@ -27,7 +27,6 @@
 -------------------------------
 # TODO: rewrite mocked protocol typespecs
 -------------------------------
-
 lib/evm/interface/mock/mock_account_interface
 lib/evm/interface/mock/mock_block_interface
 lib/evm/machine_code

--- a/apps/blockchain/lib/blockchain/interface/account_interface.ex
+++ b/apps/blockchain/lib/blockchain/interface/account_interface.ex
@@ -286,7 +286,7 @@ defimpl EVM.Interface.AccountInterface, for: Blockchain.Interface.AccountInterfa
           EVM.Wei.t(),
           binary(),
           integer(),
-          Header.t()
+          Block.Header.t()
         ) :: {EVM.Interface.AccountInterface.t(), EVM.Gas.t(), EVM.SubState.t(), EVM.VM.output()}
   def message_call(
         account_interface,
@@ -344,7 +344,7 @@ defimpl EVM.Interface.AccountInterface, for: Blockchain.Interface.AccountInterfa
           EVM.Wei.t(),
           EVM.MachineCode.t(),
           integer(),
-          Header.t()
+          Block.Header.t()
         ) :: {:ok | :error, {EVM.Interface.AccountInterface.t(), EVM.Gas.t(), EVM.SubState.t()}}
   def create_contract(
         account_interface,

--- a/apps/ex_wire/lib/ex_wire/handler.ex
+++ b/apps/ex_wire/lib/ex_wire/handler.ex
@@ -32,9 +32,9 @@ defmodule ExWire.Handler do
 
     @type t :: %__MODULE__{
             remote_host: Endpoint.t(),
-            signature: Crpyto.signature(),
+            signature: Crypto.signature(),
             recovery_id: Crypto.recovery_id(),
-            hash: Cryto.hash(),
+            hash: Crypto.hash(),
             data: binary(),
             timestamp: integer(),
             type: integer()

--- a/apps/ex_wire/lib/ex_wire/handler/pong.ex
+++ b/apps/ex_wire/lib/ex_wire/handler/pong.ex
@@ -21,7 +21,7 @@ defmodule ExWire.Handler.Pong do
       ...> })
       :no_response
   """
-  @spec handle(Params.t(), Keyword.t()) :: Handler.handler_response()
+  @spec handle(Handler.Params.t(), Keyword.t()) :: Handler.handler_response()
   def handle(params, options \\ []) do
     pong = Pong.decode(params.data)
 

--- a/apps/ex_wire/lib/ex_wire/handshake.ex
+++ b/apps/ex_wire/lib/ex_wire/handshake.ex
@@ -42,7 +42,7 @@ defmodule ExWire.Handshake do
           init_nonce: nonce(),
           resp_nonce: nonce(),
           random_key_pair: ExthCrypto.Key.key_pair(),
-          remote_random_pub: ExthCrypto.Key.pubic_key(),
+          remote_random_pub: ExthCrypto.Key.public_key(),
           auth_msg: AuthMsgV4.t(),
           ack_resp: AckRespV4.t(),
           encoded_auth_msg: binary(),

--- a/apps/ex_wire/lib/ex_wire/handshake/eip_8.ex
+++ b/apps/ex_wire/lib/ex_wire/handshake/eip_8.ex
@@ -27,7 +27,7 @@ defmodule ExWire.Handshake.EIP8 do
           ExRLP.t(),
           ExthCrypto.Key.public_key(),
           {ExthCrypto.Key.public_key(), ExthCrypto.Key.private_key()} | nil,
-          Cipher.init_vector() | nil
+          ExthCrypto.Cipher.init_vector() | nil
         ) :: {:ok, binary()} | {:error, String.t()}
   def wrap_eip_8(
         rlp,
@@ -105,7 +105,7 @@ defmodule ExWire.Handshake.EIP8 do
         ""}
   """
   @spec unwrap_eip_8(binary(), ExthCrypto.Key.private_key()) ::
-          {:ok, RLP.t(), binary(), binary()} | {:error, String.t()}
+          {:ok, ExRLP.t(), binary(), binary()} | {:error, String.t()}
   def unwrap_eip_8(encoded_packet, my_static_private_key) do
     <<auth_size_int::size(16), _::binary()>> = encoded_packet
 

--- a/apps/ex_wire/lib/ex_wire/handshake/struct/auth_msg_v4.ex
+++ b/apps/ex_wire/lib/ex_wire/handshake/struct/auth_msg_v4.ex
@@ -16,7 +16,7 @@ defmodule ExWire.Handshake.Struct.AuthMsgV4 do
   ]
 
   @type t :: %__MODULE__{
-          signature: ExthCrypto.signature(),
+          signature: ExthCrypto.Signature.signature(),
           initiator_public_key: ExthCrypto.Key.public_key_der(),
           initiator_nonce: binary(),
           initiator_version: integer(),

--- a/apps/ex_wire/lib/ex_wire/kademlia/bucket.ex
+++ b/apps/ex_wire/lib/ex_wire/kademlia/bucket.ex
@@ -301,7 +301,7 @@ defmodule ExWire.Kademlia.Bucket do
       iex> bucket |> ExWire.Kademlia.Bucket.insert_node(node) |> ExWire.Kademlia.Bucket.member?(node)
       true
   """
-  @spec member?(t(), Peer.t()) :: boolean()
+  @spec member?(t(), ExWire.Struct.Peer.t()) :: boolean()
   def member?(%__MODULE__{nodes: nodes}, node) do
     nodes
     |> Enum.any?(fn bucket_node ->

--- a/apps/ex_wire/lib/ex_wire/message.ex
+++ b/apps/ex_wire/lib/ex_wire/message.ex
@@ -4,7 +4,8 @@ defmodule ExWire.Message do
   easily encoded and decoded.
   """
   alias ExWire.Message.{Ping, Pong, FindNeighbours, Neighbours}
-  alias ExWire.{Endpoint, Crypto}
+  alias ExWire.Crypto
+  alias ExWire.Struct.Endpoint
 
   defmodule UnknownMessageError do
     defexception [:message]

--- a/apps/ex_wire/lib/ex_wire/message/find_neighbours.ex
+++ b/apps/ex_wire/lib/ex_wire/message/find_neighbours.ex
@@ -81,6 +81,6 @@ defmodule ExWire.Message.FindNeighbours do
       iex> ExWire.Message.FindNeighbours.to(%ExWire.Message.FindNeighbours{target: <<1>>, timestamp: 2})
       nil
   """
-  @spec to(t) :: Endpoint.t() | nil
+  @spec to(t) :: ExWire.Struct.Endpoint.t() | nil
   def to(_message), do: nil
 end

--- a/apps/ex_wire/lib/ex_wire/message/neighbours.ex
+++ b/apps/ex_wire/lib/ex_wire/message/neighbours.ex
@@ -101,6 +101,6 @@ defmodule ExWire.Message.Neighbours do
       iex> ExWire.Message.Neighbours.to(%ExWire.Message.Neighbours{nodes: [], timestamp: 1})
       nil
   """
-  @spec to(t) :: Endpoint.t() | nil
+  @spec to(t) :: ExWire.Struct.Endpoint.t() | nil
   def to(_message), do: nil
 end

--- a/apps/ex_wire/lib/ex_wire/protocol.ex
+++ b/apps/ex_wire/lib/ex_wire/protocol.ex
@@ -28,7 +28,7 @@ defmodule ExWire.Protocol do
         152, 152, 127, 241, 82, 7, 92, 202, 59, 197, 237, 102, 1, 1, 214, 1, 201,
         132, 1, 2, 3, 4, 128, 130, 0, 5, 201, 132, 5, 6, 7, 8, 130, 0, 6, 128, 4>>
   """
-  @spec encode(Message.t(), Crypto.private_key()) :: binary()
+  @spec encode(Message.t(), ExthCrypto.Key.private_key()) :: binary()
   def encode(message, private_key) do
     signed_message = sign_message(message, private_key)
 
@@ -52,7 +52,7 @@ defmodule ExWire.Protocol do
       iex> ExthCrypto.Signature.verify(message |> ExWire.Message.encode |> ExWire.Crypto.hash, signature, ExthCrypto.Test.public_key())
       true
   """
-  @spec sign_message(Message.t(), Crypto.private_key()) :: binary()
+  @spec sign_message(Message.t(), ExthCrypto.Key.private_key()) :: binary()
   def sign_message(message, private_key) do
     message
     |> Message.encode()
@@ -69,7 +69,7 @@ defmodule ExWire.Protocol do
       iex> ExthCrypto.Signature.verify(ExWire.Crypto.hash("mace windu"), signature, ExthCrypto.Test.public_key())
       true
   """
-  @spec sign_binary(binary(), Crypto.private_key()) :: binary()
+  @spec sign_binary(binary(), ExthCrypto.Key.private_key()) :: binary()
   def sign_binary(value, private_key) do
     hashed_value = Crypto.hash(value)
 

--- a/apps/ex_wire/lib/ex_wire/struct/block_queue.ex
+++ b/apps/ex_wire/lib/ex_wire/struct/block_queue.ex
@@ -423,7 +423,7 @@ defmodule ExWire.Struct.BlockQueue do
     trie.root_hash
   end
 
-  @spec get_ommers_hash([EVM.hash()]) :: ExthCrypto.hash()
+  @spec get_ommers_hash([EVM.hash()]) :: ExthCrypto.Hash.hash()
   defp get_ommers_hash(ommers) do
     ommers |> ExRLP.encode() |> ExthCrypto.Hash.Keccak.kec()
   end

--- a/apps/ex_wire/lib/ex_wire/struct/peer.ex
+++ b/apps/ex_wire/lib/ex_wire/struct/peer.ex
@@ -32,7 +32,7 @@ defmodule ExWire.Struct.Peer do
         ident: "6ce059...1acd9d"
       }
   """
-  @spec new(Sring.t(), integer(), String.t()) :: t
+  @spec new(String.t(), integer(), String.t()) :: t
   def new(host, port, remote_id_hex) do
     remote_id =
       remote_id_hex

--- a/apps/exth_crypto/lib/aes.ex
+++ b/apps/exth_crypto/lib/aes.ex
@@ -61,7 +61,7 @@ defmodule ExthCrypto.AES do
   @spec encrypt(
           ExthCrypto.Cipher.plaintext(),
           ExthCrypto.Cipher.mode(),
-          ExthCrypto.symmetric_key(),
+          ExthCrypto.Key.symmetric_key(),
           ExthCrypto.Cipher.init_vector()
         ) :: ExthCrypto.Cipher.ciphertext()
   def encrypt(plaintext, :cbc, symmetric_key, init_vector) do
@@ -86,7 +86,7 @@ defmodule ExthCrypto.AES do
   @spec encrypt(
           ExthCrypto.Cipher.plaintext(),
           ExthCrypto.Cipher.mode(),
-          ExthCrypto.symmetric_key()
+          ExthCrypto.Key.symmetric_key()
         ) :: ExthCrypto.Cipher.ciphertext()
   def encrypt(plaintext, :ecb, symmetric_key) do
     padding_bits = (16 - rem(byte_size(plaintext), 16)) * 8
@@ -147,7 +147,7 @@ defmodule ExthCrypto.AES do
   @spec decrypt(
           ExthCrypto.Cipher.ciphertext(),
           ExthCrypto.Cipher.mode(),
-          ExthCrypto.symmetric_key(),
+          ExthCrypto.Key.symmetric_key(),
           ExthCrypto.Cipher.init_vector()
         ) :: ExthCrypto.Cipher.plaintext()
   def decrypt(ciphertext, :cbc, symmetric_key, init_vector) do
@@ -165,7 +165,7 @@ defmodule ExthCrypto.AES do
   @spec decrypt(
           ExthCrypto.Cipher.ciphertext(),
           ExthCrypto.Cipher.mode(),
-          ExthCrypto.symmetric_key()
+          ExthCrypto.Key.symmetric_key()
         ) :: ExthCrypto.Cipher.plaintext()
   def decrypt(ciphertext, :ecb, symmetric_key) do
     :crypto.block_decrypt(:aes_ecb, symmetric_key, ciphertext)
@@ -221,7 +221,7 @@ defmodule ExthCrypto.AES do
       "hello"
   """
   @spec stream_decrypt(ExthCrypto.Cipher.ciphertext(), ExthCrypto.Cipher.stream()) ::
-          {ExthCrypto.Cipher.stream(), ExthCrypto.Cipher.plaintrxt()}
+          {ExthCrypto.Cipher.stream(), ExthCrypto.Cipher.plaintext()}
   def stream_decrypt(plaintext, stream) do
     :crypto.stream_decrypt(stream, plaintext)
   end

--- a/apps/exth_crypto/lib/ecies/parameters.ex
+++ b/apps/exth_crypto/lib/ecies/parameters.ex
@@ -15,8 +15,8 @@ defmodule ExthCrypto.ECIES.Parameters do
 
   @type t :: %__MODULE__{
           mac: :crypto.hash_algorithms(),
-          hasher: ExthCrypto.hash_type(),
-          cipher: ExthCrypto.cipher(),
+          hasher: ExthCrypto.Hash.hash_type(),
+          cipher: ExthCrypto.Cipher.cipher(),
           key_len: integer()
         }
 

--- a/apps/exth_crypto/lib/exth_crypto.ex
+++ b/apps/exth_crypto/lib/exth_crypto.ex
@@ -5,4 +5,5 @@ defmodule ExthCrypto do
 
   @type curve :: nil
   @type curve_params :: nil
+  @type named_curve :: atom()
 end

--- a/apps/exth_crypto/lib/hash.ex
+++ b/apps/exth_crypto/lib/hash.ex
@@ -19,13 +19,13 @@ defmodule ExthCrypto.Hash do
   @doc """
   The SHA1 hasher.
   """
-  @spec sha1() :: ExthCrypto.hash_type()
+  @spec sha1() :: hash_type()
   def sha1, do: {&ExthCrypto.Hash.SHA.sha1/1, nil, 20}
 
   @doc """
   The KECCAK hasher, as defined by Ethereum.
   """
-  @spec kec() :: ExCrpyto.hash_type()
+  @spec kec() :: hash_type()
   def kec, do: {&ExthCrypto.Hash.Keccak.kec/1, nil, 256}
 
   @doc """

--- a/apps/exth_crypto/lib/hash/keccak.ex
+++ b/apps/exth_crypto/lib/hash/keccak.ex
@@ -7,7 +7,7 @@ defmodule ExthCrypto.Hash.Keccak do
   been changed prior to adoption by NIST, but after adoption by Ethereum.
   """
 
-  @type keccak_hash :: ExthCrypto.hash()
+  @type keccak_hash :: ExthCrypto.Hash.hash()
   @type keccak_mac :: {atom(), binary()}
 
   @doc """


### PR DESCRIPTION
Fix several issues with type definitions. Many were mistyped. Others assumed a module was aliased, and others just assumed that a type existed when it didn't. Not all of them were listed in `.dialyzer.ignore-warnings` but they show up when running dialyzer locally.