### PR TITLE
Run state tests in different processes

### DIFF
--- a/apps/blockchain/mix.exs
+++ b/apps/blockchain/mix.exs
@@ -17,7 +17,8 @@ defmodule Blockchain.Mixfile do
       ],
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
-      deps: deps()
+      deps: deps(),
+      elixirc_paths: elixirc_paths(Mix.env())
     ]
   end
 
@@ -57,4 +58,7 @@ defmodule Blockchain.Mixfile do
       {:poison, "~> 3.1.0"}
     ]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 end

--- a/apps/blockchain/test/blockchain/state_test.exs
+++ b/apps/blockchain/test/blockchain/state_test.exs
@@ -462,17 +462,81 @@ defmodule Blockchain.StateTest do
   }
 
   test "Blockchain state tests" do
-    for fork <- forks_with_existing_implementation() do
-      tests()
-      |> Enum.reject(&known_fork_failure?(&1, fork))
-      |> Enum.each(fn test_path ->
-        test_path
-        |> read_state_test_file()
-        |> Enum.filter(&fork_test?(&1, fork))
-        |> Enum.flat_map(&run_test(&1, fork))
-        |> Enum.filter(&failed_test?/1)
-        |> make_assertions()
-      end)
+    forks_with_existing_implementation()
+    |> Enum.map(&spawn_forks/1)
+    |> Enum.flat_map(&receive_replies/1)
+    |> make_assertions()
+  end
+
+  defp run_tests_for_fork(fork) do
+    tests()
+    |> Enum.reject(&known_fork_failure?(&1, fork))
+    |> Enum.flat_map(fn test_path ->
+      test_path
+      |> read_state_test_file()
+      |> Enum.filter(&fork_test?(&1, fork))
+      |> Enum.flat_map(&run_test(&1, fork))
+      |> Enum.filter(&failed_test?/1)
+    end)
+  end
+
+  defp spawn_forks(fork) do
+    {fork_pid, fork_ref} = spawn_tests_for_fork(fork)
+    {fork, fork_pid, fork_ref}
+  end
+
+  defp receive_replies({fork, fork_pid, fork_ref}) do
+    ten_minute_timeout = 1000 * 60 * 10
+
+    case receive_fork_reply(fork_pid, fork_ref, ten_minute_timeout) do
+      {:fork_failure, error} ->
+        raise fork_failure_error(fork, error)
+
+      {:fork_timeout, stacktrace} ->
+        raise fork_timeout_error(fork, stacktrace, ten_minute_timeout)
+
+      test_failures ->
+        test_failures
+    end
+  end
+
+  defp fork_failure_error(fork, error) do
+    "[#{fork}] error: #{inspect(error)}"
+  end
+
+  defp fork_timeout_error(fork, stacktrace, timeout) do
+    "[#{fork}] timeout after #{inspect(timeout)} milliseconds: #{inspect(stacktrace)}"
+  end
+
+  defp spawn_tests_for_fork(fork) do
+    parent = self()
+
+    spawn_monitor(fn ->
+      failing_tests = run_tests_for_fork(fork)
+      send(parent, {self(), :fork_tests_finished, failing_tests})
+      exit(:shutdown)
+    end)
+  end
+
+  defp receive_fork_reply(fork_pid, fork_ref, timeout) do
+    receive do
+      {^fork_pid, :fork_tests_finished, failing_tests} ->
+        Process.demonitor(fork_ref, [:flush])
+        failing_tests
+
+      {:DOWN, ^fork_ref, :process, ^fork_pid, error} ->
+        {:fork_failure, error}
+    after
+      timeout ->
+        case Process.info(fork_pid, :current_stacktrace) do
+          {:current_stacktrace, stacktrace} ->
+            Process.demonitor(fork_ref, [:flush])
+            Process.exit(fork_pid, :kill)
+            {:fork_timeout, stacktrace}
+
+          nil ->
+            receive_fork_reply(fork_pid, fork_ref, timeout)
+        end
     end
   end
 

