### PR TITLE
Split tests by groups instead of forks

### DIFF
--- a/apps/blockchain/test/blockchain/state_test.exs
+++ b/apps/blockchain/test/blockchain/state_test.exs
@@ -453,18 +453,33 @@ defmodule Blockchain.StateTest do
   }
 
   @fifteen_minutes 1000 * 60 * 15
+  @num_test_groups 10
 
   @tag :ethereum_common_tests
   @tag :state_common_tests
   test "Blockchain state tests" do
-    forks_with_existing_implementation()
-    |> Task.async_stream(&run_tests_for_fork(&1), timeout: @fifteen_minutes)
+    grouped_test_per_fork()
+    |> Task.async_stream(&run_tests(&1), timeout: @fifteen_minutes)
     |> Enum.flat_map(fn {:ok, results} -> results end)
     |> make_assertions()
   end
 
-  defp run_tests_for_fork(fork) do
-    tests()
+  defp grouped_test_per_fork do
+    for fork <- forks_with_existing_implementation(),
+        test_group <- split_tests_into_groups(@num_test_groups),
+        do: {fork, test_group}
+  end
+
+  defp split_tests_into_groups(num_groups_desired) do
+    all_tests = tests()
+    test_count = Enum.count(all_tests)
+    tests_per_group = div(test_count, num_groups_desired)
+
+    Enum.chunk_every(all_tests, tests_per_group)
+  end
+
+  defp run_tests({fork, tests}) do
+    tests
     |> Stream.reject(&known_fork_failure?(&1, fork))
     |> Enum.flat_map(fn test_path ->
       test_path


### PR DESCRIPTION
Part of https://github.com/poanetwork/mana/issues/330

What changed?
=============

In order to improve the build time, we split our tests by forks in previous commits. When we started using `Task.async_stream`, it became apparent that we could just split tests by groups of tests rather than by forks. What we end up doing here is splitting all tests into ten groups for each fork. We then run those tests asynchronously.

We tested splitting tests into 20 groups but we did not see an improvement in build times. I think that is due to the fact that the build can only be as fast as the slowest test we have. And I think one (or more) of the tests we have take several minutes.

For a sample of CI runs in this branch, see https://circleci.com/gh/poanetwork/workflows/mana/tree/gv-split-tests-by-directory