### PR TITLE
EIP2: out of gas error on contract creation if not enough gas

### DIFF
--- a/apps/blockchain/lib/blockchain/contract/create_contract.ex
+++ b/apps/blockchain/lib/blockchain/contract/create_contract.ex
@@ -135,15 +135,10 @@ defmodule Blockchain.Contract.CreateContract do
         end
 
       resultant_state =
-        cond do
-          state_after_init == nil ->
-            params.state
-
-          insufficient_gas ->
-            state_after_init
-
-          true ->
-            Account.put_code(state_after_init, address, output)
+        if insufficient_gas do
+          state_after_init
+        else
+          Account.put_code(state_after_init, address, output)
         end
 
       {:ok, {resultant_state, resultant_gas, accrued_sub_state}}

--- a/apps/blockchain/lib/blockchain/contract/create_contract.ex
+++ b/apps/blockchain/lib/blockchain/contract/create_contract.ex
@@ -71,7 +71,7 @@ defmodule Blockchain.Contract.CreateContract do
       if output == :failed do
         {:error, {params.state, 0, SubState.empty()}}
       else
-        {:ok, finalize(result, params, contract_address)}
+        finalize(result, params, contract_address)
       end
     end
   end
@@ -122,30 +122,32 @@ defmodule Blockchain.Contract.CreateContract do
     state_after_init = exec_env.account_interface.state
 
     contract_creation_cost = creation_cost(output)
+    insufficient_gas = remaining_gas < contract_creation_cost
 
-    insufficient_gas_before_homestead =
-      remaining_gas < contract_creation_cost and Header.is_before_homestead?(params.block_header)
+    if insufficient_gas && EVM.Configuration.fail_contract_creation?(params.config) do
+      {:error, {params.state, 0, SubState.empty()}}
+    else
+      resultant_gas =
+        cond do
+          state_after_init == nil -> 0
+          insufficient_gas -> remaining_gas
+          true -> remaining_gas - contract_creation_cost
+        end
 
-    resultant_gas =
-      cond do
-        state_after_init == nil -> 0
-        insufficient_gas_before_homestead -> remaining_gas
-        true -> remaining_gas - contract_creation_cost
-      end
+      resultant_state =
+        cond do
+          state_after_init == nil ->
+            params.state
 
-    resultant_state =
-      cond do
-        state_after_init == nil ->
-          params.state
+          insufficient_gas ->
+            state_after_init
 
-        insufficient_gas_before_homestead ->
-          state_after_init
+          true ->
+            Account.put_code(state_after_init, address, output)
+        end
 
-        true ->
-          Account.put_code(state_after_init, address, output)
-      end
-
-    {resultant_state, resultant_gas, accrued_sub_state}
+      {:ok, {resultant_state, resultant_gas, accrued_sub_state}}
+    end
   end
 
   # Returns the additional cost after creating a new contract.

--- a/apps/blockchain/lib/blockchain/contract/create_contract.ex
+++ b/apps/blockchain/lib/blockchain/contract/create_contract.ex
@@ -124,14 +124,14 @@ defmodule Blockchain.Contract.CreateContract do
     contract_creation_cost = creation_cost(output)
     insufficient_gas = remaining_gas < contract_creation_cost
 
-    if insufficient_gas && EVM.Configuration.fail_contract_creation?(params.config) do
+    if insufficient_gas && EVM.Configuration.fail_contract_creation_lack_of_gas?(params.config) do
       {:error, {params.state, 0, SubState.empty()}}
     else
       resultant_gas =
-        cond do
-          state_after_init == nil -> 0
-          insufficient_gas -> remaining_gas
-          true -> remaining_gas - contract_creation_cost
+        if insufficient_gas do
+          remaining_gas
+        else
+          remaining_gas - contract_creation_cost
         end
 
       resultant_state =