--- a/apps/blockchain/test/blockchain/state_test.exs
+++ b/apps/blockchain/test/blockchain/state_test.exs
@@ -470,12 +470,12 @@ defmodule Blockchain.StateTest do
 
   defp run_tests_for_fork(fork) do
     tests()
-    |> Enum.reject(&known_fork_failure?(&1, fork))
+    |> Stream.reject(&known_fork_failure?(&1, fork))
     |> Enum.flat_map(fn test_path ->
       test_path
       |> read_state_test_file()
-      |> Enum.filter(&fork_test?(&1, fork))
-      |> Enum.flat_map(&run_test(&1, fork))
+      |> Stream.filter(&fork_test?(&1, fork))
+      |> Stream.flat_map(&run_test(&1, fork))
       |> Enum.filter(&failed_test?/1)
     end)
   end
@@ -486,7 +486,7 @@ defmodule Blockchain.StateTest do
   end
 
   defp receive_replies({fork, fork_pid, fork_ref}) do
-    ten_minute_timeout = 1000 * 60 * 10
+    ten_minute_timeout = 1000 * 60 * 15
 
     case receive_fork_reply(fork_pid, fork_ref, ten_minute_timeout) do
       {:fork_failure, error} ->

--- a/apps/blockchain/test/blockchain_test.exs
+++ b/apps/blockchain/test/blockchain_test.exs
@@ -3,7 +3,7 @@ defmodule BlockchainTest do
 
   import EthCommonTest.Helpers
 
-  alias Blockchain.{Blocktree, Account, Transaction, Chain}
+  alias Blockchain.{Blocktree, Account, Transaction, Chain, AsyncCommonTests}
   alias MerklePatriciaTree.Trie
   alias Blockchain.Account.Storage
   alias Block.Header
@@ -28,69 +28,9 @@ defmodule BlockchainTest do
 
   test "runs blockchain tests" do
     forks_with_existing_implementation()
-    |> Enum.map(&spawn_forks/1)
-    |> Enum.flat_map(&receive_replies/1)
+    |> AsyncCommonTests.spawn_forks(&run_tests_for_fork/1)
+    |> AsyncCommonTests.receive_replies()
     |> make_assertions()
-  end
-
-  defp spawn_forks(fork) do
-    {fork_pid, fork_ref} = spawn_tests_for_fork(fork)
-    {fork, fork_pid, fork_ref}
-  end
-
-  defp receive_replies({fork, fork_pid, fork_ref}) do
-    ten_minute_timeout = 1000 * 60 * 10
-
-    case receive_fork_reply(fork_pid, fork_ref, ten_minute_timeout) do
-      {:fork_failure, error} ->
-        raise fork_failure_error(fork, error)
-
-      {:fork_timeout, stacktrace} ->
-        raise fork_timeout_error(fork, stacktrace, ten_minute_timeout)
-
-      test_failures ->
-        test_failures
-    end
-  end
-
-  defp fork_failure_error(fork, error) do
-    "[#{fork}] error: #{inspect(error)}"
-  end
-
-  defp fork_timeout_error(fork, stacktrace, timeout) do
-    "[#{fork}] timeout after #{inspect(timeout)} milliseconds: #{inspect(stacktrace)}"
-  end
-
-  defp spawn_tests_for_fork(fork) do
-    parent = self()
-
-    spawn_monitor(fn ->
-      failing_tests = run_tests_for_fork(fork)
-      send(parent, {self(), :fork_tests_finished, failing_tests})
-      exit(:shutdown)
-    end)
-  end
-
-  defp receive_fork_reply(fork_pid, fork_ref, timeout) do
-    receive do
-      {^fork_pid, :fork_tests_finished, failing_tests} ->
-        Process.demonitor(fork_ref, [:flush])
-        failing_tests
-
-      {:DOWN, ^fork_ref, :process, ^fork_pid, error} ->
-        {:fork_failure, error}
-    after
-      timeout ->
-        case Process.info(fork_pid, :current_stacktrace) do
-          {:current_stacktrace, stacktrace} ->
-            Process.demonitor(fork_ref, [:flush])
-            Process.exit(fork_pid, :kill)
-            {:fork_timeout, stacktrace}
-
-          nil ->
-            receive_fork_reply(fork_pid, fork_ref, timeout)
-        end
-    end
   end
 
   defp run_tests_for_fork(fork) do

