### PR TITLE
Extract difficulty hardfork check to Block

### DIFF
--- a/.dialyzer.ignore-warnings
+++ b/.dialyzer.ignore-warnings
@@ -92,8 +92,8 @@ r', 'beneficiary':=_, 'difficulty':='nil', 'extra_data':=_, 'gas_limit':=0, 'gas
 apps/merkle_patricia_tree/lib/merkle_patricia_tree/trie/helper.ex:41: Guard test is_binary(__@1::<<_:4>
 >) can never succeed
 
-apps/blockchain/lib/blockchain/block.ex:675: Function add_transactions/3 has no local return
-apps/blockchain/lib/blockchain/block.ex:675: The call 'Elixir.Blockchain.Block':add_transactions(_@1
+apps/blockchain/lib/blockchain/block.ex:691: Function add_transactions/3 has no local return
+apps/blockchain/lib/blockchain/block.ex:691: The call 'Elixir.Blockchain.Block':add_transactions(_@1
 ::any(),_@2::any(),_@3::any(),#{'__struct__':='Elixir.EVM.Configuration.Frontier', 'contract_creatio
 n_cost':=21000, 'has_delegate_call':='false'}) will never return since the success typing is (#{'__s
 truct__':='Elixir.Blockchain.Block', 'block_hash':='nil' | <<_:256>>, 'header':=#{'__struct__':='Eli

--- a/apps/evm/test/block/header_test.exs
+++ b/apps/evm/test/block/header_test.exs
@@ -7,12 +7,6 @@ defmodule Block.HeaderTest do
   alias Block.Header
   alias EVM.EthereumCommonTestsHelper, as: Helper
 
-  @fork_block_num %{
-    frontier: 1,
-    homestead: 1_150_000,
-    byzantium: 4_370_000
-  }
-
   describe "Difficulty Tests (Ethereum Common Tests)" do
     test "calculates Frontier difficulty" do
       "difficultyFrontier.json"
@@ -38,7 +32,7 @@ defmodule Block.HeaderTest do
 
     {header, parent_header} = build_headers(test_data)
 
-    difficulty = Header.get_frontier_difficulty(header, parent_header, 131_072, 131_072, 2048)
+    difficulty = Header.get_frontier_difficulty(header, parent_header)
 
     {name, expected_difficulty, difficulty}
   end
@@ -48,7 +42,7 @@ defmodule Block.HeaderTest do
 
     {header, parent_header} = build_headers(test_data)
 
-    difficulty = Header.get_homestead_difficulty(header, parent_header, 131_072, 131_072, 2048)
+    difficulty = Header.get_homestead_difficulty(header, parent_header)
 
     {name, expected_difficulty, difficulty}
   end


### PR DESCRIPTION
Why:

We would like to implement the next difficulty calculation for hardfork
Byzantium. With the current setup we would need to pass more information
about the chain into EVM.Block.get_difficulty. Rather than couple EVM
and Blockchain more, it would be nice to clean up the separation.

This commit:

Extracts difficulty hardfork check to Blockchain.Block instead of
passing chain parameters to Block.Header. The logic for the `chain`
lives in the Blockchain, so it makes sense make our Homestead vs
Frontier check there.