### PR TITLE
add new logs to the end of list

### DIFF
--- a/apps/evm/lib/evm/sub_state.ex
+++ b/apps/evm/lib/evm/sub_state.ex
@@ -60,7 +60,7 @@ defmodule EVM.SubState do
   def add_log(sub_state, address, topics, data) do
     log_entry = LogEntry.new(address, topics, data)
 
-    new_logs = [log_entry | sub_state.logs]
+    new_logs = sub_state.logs ++ [log_entry]
 
     %{sub_state | logs: new_logs}
   end

--- a/apps/evm/test/evm/sub_state_test.exs
+++ b/apps/evm/test/evm/sub_state_test.exs
@@ -1,4 +1,30 @@
 defmodule EVM.SubStateTest do
   use ExUnit.Case, async: true
   doctest EVM.SubState
+
+  describe "add_log/4" do
+    test "adds logs to the end" do
+      sub_state = %EVM.SubState{
+        logs: [
+          %EVM.LogEntry{
+            address: <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>,
+            data: "adsfa",
+            topics: [1, 10, 12]
+          }
+        ],
+        refund: 0,
+        selfdestruct_list: []
+      }
+
+      new_substate = EVM.SubState.add_log(sub_state, 1, [5], "zxcz")
+
+      expected_last_log_entry = %EVM.LogEntry{
+        address: <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1>>,
+        data: "zxcz",
+        topics: [5]
+      }
+
+      assert expected_last_log_entry == List.last(new_substate.logs)
+    end
+  end
 end

--- a/apps/evm/test/evm_test.exs
+++ b/apps/evm/test/evm_test.exs
@@ -65,7 +65,7 @@ defmodule EvmTest do
         end
 
         if test["logs"] do
-          logs_hash = sub_state.logs |> Enum.reverse() |> logs_hash()
+          logs_hash = sub_state.logs |> logs_hash()
           assert hex_to_bin(test["logs"]) == logs_hash
         end
       end


### PR DESCRIPTION
Following Homestead tests fixed:
- "stRandom/randomStatetest324.json",
- "stRandom2/randomStatetest418.json",
- "stTransitionTest/createNameRegistratorPerTxsNotEnoughGasBefore.json",
- "stWalletTest/walletAddOwnerRemovePendingTransaction.json",
- "stWalletTest/walletChangeOwnerRemovePendingTransaction.json",
- "stWalletTest/walletChangeRequirementRemovePendingTransaction.json",
 - "stWalletTest/walletConfirm.json",
- "stWalletTest/walletRemoveOwnerRemovePendingTransaction.json",