### PR TITLE
fix nested create suicide EIP150

### DIFF
--- a/apps/blockchain/test/blockchain/state_test.exs
+++ b/apps/blockchain/test/blockchain/state_test.exs
@@ -8,8 +8,7 @@ defmodule Blockchain.StateTest do
   use EthCommonTest.Harness
   use ExUnit.Case, async: true
 
-  @failing_tests
-  %{
+  @failing_tests %{
     "EIP150" => [
       "stZeroCallsTest/ZeroValue_SUICIDE",
       "stTransitionTest/createNameRegistratorPerTxsNotEnoughGasBefore",

--- a/apps/blockchain/test/blockchain/state_test.exs
+++ b/apps/blockchain/test/blockchain/state_test.exs
@@ -8,7 +8,8 @@ defmodule Blockchain.StateTest do
   use EthCommonTest.Harness
   use ExUnit.Case, async: true
 
-  @failing_tests %{
+  @failing_tests
+  %{
     "EIP150" => [
       "stZeroCallsTest/ZeroValue_SUICIDE",
       "stTransitionTest/createNameRegistratorPerTxsNotEnoughGasBefore",
@@ -50,8 +51,7 @@ defmodule Blockchain.StateTest do
       "stInitCodeTest/NotEnoughCashContractCreation",
       "stEIP158Specific/vitalikTransactionTest",
       "stEIP150Specific/SuicideToNotExistingContract",
-      "stDelegatecallTestHomestead/Delegatecall1024OOG",
-      "stCreateTest/CREATE_AcreateB_BSuicide_BStore"
+      "stDelegatecallTestHomestead/Delegatecall1024OOG"
     ],
     "Frontier" => [
       "stTransactionTest/UserTransactionGasLimitIsTooLowWhenZeroCost",
@@ -103,6 +103,7 @@ defmodule Blockchain.StateTest do
       "stDelegatecallTestHomestead/callOutput1"
     ]
   }
+
   test "Blockchain state tests" do
     Enum.each(test_directories(), fn directory_path ->
       test_group = Enum.fetch!(String.split(directory_path, "/"), 4)

--- a/apps/blockchain/test/blockchain_test.exs
+++ b/apps/blockchain/test/blockchain_test.exs
@@ -15,9 +15,7 @@ defmodule BlockchainTest do
     "Frontier" => [],
     "Homestead" => [],
     "EIP150" => [
-      "GeneralStateTests/stCreateTest/CREATE_AcreateB_BSuicide_BStore_d0g0v0.json",
       "GeneralStateTests/stDelegatecallTestHomestead/Delegatecall1024OOG_d0g0v0.json",
-      "GeneralStateTests/stDelegatecallTestHomestead/delegatecodeDynamicCode_d0g0v0.json",
       "GeneralStateTests/stEIP150Specific/SuicideToNotExistingContract_d0g0v0.json",
       "GeneralStateTests/stEIP158Specific/vitalikTransactionTest_d0g0v0.json",
       "GeneralStateTests/stNonZeroCallsTest/NonZeroValue_SUICIDE_d0g0v0.json",

--- a/apps/evm/lib/evm/exec_env.ex
+++ b/apps/evm/lib/evm/exec_env.ex
@@ -23,7 +23,8 @@ defmodule EVM.ExecEnv do
             stack_depth: 0,
             account_interface: nil,
             block_interface: nil,
-            config: EVM.Configuration.Frontier.new()
+            config: EVM.Configuration.Frontier.new(),
+            created_accounts: []
 
   @typedoc """
   Terms from Yellow Paper:
@@ -49,7 +50,8 @@ defmodule EVM.ExecEnv do
           stack_depth: integer(),
           block_interface: BlockInterface.t(),
           account_interface: AccountInterface.t(),
-          config: Configuration.t()
+          config: Configuration.t(),
+          created_accounts: [EVM.address()]
         }
 
   @spec put_storage(t(), integer(), integer()) :: t()
@@ -101,6 +103,13 @@ defmodule EVM.ExecEnv do
 
   @spec new_account?(t()) :: boolean()
   def new_account?(exec_env) do
-    !AccountInterface.account_exists?(exec_env.account_interface, exec_env.address)
+    Enum.member?(exec_env.created_accounts, exec_env.address)
+  end
+
+  @spec add_created_address(t(), integer()) :: t()
+  def add_created_address(exec_env, address) do
+    address = :binary.encode_unsigned(address)
+
+    %{exec_env | created_accounts: [address | exec_env.created_accounts]}
   end
 end

--- a/apps/evm/lib/evm/message_call.ex
+++ b/apps/evm/lib/evm/message_call.ex
@@ -172,7 +172,8 @@ defmodule EVM.MessageCall do
       stack_depth: message_call.stack_depth + 1,
       account_interface: message_call.current_exec_env.account_interface,
       block_interface: message_call.current_exec_env.block_interface,
-      config: message_call.current_exec_env.config
+      config: message_call.current_exec_env.config,
+      created_accounts: message_call.current_exec_env.created_accounts
     }
   end
 

--- a/apps/evm/lib/evm/operation/system.ex
+++ b/apps/evm/lib/evm/operation/system.ex
@@ -11,7 +11,8 @@ defmodule EVM.Operation.System do
     Gas,
     Memory,
     SubState,
-    Configuration
+    Configuration,
+    Address
   }
 
   @dialyzer {:no_return, callcode: 2}
@@ -78,11 +79,9 @@ defmodule EVM.Operation.System do
     # Note if was exception halt or other failure on stack
     result =
       if status == :ok do
-        nonce =
-          exec_env.account_interface
-          |> AccountInterface.get_account_nonce(exec_env.address)
+        nonce = AccountInterface.get_account_nonce(exec_env.account_interface, exec_env.address)
 
-        EVM.Address.new(exec_env.address, nonce)
+        Address.new(exec_env.address, nonce)
       else
         0
       end
@@ -93,6 +92,7 @@ defmodule EVM.Operation.System do
         gas: n_gas + remaining_gas
     }
 
+    exec_env = ExecEnv.add_created_address(exec_env, result)
     exec_env = %{exec_env | account_interface: updated_account_interface}
 
     sub_state = SubState.merge(n_sub_state, sub_state)


### PR DESCRIPTION
We need to store created accounts in the current evm execution and pass them to the nested message calls. 

From EIP 150:
```If SELFDESTRUCT hits a newly created account, it triggers an additional gas cost of 25000 (similar to CALLs).```