### PR TITLE
Increment nonce of touched accounts on CREATE

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ Ethereum common tests are created for all clients to test against. We plan to pr
    - [BlockchainTests](https://github.com/ethereum/tests/tree/develop/BlockchainTests) (Includes GeneralStateTests) 1275/1275 = 100% passing
    - [GeneralStateTests](https://github.com/ethereum/tests/tree/develop/GeneralStateTests) 1089/1114 = 97.8% passing
 - [x] EIP158
-   - [BlockchainTests](https://github.com/ethereum/tests/tree/develop/BlockchainTests) (Includes GeneralStateTests) 1231/1233 = 99.8% passing
-   - [GeneralStateTests](https://github.com/ethereum/tests/tree/develop/GeneralStateTests) 1174/1181 = 99.4% passing
+   - [BlockchainTests](https://github.com/ethereum/tests/tree/develop/BlockchainTests) (Includes GeneralStateTests) 1232/1233 = 99.9% passing
+   - [GeneralStateTests](https://github.com/ethereum/tests/tree/develop/GeneralStateTests) 1175/1181= 99.5% passing
 - [x] Byzantium
    - [GeneralStateTests](https://github.com/ethereum/tests/tree/develop/GeneralStateTests) 3204/4754 = 67.4% passing
 - [ ] Constantinople:  View the community [Constantinople Project Tracker](https://github.com/ethereum/pm/issues/53).

--- a/apps/blockchain/lib/blockchain/contract.ex
+++ b/apps/blockchain/lib/blockchain/contract.ex
@@ -6,7 +6,6 @@ defmodule Blockchain.Contract do
   in sections 7 and 8 of the Yellow Paper.
   """
 
-  alias Blockchain.Account
   alias Blockchain.Contract.{CreateContract, MessageCall}
 
   @doc """
@@ -27,16 +26,4 @@ defmodule Blockchain.Contract do
   @spec message_call(MessageCall.t()) ::
           {EVM.state(), EVM.Gas.t(), EVM.SubState.t(), EVM.VM.output()}
   def message_call(params), do: MessageCall.execute(params)
-
-  @doc """
-  Creates a blank contract prior to initialization code
-  being run and sets its nonce to 1, as defined in Eq.(78-82) of the Yellow Paper.
-  """
-  @spec create_blank(EVM.state(), EVM.address(), EVM.address(), EVM.Wei.t(), integer()) ::
-          EVM.state()
-  def create_blank(state, contract_address, sender_address, endowment, nonce) do
-    state
-    |> Account.put_account(contract_address, %Account{nonce: nonce})
-    |> Account.transfer!(sender_address, contract_address, endowment)
-  end
 end

--- a/apps/blockchain/lib/eth_common_test/helpers.ex
+++ b/apps/blockchain/lib/eth_common_test/helpers.ex
@@ -85,6 +85,6 @@ defmodule EthCommonTest.Helpers do
 
   @spec ethereum_common_tests_path :: String.t()
   def ethereum_common_tests_path do
-    "../../ethereum_common_tests/"
+    Path.join(System.cwd(), "/../../ethereum_common_tests")
   end
 end

--- a/apps/blockchain/test/blockchain/contract_test.exs
+++ b/apps/blockchain/test/blockchain/contract_test.exs
@@ -1,35 +1,4 @@
 defmodule Blockchain.ContractTest do
   use ExUnit.Case, async: true
   doctest Blockchain.Contract
-
-  alias Blockchain.{Account, Contract}
-  alias MerklePatriciaTree.Trie
-
-  setup do
-    db = MerklePatriciaTree.Test.random_ets_db(:contract_test)
-    {:ok, %{db: db}}
-  end
-
-  describe "create_blank/4" do
-    test "creates valid blank contract", %{db: db} do
-      sender_address = <<0x01::160>>
-      contract_address = <<0x02::160>>
-      sender_account = %Account{balance: 10}
-      endowment = 6
-
-      accounts =
-        db
-        |> Trie.new()
-        |> Account.put_account(sender_address, sender_account)
-        |> Contract.create_blank(contract_address, sender_address, endowment, 0)
-        |> Account.get_accounts([sender_address, contract_address])
-
-      expected_accounts = [
-        %Account{balance: sender_account.balance - endowment},
-        %Account{balance: endowment, nonce: 0}
-      ]
-
-      assert accounts == expected_accounts
-    end
-  end
 end

--- a/apps/blockchain/test/blockchain/state_test.exs
+++ b/apps/blockchain/test/blockchain/state_test.exs
@@ -415,7 +415,6 @@ defmodule Blockchain.StateTest do
     "EIP158" => [
       "stTransactionTest/EmptyTransaction2",
       "stSpecialTest/failed_tx_xcf416c53",
-      "stRevertTest/RevertPrefound",
       "stRevertTest/RevertOpcodeMultipleSubCalls"
     ],
     "Frontier" => [

--- a/apps/evm/lib/evm/configuration.ex
+++ b/apps/evm/lib/evm/configuration.ex
@@ -54,8 +54,8 @@ defprotocol EVM.Configuration do
   def exp_byte_cost(t)
 
   # EIP161-a
-  @spec start_nonce(t) :: integer()
-  def start_nonce(t)
+  @spec increment_nonce_on_create?(t) :: boolean()
+  def increment_nonce_on_create?(t)
 
   # EIP161-b
   @spec empty_account_value_transfer?(t) :: boolean()

--- a/apps/evm/lib/evm/configuration/byzantium.ex
+++ b/apps/evm/lib/evm/configuration/byzantium.ex
@@ -55,8 +55,9 @@ defimpl EVM.Configuration, for: EVM.Configuration.Byzantium do
   def limit_contract_code_size?(config, size),
     do: Configuration.limit_contract_code_size?(config.fallback_config, size)
 
-  @spec start_nonce(Configuration.t()) :: integer()
-  def start_nonce(config), do: Configuration.start_nonce(config.fallback_config)
+  @spec increment_nonce_on_create?(Configuration.t()) :: boolean()
+  def increment_nonce_on_create?(config),
+    do: Configuration.increment_nonce_on_create?(config.fallback_config)
 
   @spec empty_account_value_transfer?(Configuration.t()) :: boolean()
   def empty_account_value_transfer?(config),

--- a/apps/evm/lib/evm/configuration/eip150.ex
+++ b/apps/evm/lib/evm/configuration/eip150.ex
@@ -62,8 +62,9 @@ defimpl EVM.Configuration, for: EVM.Configuration.EIP150 do
   def limit_contract_code_size?(config, _),
     do: Configuration.limit_contract_code_size?(config.fallback_config)
 
-  @spec start_nonce(Configuration.t()) :: integer()
-  def start_nonce(config), do: Configuration.start_nonce(config.fallback_config)
+  @spec increment_nonce_on_create?(Configuration.t()) :: boolean()
+  def increment_nonce_on_create?(config),
+    do: Configuration.increment_nonce_on_create?(config.fallback_config)
 
   @spec empty_account_value_transfer?(Configuration.t()) :: boolean()
   def empty_account_value_transfer?(config),

--- a/apps/evm/lib/evm/configuration/eip158.ex
+++ b/apps/evm/lib/evm/configuration/eip158.ex
@@ -2,7 +2,7 @@ defmodule EVM.Configuration.EIP158 do
   defstruct fallback_config: EVM.Configuration.EIP150.new(),
             exp_byte_cost: 50,
             code_size_limit: 24_577,
-            start_nonce: 1,
+            increment_nonce_on_create: true,
             empty_account_value_transfer: true,
             clean_touched_accounts: true
 
@@ -57,8 +57,8 @@ defimpl EVM.Configuration, for: EVM.Configuration.EIP158 do
   @spec limit_contract_code_size?(Configuration.t(), integer()) :: boolean()
   def limit_contract_code_size?(config, size), do: size >= config.code_size_limit
 
-  @spec start_nonce(Configuration.t()) :: integer()
-  def start_nonce(config), do: config.start_nonce
+  @spec increment_nonce_on_create?(Configuration.t()) :: boolean()
+  def increment_nonce_on_create?(config), do: config.increment_nonce_on_create
 
   @spec empty_account_value_transfer?(Configuration.t()) :: boolean()
   def empty_account_value_transfer?(config), do: config.empty_account_value_transfer

--- a/apps/evm/lib/evm/configuration/frontier.ex
+++ b/apps/evm/lib/evm/configuration/frontier.ex
@@ -12,7 +12,7 @@ defmodule EVM.Configuration.Frontier do
             fail_nested_operation: true,
             exp_byte_cost: 10,
             limit_contract_code_size: false,
-            start_nonce: 0,
+            increment_nonce_on_create: false,
             empty_account_value_transfer: false,
             clean_touched_accounts: false,
             has_revert: false,
@@ -65,8 +65,8 @@ defimpl EVM.Configuration, for: EVM.Configuration.Frontier do
   @spec limit_contract_code_size?(Configuration.t(), integer()) :: boolean()
   def limit_contract_code_size?(config, _), do: config.limit_contract_code_size
 
-  @spec start_nonce(Configuration.t()) :: integer()
-  def start_nonce(config), do: config.start_nonce
+  @spec increment_nonce_on_create?(Configuration.t()) :: boolean()
+  def increment_nonce_on_create?(config), do: config.increment_nonce_on_create
 
   @spec empty_account_value_transfer?(Configuration.t()) :: boolean()
   def empty_account_value_transfer?(config), do: config.empty_account_value_transfer

--- a/apps/evm/lib/evm/configuration/homestead.ex
+++ b/apps/evm/lib/evm/configuration/homestead.ex
@@ -55,8 +55,9 @@ defimpl EVM.Configuration, for: EVM.Configuration.Homestead do
   def limit_contract_code_size?(config, _),
     do: Configuration.limit_contract_code_size?(config.fallback_config)
 
-  @spec start_nonce(Configuration.t()) :: integer()
-  def start_nonce(config), do: Configuration.start_nonce(config.fallback_config)
+  @spec increment_nonce_on_create?(Configuration.t()) :: boolean()
+  def increment_nonce_on_create?(config),
+    do: Configuration.increment_nonce_on_create?(config.fallback_config)
 
   @spec empty_account_value_transfer?(Configuration.t()) :: boolean()
   def empty_account_value_transfer?(config),


### PR DESCRIPTION
This closes #368.

What changed?
=============

We increment the nonce of an account when it is touched on CREATE (operation or
transaction call). We change the implementation of `start_nonce` introduced in
https://github.com/poanetwork/mana/pull/353, to `increment_nonce_on_create`
since I think that may be what is described in EIP 161 part a:

> a. Account creation transactions and the CREATE operation SHALL, prior to
the execution of the initialisation code, increment the nonce over and
above its normal starting value by one (for normal networks, this will be
simply 1, however test-nets with non-zero default starting nonces will be
different).

Note that the test-nests comment above would be configured at the chain level
not at the EVM-fork level. So I think it is safe to replace the `start_nonce`
implementation with this `increment_nonce_on_create`, though I am happy to
change the name of the configuration if something else seems more appropriate
and/or descriptive.