### PR TITLE
Catch timeout errors in the `sync_with_infura` script

### DIFF
--- a/apps/blockchain/scripts/sync_with_infura.ex
+++ b/apps/blockchain/scripts/sync_with_infura.ex
@@ -93,8 +93,8 @@ defmodule SyncWithInfura do
       end
 
     Blockchain.Block.add_ommers(block, ommers)
-  rescue
-    error ->
+  catch
+    :exit, error ->
       Logger.info("error:  #{inspect(error)}")
       Logger.info("Retrying")
       get_block(n)


### PR DESCRIPTION
Exthereum timeout errors weren't being caught by the `rescue` statment.