### PR TITLE
Parallelize tests by separating blockchain/state_tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 jobs:
   build:
-    parallelism: 1
+    parallelism: 3
     resource_class: large
     docker:
       - image: circleci/elixir:1.7.2
@@ -78,7 +78,10 @@ jobs:
           paths: "_build"
 
       - run:
-          command: mix test --exclude network --exclude pending
+          name: Run Tests
+          command: |
+            echo "Running in node $CIRCLE_NODE_INDEX"
+            bin/test_command_for_node $CIRCLE_NODE_INDEX
           no_output_timeout: "20m"
 
       - persist_to_workspace:

--- a/apps/blockchain/test/blockchain/state_test.exs
+++ b/apps/blockchain/test/blockchain/state_test.exs
@@ -463,6 +463,8 @@ defmodule Blockchain.StateTest do
 
   @timeout 1000 * 60 * 15
 
+  @tag :ethereum_common_tests
+  @tag :state_common_tests
   test "Blockchain state tests" do
     forks_with_existing_implementation()
     |> AsyncCommonTests.spawn_forks(&run_tests_for_fork/1)

--- a/apps/blockchain/test/blockchain_test.exs
+++ b/apps/blockchain/test/blockchain_test.exs
@@ -26,6 +26,8 @@ defmodule BlockchainTest do
     "HomesteadToEIP150At5" => []
   }
 
+  @tag :ethereum_common_tests
+  @tag :blockchain_common_tests
   test "runs blockchain tests" do
     forks_with_existing_implementation()
     |> AsyncCommonTests.spawn_forks(&run_tests_for_fork/1)

--- a/bin/test_command_for_node
+++ b/bin/test_command_for_node
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+CI_NODE=$1
+
+echo_and_run() {
+  # echo the command so we can see what we're running
+  echo "\$ $@"
+  "$@"
+}
+
+# Exit if any subcommand fails
+set -e
+
+if [ $CI_NODE -eq 2 ]; then
+  echo_and_run mix cmd --app blockchain mix test --only blockchain_common_tests
+elif [ $CI_NODE -eq 1 ]; then
+  echo_and_run mix cmd --app blockchain mix test --only state_common_tests
+else
+  echo_and_run mix test --exclude network --exclude pending --exclude ethereum_common_tests
+fi


### PR DESCRIPTION
This closes #330. It is the third step (after #374 and #376) to improve the build times.

What changed?
=============

We parallelize the builds by separating the blockchain common tests and state tests into their own builds and then the rest of the tests into another build.

We could use some other CircleCI features such as `--split-by=timings`, but since we only have two tests that take a really long time, and we know which tests those are, it seems simpler to separate those two tests into their own containers.

From a very limited set of data, it seems like this saves us ~9 minutes on a single build run.