--- a/apps/blockchain/test/support/async_common_tests.ex
+++ b/apps/blockchain/test/support/async_common_tests.ex
@@ -1,0 +1,87 @@
+defmodule Blockchain.AsyncCommonTests do
+  @moduledoc """
+  Module to help spawn a process for each ethereum fork when testing Ethereum
+  Common Tests
+  """
+
+  @ten_minutes 1000 * 60 * 10
+
+  @doc """
+  Spawns a process for given `fork` and calls the function provided to get
+  results.
+
+  Returns a three tuple, `{fork_name, fork_process_pid, fork_ref}` to be
+  used with `receive_replies/1`.
+  """
+  def spawn_forks(forks, run_fork_test_fn) do
+    Enum.map(forks, fn fork ->
+      {fork_pid, fork_ref} = spawn_tests_for_fork(fork, run_fork_test_fn)
+      {fork, fork_pid, fork_ref}
+    end)
+  end
+
+  @doc """
+  Expects list of three tuples returned from `spawn_forks/2` and waits for
+  messages from spawned processes.
+
+  This will return an aggregated list of the results returned by the function
+  provided to `spawn_forks/2`, or it will raise an error if one of the fork
+  processes crashes or takes too long.
+  """
+  def receive_replies(replies, timeout \\ @ten_minutes) when is_list(replies) do
+    Enum.flat_map(replies, &receive_reply(&1, timeout))
+  end
+
+  defp receive_reply({fork, fork_pid, fork_ref}, timeout) do
+    case receive_fork_reply(fork_pid, fork_ref, timeout) do
+      {:fork_failure, error} ->
+        raise fork_failure_error(fork, error)
+
+      {:fork_timeout, stacktrace} ->
+        raise fork_timeout_error(fork, stacktrace, timeout)
+
+      results ->
+        results
+    end
+  end
+
+  defp fork_failure_error(fork, error) do
+    "[#{fork}] error: #{inspect(error)}"
+  end
+
+  defp fork_timeout_error(fork, stacktrace, timeout) do
+    "[#{fork}] timeout after #{inspect(timeout)} milliseconds: #{inspect(stacktrace)}"
+  end
+
+  defp spawn_tests_for_fork(fork, run_fork_test_fn) do
+    parent = self()
+
+    spawn_monitor(fn ->
+      results = run_fork_test_fn.(fork)
+      send(parent, {self(), :fork_tests_finished, results})
+      exit(:shutdown)
+    end)
+  end
+
+  defp receive_fork_reply(fork_pid, fork_ref, timeout) do
+    receive do
+      {^fork_pid, :fork_tests_finished, results} ->
+        Process.demonitor(fork_ref, [:flush])
+        results
+
+      {:DOWN, ^fork_ref, :process, ^fork_pid, error} ->
+        {:fork_failure, error}
+    after
+      timeout ->
+        case Process.info(fork_pid, :current_stacktrace) do
+          {:current_stacktrace, stacktrace} ->
+            Process.demonitor(fork_ref, [:flush])
+            Process.exit(fork_pid, :kill)
+            {:fork_timeout, stacktrace}
+
+          nil ->
+            receive_fork_reply(fork_pid, fork_ref, timeout)
+        end
+    end
+  end
+end


### PR DESCRIPTION
This relates to #330

What changed?
=============

We are currently running all state tests (that is the ethereum common tests under `/GeneralStateTests` directory) in a single ExUnit test. So we can't get any of the automatic parallelization that ExUnit's `async: true` provides.

Here we split each hardfork we are testing into a separate process. We then combine the results and assert whether or not the ExUnit test succeeded or failed as a whole.

We have already done this in `blockchain_tests` so we extract common functionality related to spawning processes for each fork into a shared module called `AsyncCommonTests` (could use a better name).

From a very brief look the builds, it looks like this shaves another 4-6 minutes off of the build.

So https://github.com/poanetwork/mana/pull/374 and this PR combined will have shaved between 10-12 mins off the build.