--- a/apps/blockchain/lib/blockchain/interface/account_interface.ex
+++ b/apps/blockchain/lib/blockchain/interface/account_interface.ex
@@ -333,7 +333,9 @@ defimpl EVM.Interface.AccountInterface, for: Blockchain.Interface.AccountInterfa
       ...> |> Blockchain.Interface.AccountInterface.new()
       ...> |> EVM.Interface.AccountInterface.create_contract(<<0x10::160>>, <<0x10::160>>, 1000, 1, 5, EVM.MachineCode.compile([:push1, 3, :push1, 5, :add, :push1, 0x00, :mstore, :push1, 32, :push1, 0, :return]), 5, %Block.Header{nonce: 1},  EVM.Configuration.Frontier.new())
       iex> account_interface.state.root_hash
-      <<9, 235, 32, 146, 153, 242, 209, 192, 224, 61, 214, 174, 48, 24, 148, 28, 51, 254, 7, 82, 58, 82, 220, 157, 29, 159, 203, 51, 52, 240, 37, 122>>
+      <<226, 121, 240, 77, 157, 98, 127, 111, 137, 201, 186, 41, 100, 239,
+              227, 209, 92, 247, 21, 58, 119, 4, 191, 255, 84, 144, 86, 99, 178,
+              157, 145, 31>>
   """
   @spec create_contract(
           EVM.Interface.AccountInterface.t(),

--- a/apps/blockchain/test/blockchain/state_test.exs
+++ b/apps/blockchain/test/blockchain/state_test.exs
@@ -10,7 +10,6 @@ defmodule Blockchain.StateTest do
 
   @failing_tests %{
     "Frontier" => [
-      "stTransitionTest/createNameRegistratorPerTxsNotEnoughGasAfter",
       "stTransactionTest/UserTransactionGasLimitIsTooLowWhenZeroCost",
       "stTransactionTest/TransactionToItselfNotEnoughFounds",
       "stTransactionTest/TransactionNonceCheck2",
@@ -43,7 +42,6 @@ defmodule Blockchain.StateTest do
       "stRevertTest/RevertOpcodeMultipleSubCalls",
       "stRevertTest/RevertOpcodeInInit",
       "stRevertTest/RevertOpcodeInInit",
-      "stRandom2/randomStatetest643",
       "stRandom2/201503110226PYTHON_DUP6",
       "stRandom/randomStatetest347",
       "stRandom/randomStatetest184",

--- a/apps/blockchain/test/blockchain_test.exs
+++ b/apps/blockchain/test/blockchain_test.exs
@@ -15,9 +15,7 @@ defmodule BlockchainTest do
     "Frontier" => [],
     "Homestead" => [
       "GeneralStateTests/stDelegatecallTestHomestead/delegatecodeDynamicCode_d0g0v0.json",
-      "GeneralStateTests/stRandom2/randomStatetest643_d0g0v0.json",
-      "bcValidBlockTest/dataTx2.json",
-      "bcWalletTest/wallet2outOf3txs.json"
+      "GeneralStateTests/stDelegatecallTestHomestead/delegatecodeDynamicCode_d0g0v0.json"
     ],
     # the rest are not implemented yet
     "Byzantium" => [],

--- a/apps/evm/lib/evm/configuration.ex
+++ b/apps/evm/lib/evm/configuration.ex
@@ -10,8 +10,8 @@ defprotocol EVM.Configuration do
   def contract_creation_cost(t)
 
   # EIP2
-  @spec fail_contract_creation?(t) :: boolean()
-  def fail_contract_creation?(t)
+  @spec fail_contract_creation_lack_of_gas?(t) :: boolean()
+  def fail_contract_creation_lack_of_gas?(t)
 
   # EIP7
   @spec has_delegate_call?(t) :: boolean()

--- a/apps/evm/lib/evm/configuration.ex
+++ b/apps/evm/lib/evm/configuration.ex
@@ -1,13 +1,19 @@
 defprotocol EVM.Configuration do
   @moduledoc """
