### PR TITLE
Add Ethereum common difficulty tests

### DIFF
--- a/apps/evm/lib/block/header.ex
+++ b/apps/evm/lib/block/header.ex
@@ -9,38 +9,41 @@ defmodule Block.Header do
   @empty_trie MerklePatriciaTree.Trie.empty_trie_root_hash()
   @empty_keccak [] |> ExRLP.encode() |> Keccak.kec()
 
-  # H_p P(B_H)H_r
   defstruct parent_hash: nil,
-            # H_o KEC(RLP(L∗H(B_U)))
             ommers_hash: @empty_keccak,
-            # H_c
             beneficiary: nil,
-            # H_r TRIE(LS(Π(σ, B)))
             state_root: @empty_trie,
-            # H_t TRIE({∀i < kBTk, i ∈ P : p(i, LT(B_T[i]))})
             transactions_root: @empty_trie,
-            # H_e TRIE({∀i < kBRk, i ∈ P : p(i, LR(B_R[i]))})
             receipts_root: @empty_trie,
-            # H_b bloom
             logs_bloom: <<0::2048>>,
-            # H_d
             difficulty: nil,
-            # H_i
             number: nil,
-            # H_l
             gas_limit: 0,
-            # H_g
             gas_used: 0,
-            # H_s
             timestamp: nil,
-            # H_x
             extra_data: <<>>,
-            # H_m
             mix_hash: <<0::256>>,
-            # H_n
             nonce: <<0::64>>
 
-  # As defined in section 4.3
+  @typedoc """
+  As defined in section 4.3 of Yellow Paper:
+
+  * H_p P(B_H)H_r = parent_hash
+  * H_o KEC(RLP(L∗H(B_U)))  = ommers_hash
+  * H_c = beneficiary
+  * H_r TRIE(LS(Π(σ, B))) = state_root
+  * H_t TRIE({∀i < kBTk, i ∈ P : p(i, LT(B_T[i]))}) = transactions_root
+  * H_e TRIE({∀i < kBRk, i ∈ P : p(i, LR(B_R[i]))}) = receipts_root
+  * H_b bloom = logs_bloom
+  * H_d = difficulty
+  * H_i = number
+  * H_l = gas_limit
+  * H_g = gas_used
+  * H_s = timestamp
+  * H_x = extra_data
+  * H_m = mix_hash
+  * H_n = nonce
+  """
   @type t :: %__MODULE__{
           parent_hash: EVM.hash(),
           ommers_hash: EVM.trie_root(),
@@ -48,7 +51,6 @@ defmodule Block.Header do
           state_root: EVM.trie_root(),
           transactions_root: EVM.trie_root(),
           receipts_root: EVM.trie_root(),
-          # TODO
           logs_bloom: binary(),
           difficulty: integer() | nil,
           number: integer() | nil,
@@ -395,28 +397,6 @@ defmodule Block.Header do
       ...>  %Block.Header{number: 3_000_000, timestamp: 55, difficulty: 300_000}
       ...> )
       268_734_142
