### PR TITLE
Fix test_group from path retrieval in state tests

### DIFF
--- a/apps/blockchain/test/blockchain/state_test.exs
+++ b/apps/blockchain/test/blockchain/state_test.exs
@@ -471,7 +471,7 @@ defmodule Blockchain.StateTest do
 
   test "Blockchain state tests" do
     Enum.each(test_directories(), fn directory_path ->
-      test_group = Enum.fetch!(String.split(directory_path, "/"), 4)
+      test_group = Enum.fetch!(String.split(directory_path, "/"), -1)
 
       directory_path
       |> tests()

--- a/apps/blockchain/test/blockchain/state_test.exs
+++ b/apps/blockchain/test/blockchain/state_test.exs
@@ -471,7 +471,7 @@ defmodule Blockchain.StateTest do
 
   test "Blockchain state tests" do
     Enum.each(test_directories(), fn directory_path ->
-      test_group = Enum.fetch!(String.split(directory_path, "/"), -1)
+      test_group = test_group_from_directory(directory_path)
 
       directory_path
       |> tests()
@@ -668,6 +668,12 @@ defmodule Blockchain.StateTest do
     logs
     |> ExRLP.encode()
     |> Keccak.kec()
+  end
+
+  defp test_group_from_directory(directory_path) do
+    directory_path
+    |> String.split("/")
+    |> Enum.fetch!(-1)
   end
 
   defp test_directories do


### PR DESCRIPTION
The `test_group` variable, which is used to determine known failures, was incorrectly returning the wrong part of the path (likely due to us changing from a relative path to an absolute path at some point). It was usually returning `mana`. We reverse the index to grab the elements from the end of the list so that we always get the group name, regardless of where the path starts.