-  Prototcol for defining hardfork configurations.
+  Protocol for defining hardfork configurations.
   """
 
   @type t :: module()
 
+  # EIP2
   @spec contract_creation_cost(t) :: integer()
   def contract_creation_cost(t)
 
+  # EIP2
+  @spec fail_contract_creation?(t) :: boolean()
+  def fail_contract_creation?(t)
+
+  # EIP7
   @spec has_delegate_call?(t) :: boolean()
   def has_delegate_call?(t)
 end

--- a/apps/evm/lib/evm/configuration/frontier.ex
+++ b/apps/evm/lib/evm/configuration/frontier.ex
@@ -15,6 +15,6 @@ defimpl EVM.Configuration, for: EVM.Configuration.Frontier do
   @spec has_delegate_call?(EVM.Configuration.t()) :: boolean()
   def has_delegate_call?(config), do: config.has_delegate_call
 
-  @spec fail_contract_creation?(EVM.Configuration.t()) :: boolean()
-  def fail_contract_creation?(config), do: config.fail_contract_creation
+  @spec fail_contract_creation_lack_of_gas?(EVM.Configuration.t()) :: boolean()
+  def fail_contract_creation_lack_of_gas?(config), do: config.fail_contract_creation
 end

--- a/apps/evm/lib/evm/configuration/frontier.ex
+++ b/apps/evm/lib/evm/configuration/frontier.ex
@@ -1,5 +1,7 @@
 defmodule EVM.Configuration.Frontier do
-  defstruct contract_creation_cost: 21_000, has_delegate_call: false
+  defstruct contract_creation_cost: 21_000,
+            has_delegate_call: false,
+            fail_contract_creation: false
 
   def new do
     %__MODULE__{}
@@ -12,4 +14,7 @@ defimpl EVM.Configuration, for: EVM.Configuration.Frontier do
 
   @spec has_delegate_call?(EVM.Configuration.t()) :: boolean()
   def has_delegate_call?(config), do: config.has_delegate_call
+
+  @spec fail_contract_creation?(EVM.Configuration.t()) :: boolean()
+  def fail_contract_creation?(config), do: config.fail_contract_creation
 end

--- a/apps/evm/lib/evm/configuration/homestead.ex
+++ b/apps/evm/lib/evm/configuration/homestead.ex
@@ -1,5 +1,5 @@
 defmodule EVM.Configuration.Homestead do
-  defstruct contract_creation_cost: 53_000, has_delegate_call: true
+  defstruct contract_creation_cost: 53_000, has_delegate_call: true, fail_contract_creation: true
 
   def new do
     %__MODULE__{}
@@ -12,4 +12,7 @@ defimpl EVM.Configuration, for: EVM.Configuration.Homestead do
 
   @spec has_delegate_call?(EVM.Configuration.t()) :: boolean()
   def has_delegate_call?(config), do: config.has_delegate_call
+
+  @spec fail_contract_creation?(EVM.Configuration.t()) :: boolean()
+  def fail_contract_creation?(config), do: config.fail_contract_creation
 end

--- a/apps/evm/lib/evm/configuration/homestead.ex
+++ b/apps/evm/lib/evm/configuration/homestead.ex
@@ -13,6 +13,6 @@ defimpl EVM.Configuration, for: EVM.Configuration.Homestead do
   @spec has_delegate_call?(EVM.Configuration.t()) :: boolean()
   def has_delegate_call?(config), do: config.has_delegate_call
 
-  @spec fail_contract_creation?(EVM.Configuration.t()) :: boolean()
-  def fail_contract_creation?(config), do: config.fail_contract_creation
+  @spec fail_contract_creation_lack_of_gas?(EVM.Configuration.t()) :: boolean()
+  def fail_contract_creation_lack_of_gas?(config), do: config.fail_contract_creation
 end


### PR DESCRIPTION
fixes https://github.com/poanetwork/mana/issues/325

From [EIP2](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2.md):
```
If contract creation does not have enough gas to pay for the final gas fee for adding the contract code to the state, the contract creation fails (i.e. goes out-of-gas) rather than leaving an empty contract.
```
merge after https://github.com/poanetwork/mana/pull/323