### PR TITLE
Add Homestead difficulty common tests

### DIFF
--- a/apps/evm/lib/block/header.ex
+++ b/apps/evm/lib/block/header.ex
@@ -400,7 +400,7 @@ defmodule Block.Header do
       ...> )
       268_734_142
   """
-  @spec get_difficulty(t, t | nil, integer()) :: integer()
+  @spec get_difficulty(t, t | nil, integer(), integer(), integer(), integer()) :: integer()
   def get_difficulty(
         header,
         parent_header,
@@ -414,7 +414,7 @@ defmodule Block.Header do
         initial_difficulty
 
       is_before_homestead?(header, homestead_block) ->
-        get_frontier_difficulty(
+        calculate_frontier_difficulty(
           header,
           parent_header,
           minimum_difficulty,
@@ -422,20 +422,33 @@ defmodule Block.Header do
         )
 
       true ->
-        # Find the delta from parent block
-        difficulty_delta =
-          difficulty_x(parent_header.difficulty, difficulty_bound_divisor) *
-            homestead_difficulty_parameter(header, parent_header)
-
-        # Add delta to parent's difficulty
-        next_difficulty = parent_header.difficulty + difficulty_delta + difficulty_e(header)
-
-        # Return next difficulty, capped at minimum
-        max(minimum_difficulty, next_difficulty)
+        calculate_homestead_difficulty(
+          header,
+          parent_header,
+          minimum_difficulty,
+          difficulty_bound_divisor
+        )
     end
   end
 
-  defp get_frontier_difficulty(
+  @spec calculate_homestead_difficulty(t, t | nil, integer(), integer()) :: integer()
+  defp calculate_homestead_difficulty(
+         header,
+         parent_header,
+         minimum_difficulty,
+         difficulty_bound_divisor
+       ) do
+    difficulty_delta =
+      difficulty_x(parent_header.difficulty, difficulty_bound_divisor) *
+        homestead_difficulty_parameter(header, parent_header)
+
+    next_difficulty = parent_header.difficulty + difficulty_delta + difficulty_e(header)
+
+    max(minimum_difficulty, next_difficulty)
+  end
+
+  @spec calculate_frontier_difficulty(t, t | nil, integer(), integer()) :: integer()
+  defp calculate_frontier_difficulty(
          header,
          parent_header,
          minimum_difficulty,


### PR DESCRIPTION
Closes #349

What changed?
============

The difficulty algorithm for Homestead was already implemented. We simply extract it here into a private function to have the same level of abstraction in the `Block.Header.get_difficulty` function.

More importantly
================

There is something strange with the common test files for difficulty:

Under the `BasicTests` directory of ethereum common tests, there are files named `difficultyFrontier.json` and `difficultyHomestead.json`. Each of them contains tests for Frontier and for Homestead (and other forks prior to Byzantium as well). The strange thing is that the Homestead tests in the `difficultyFrontier.json` file fail when tested against the Homestead implementation, and the same is true of the Frontier tests in `difficultyHomestead.json` file when tested against the Frontier implementation.

I don't know why that happens, but my guess is that this is a side effect of auto-generating the common test files. They probably include all the tests they have, but they generate them based on a particular implementation of the difficulty equation. So the `Homestead` blocks in the `difficultyFrontier.json` file are incorrect because they use the frontier implementation of the difficulty equation. And the same is true of the `Frontier` blocks found in the `difficultyHomestead.json` file.

So what we do is simply ignore the Homestead blocks when we are testing `difficultyFrontier.json` file. And we ignore the Frontier blocks when we are testing the `difficultyHomestead.json` file.