### PR TITLE
Run Blockchain Tests in different processes

### DIFF
--- a/apps/blockchain/test/blockchain_test.exs
+++ b/apps/blockchain/test/blockchain_test.exs
@@ -58,7 +58,7 @@ defmodule BlockchainTest do
   end
 
   defp fork_timeout_error(fork, stacktrace, timeout) do
-    "[#{fork}] timeout after #{inspect(timeout)} miliseconds: #{inspect(stacktrace)}"
+    "[#{fork}] timeout after #{inspect(timeout)} milliseconds: #{inspect(stacktrace)}"
   end
 
   defp spawn_tests_for_fork(fork) do
@@ -95,13 +95,13 @@ defmodule BlockchainTest do
 
   defp run_tests_for_fork(fork) do
     tests()
-    |> Enum.reject(&known_fork_failures?(&1, fork))
+    |> Stream.reject(&known_fork_failures?(&1, fork))
     |> Enum.flat_map(fn json_test_path ->
       json_test_path
       |> read_test()
-      |> Enum.filter(&fork_test(&1, fork))
-      |> Enum.map(&run_test/1)
-      |> Enum.filter(&failing_tests/1)
+      |> Stream.filter(&fork_test?(&1, fork))
+      |> Stream.map(&run_test/1)
+      |> Enum.filter(&failing_test?/1)
     end)
   end
 
@@ -119,7 +119,7 @@ defmodule BlockchainTest do
     |> Poison.decode!()
   end
 
-  defp fork_test({_test_name, json_test}, fork) do
+  defp fork_test?({_test_name, json_test}, fork) do
     fork == json_test["network"]
   end
 
@@ -174,7 +174,7 @@ defmodule BlockchainTest do
     "[#{fork}] #{test_name}: expected #{inspect(expected)}, but received #{inspect(actual)}"
   end
 
-  defp failing_tests({_fork, _test_name, expected, actual}) do
+  defp failing_test?({_fork, _test_name, expected, actual}) do
     expected != actual
   end
 


### PR DESCRIPTION
This is a first step for https://github.com/poanetwork/mana/issues/330

What changed?
=============

We are currently running all blockchain tests (that is the ethereum common tests under `/BlockchainTests` directory) in a single ExUnit `test`. So we can't get any of the automatic parallelization that ExUnit's `async: true` provides.

Here we split each hardfork we are testing into a separate process. We then combine the results and assert whether or not the ExUnit test succeeded or failed as a whole.

In a very limited sample (two CI builds), this seems to shave between 6 and 7 minutes off the build: the [latest build](https://circleci.com/workflow-run/0bc29d11-7d5e-494d-a819-7281d37ea600) I had seen was 32:13 minutes, and the two runs for this PR were at [25:46](https://circleci.com/workflow-run/a990c3f1-981d-4420-9bc0-edb232d3622e) and [24:49](https://circleci.com/workflow-run/82f462b2-c70b-4b22-9777-d8774df960e0).