-
-      Test actual Ropsten genesis block
-      iex> Block.Header.get_difficulty(
-      ...>   %Block.Header{number: 0, timestamp: 0},
-      ...>   nil,
-      ...>   0x100000,
-      ...>   0x020000,
-      ...>   0x0800,
-      ...>   0
-      ...> )
-      1_048_576
-
-      # Test actual Ropsten first block
-      iex> Block.Header.get_difficulty(
-      ...>   %Block.Header{number: 1, timestamp: 1_479_642_530},
-      ...>   %Block.Header{number: 0, timestamp: 0, difficulty: 1_048_576},
-      ...>   0x100000,
-      ...>   0x020000,
-      ...>   0x0800,
-      ...>   0
-      ...> )
-      997_888
   """
   @spec get_difficulty(t, t | nil, integer()) :: integer()
   def get_difficulty(

--- a/apps/evm/test/block/header_test.exs
+++ b/apps/evm/test/block/header_test.exs
@@ -1,7 +1,119 @@
 defmodule Block.HeaderTest do
   use ExUnit.Case, async: true
   doctest Block.Header
+
+  import ExthCrypto.Math, only: [hex_to_bin: 1, hex_to_int: 1]
+
   alias Block.Header
+  alias EVM.EthereumCommonTestsHelper, as: Helper
+
+  @forks_with_block %{
+    frontier: 1,
+    homestead: 1_150_000,
+    dao_fork: 1_920_000,
+    eip_150: 2_463_000,
+    spurious_dragon: 2_675_000,
+    byzantium: 4_370_000
+  }
+
+  @next_fork_block_number @forks_with_block[:homestead]
+
+  describe "Difficulty Tests (Ethereum Common Tests)" do
+    test "Calculates frontier and homestead difficulties" do
+      difficulty_tests()
+      |> read_test()
+      |> Enum.filter(&forks_to_run/1)
+      |> Enum.map(&run_test/1)
+      |> Enum.filter(&failed_tests/1)
+      |> make_assertion()
+    end
+  end
+
+  defp forks_to_run({_name, test_data}) do
+    hex_to_int(test_data["currentBlockNumber"]) < @next_fork_block_number
+  end
+
+  defp filter_test(tests, number) do
+    Enum.filter(tests, fn {name, _} -> name == "DifficultyTest#{number}" end)
+  end
+
+  defp run_test({name, test_data}) do
+    expected_difficulty = hex_to_int(test_data["currentDifficulty"])
+
+    difficulty =
+      test_data
+      |> build_headers()
+      |> get_difficulty()
+
+    {name, expected_difficulty, difficulty}
+  end
+
+  defp build_headers(test_data) do
+    test_data
+    |> build_current_header()
+    |> build_parent_header(test_data)
+  end
+
+  def build_current_header(test_data) do
+    %Header{
+      number: hex_to_int(test_data["currentBlockNumber"]),
+      timestamp: hex_to_int(test_data["currentTimestamp"])
+    }
+  end
+
+  def build_parent_header(current_header, test_data) do
+    parent_header = %Header{
+      number: current_header.number - 1,
+      timestamp: hex_to_int(test_data["parentTimestamp"]),
+      difficulty: hex_to_int(test_data["parentDifficulty"]),
+      ommers_hash: hex_to_bin(test_data["parentUncles"])
+    }
+
+    {current_header, parent_header}
+  end
+
+  defp get_difficulty({header, parent_header}) do
+    Header.get_difficulty(header, parent_header)
+  end
+
+  defp make_assertion([]), do: assert(true)
+  defp make_assertion(test_results), do: assert(false, failure_message(test_results))
+
+  def failure_message(test_results) do
+    total_failed = Enum.count(test_results)
+
+    message =
+      test_results
+      |> Enum.map(&single_test_failure_message/1)
+      |> Enum.join("\n")
+
+    """
+    #{message}
+    =======================================
+    #{total_failed} difficulty tests failed
+    """
+  end
+
+  defp single_test_failure_message({name, expected, actual}) do
+    "[#{name}] expected difficulty: #{expected}, actual: #{actual}"
+  end
+
+  defp failed_tests({_name, expected_difficulty, difficulty}) do
+    expected_difficulty != difficulty
+  end
+
+  defp difficulty_tests do
+    # difficultyFrontier.json tests have:
+    # Auto-generated Frontier/Homestead chain difficulty tests
+    # Why is it called `Frontier`? Who knows
+    Helper.basic_tests_path() <> "/difficultyFrontier.json"
+  end
+
+  defp read_test(path) do
+    path
+    |> File.read!()
+    |> Poison.decode!()
+  end
 
   test "serialize and deserialize" do
     header = %Header{
@@ -28,6 +140,49 @@ defmodule Block.HeaderTest do
              |> ExRLP.encode()
              |> ExRLP.decode()
              |> Header.deserialize()
+  end
+
+  describe "get_difficulty/6" do
+    test "Ropsten's genesis block" do
+      header = %Header{number: 0}
+      ropsten_init_difficulty = 0x100000
+      ropsten_min_difficulty = 0x020000
+      ropsten_difficulty_bound_divisor = 0x0800
+      homestead_block = 0
+
+      difficulty =
+        Header.get_difficulty(
+          header,
+          nil,
+          ropsten_init_difficulty,
+          ropsten_min_difficulty,
+          ropsten_difficulty_bound_divisor,
+          homestead_block
+        )
+
+      assert difficulty == 1_048_576
+    end
+
+    test "Ropsten's first block" do
+      header = %Header{number: 1, timestamp: 1_479_642_530}
+      parent = %Header{number: 0, timestamp: 0, difficulty: 1_048_576}
+      ropsten_init_difficulty = 0x100000
+      ropsten_min_difficulty = 0x020000
+      ropsten_difficulty_bound_divisor = 0x0800
+      homestead_block = 0
+
+      difficulty =
+        Header.get_difficulty(
+          header,
+          parent,
+          ropsten_init_difficulty,
+          ropsten_min_difficulty,
+          ropsten_difficulty_bound_divisor,
+          homestead_block
+        )
+
+      assert difficulty == 997_888
+    end
   end
 
   describe "mined_by?/2" do

--- a/apps/evm/test/support/ethereum_common_tests_helper.ex
+++ b/apps/evm/test/support/ethereum_common_tests_helper.ex
@@ -1,0 +1,11 @@
+defmodule EVM.EthereumCommonTestsHelper do
+  @ethereum_common_tests_path System.cwd() <> "/../../ethereum_common_tests/"
+
+  def common_tests_path do
+    @ethereum_common_tests_path
+  end
+
+  def basic_tests_path do
+    common_tests_path() <> "/BasicTests"
+  end
+end


### PR DESCRIPTION
Closes https://github.com/poanetwork/mana/issues/342

What changed?
============

We add Ethereum common tests that test the difficulty calculation described under the "Block Header Validity" section of the Yellow Paper.

In the common tests, under the `BasicTests` directory, there are several files that test difficulty. Some are generated manually while others are refilled automatically. We make use of the file `difficultyFrontier.json`. It is worth noting that those tests do not contain difficulty tests only for the Frontier chain. They also test other forks (like Homestead). I am not sure why they have `Frontier` in the name since other forks are included.

In order to limit which tests run, so that we can pass tests progressively as we implement various forks, we check the block number in the test to ascertain which fork we're testing. For now, we are only testing Frontier block headers.

Other changes
=============

By adding the tests, we discovered that we our difficulty calculations for Frontier (we're only testing Frontier so far) were wrong. The errors were all an off-by-one type of errors, so we make use of Elixir's built-in integer division `div/2` function instead of the `MathHelper.floor` function when calculating a block header's difficulty.

For an example of how the test failures look, see this failed build https://circleci.com/gh/poanetwork/mana/1816:

<img width="928" alt="screen shot 2018-08-14 at 9 06 20 am" src="https://user-images.githubusercontent.com/3245976/44093545-e50d7ed6-9fa1-11e8-916f-85176349dbec.png">
<img width="766" alt="screen shot 2018-08-14 at 9 06 30 am" src="https://user-images.githubusercontent.com/3245976/44093546-e5210406-9fa1-11e8-9a9d-45dc7d94df07.png">
