### PR TITLE
Implement EIP-658

### DIFF
--- a/.dialyzer.ignore-warnings
+++ b/.dialyzer.ignore-warnings
@@ -132,6 +132,11 @@ ain.Block':put_state/2. The success typing is (#{'__struct__':='Elixir.Blockchai
 }) -> #{'__struct__':='Elixir.Blockchain.Block', 'header':=#{'__struct__':='Elixir.Block.Header', 's
 tate_root':=_, _=>_}, _=>_}
 
+# We ignore this becuase we cannot reproduce it locally. It may be because CI is
+# using erlang 21 while we are using erlang 20. But we cannot yet update to
+# erlang 21 because we need rox to update
+apps/blockchain/lib/blockchain/block.ex:736: Function create_receipt/6 will never be called
+
 -------------------------------
 # blockchain/chain.ex
 -------------------------------

--- a/apps/blockchain/lib/blockchain/block/holistic_validity.ex
+++ b/apps/blockchain/lib/blockchain/block/holistic_validity.ex
@@ -69,7 +69,7 @@ defmodule Blockchain.Block.HolisticValidity do
 
     child_block =
       base_block
-      |> Block.add_transactions(block.transactions, db, chain.evm_config)
+      |> Block.add_transactions(block.transactions, db, chain)
       |> Block.add_ommers(block.ommers)
       |> Block.add_rewards(db, chain)
 

--- a/apps/blockchain/lib/blockchain/contract.ex
+++ b/apps/blockchain/lib/blockchain/contract.ex
@@ -14,7 +14,7 @@ defmodule Blockchain.Contract do
 
   We are also inlining Eq.(97) and Eq.(98).
   """
-  @spec create(CreateContract.t()) :: {EVM.state(), EVM.Gas.t(), EVM.SubState.t()}
+  @spec create(CreateContract.t()) :: {:ok | :error, {EVM.state(), EVM.Gas.t(), EVM.SubState.t()}}
   def create(params), do: CreateContract.execute(params)
 
   @doc """
@@ -24,6 +24,6 @@ defmodule Blockchain.Contract do
   We are also inlining Eq.(105).
   """
   @spec message_call(MessageCall.t()) ::
-          {EVM.state(), EVM.Gas.t(), EVM.SubState.t(), EVM.VM.output()}
+          {:ok | :error, {EVM.state(), EVM.Gas.t(), EVM.SubState.t(), EVM.VM.output()}}
   def message_call(params), do: MessageCall.execute(params)
 end

--- a/apps/blockchain/lib/blockchain/contract/create_contract.ex
+++ b/apps/blockchain/lib/blockchain/contract/create_contract.ex
@@ -45,7 +45,7 @@ defmodule Blockchain.Contract.CreateContract do
           config: EVM.Configuration.t()
         }
 
-  @spec execute(t()) :: {EVM.state(), EVM.Gas.t(), EVM.SubState.t()}
+  @spec execute(t()) :: {:ok | :error, {EVM.state(), EVM.Gas.t(), EVM.SubState.t()}}
   def execute(params) do
     sender_account = Account.get_account(params.state, params.sender)
     contract_address = Account.Address.new(params.sender, sender_account.nonce)
@@ -152,7 +152,7 @@ defmodule Blockchain.Contract.CreateContract do
           {EVM.Gas.t(), EVM.SubState.t(), EVM.ExecEnv.t(), EVM.VM.output()},
           t(),
           EVM.address()
-        ) :: {EVM.state(), EVM.Gas.t(), EVM.SubState.t()}
+        ) :: {:ok | :error, {EVM.state(), EVM.Gas.t(), EVM.SubState.t()}}
   defp finalize({remaining_gas, accrued_sub_state, exec_env, output}, params, address) do
     state_after_init = exec_env.account_interface.state
 

--- a/apps/blockchain/lib/blockchain/contract/message_call.ex
+++ b/apps/blockchain/lib/blockchain/contract/message_call.ex
@@ -62,9 +62,9 @@ defmodule Blockchain.Contract.MessageCall do
 
   TODO: Determine whether or not we should be passing in the block header directly.
   TODO: Add serious (less trivial) test cases in `contract_test.exs`
-
   """
-  @spec execute(t()) :: {EVM.state(), EVM.Gas.t(), EVM.SubState.t(), EVM.VM.output()}
+  @spec execute(t()) ::
+          {:ok | :error, {EVM.state(), EVM.Gas.t(), EVM.SubState.t(), EVM.VM.output()}}
   def execute(params) do
     run = MessageCall.get_run_function(params.recipient, params.config)
 
@@ -106,13 +106,13 @@ defmodule Blockchain.Contract.MessageCall do
     # point immediately prior to balance transfer.
     case output do
       :failed ->
-        {params.state, 0, SubState.empty(), :failed}
+        {:error, {params.state, 0, SubState.empty(), :failed}}
 
       {:revert, _output} ->
-        {params.state, gas, SubState.empty(), :failed}
+        {:error, {params.state, gas, SubState.empty(), :failed}}
 
       _ ->
-        {exec_env.account_interface.state, gas, sub_state, output}
+        {:ok, {exec_env.account_interface.state, gas, sub_state, output}}
     end
   end
 end

--- a/apps/blockchain/lib/blockchain/interface/account_interface.ex
+++ b/apps/blockchain/lib/blockchain/interface/account_interface.ex
@@ -352,7 +352,7 @@ defimpl EVM.Interface.AccountInterface, for: Blockchain.Interface.AccountInterfa
       block_header: block_header
     }
 
-    {state, gas, sub_state, output} = Contract.message_call(params)
+    {_, {state, gas, sub_state, output}} = Contract.message_call(params)
 
     {Map.put(account_interface, :state, state), gas, sub_state, output}
   end

--- a/apps/blockchain/scripts/generate_state_tests.ex
+++ b/apps/blockchain/scripts/generate_state_tests.ex
@@ -59,9 +59,7 @@ defmodule GenerateStateTests do
         %{acc | passing: passing, failing: failing}
       end)
 
-    IO.puts("Failing tests")
-    deduped_tests = dedup_tests(completed_tests[:failing])
-    IO.puts(inspect(deduped_tests), limit: :infinity)
+    log_failing_tests(completed_tests[:failing])
 
     for hardfork <- @hardforks do
       passing_tests = length(completed_tests[:passing][hardfork])
@@ -74,6 +72,15 @@ defmodule GenerateStateTests do
         }%"
       )
     end
+  end
+
+  defp log_failing_tests(failing_tests) do
+    IO.puts("Failing tests")
+
+    failing_tests
+    |> dedup_tests()
+    # credo:disable-for-next-line Credo.Check.Warning.IoInspect
+    |> IO.inspect(limit: :infinity)
   end
 
   defp dedup_tests(tests) do
@@ -167,7 +174,7 @@ defmodule GenerateStateTests do
 
           {state, logs} =
             case result do
-              {state, _, logs} -> {state, logs}
+              {state, _, logs, _tx_status} -> {state, logs}
               _ -> {pre_state, []}
             end
 

--- a/apps/blockchain/test/blockchain/block_test.exs
+++ b/apps/blockchain/test/blockchain/block_test.exs
@@ -278,6 +278,7 @@ defmodule Blockchain.BlockTest do
 
   describe "add_transactions/3" do
     test "creates contract account" do
+      chain = Blockchain.Test.ropsten_chain()
       db = MerklePatriciaTree.Test.random_ets_db()
       beneficiary = <<0x05::160>>
       private_key = <<1::256>>
@@ -322,13 +323,14 @@ defmodule Blockchain.BlockTest do
         |> Account.put_account(sender, account)
 
       block_header = %Header{
+        number: 23,
         state_root: state.root_hash,
         beneficiary: beneficiary,
         gas_limit: 900_000_000
       }
 
       block = %Block{header: block_header, transactions: []}
-      block = Block.add_transactions(block, [trx], db)
+      block = Block.add_transactions(block, [trx], db, chain)
 
       assert Enum.count(block.transactions) == 1
 

--- a/apps/blockchain/test/blockchain/contract/message_call_test.exs
+++ b/apps/blockchain/test/blockchain/contract/message_call_test.exs
@@ -53,7 +53,7 @@ defmodule Blockchain.Contract.MessageCallTest do
         block_header: %Block.Header{nonce: 1}
       }
 
-      {state, gas, sub_state, output} = Contract.message_call(params)
+      {:ok, {state, gas, sub_state, output}} = Contract.message_call(params)
 
       expected_root_hash =
         <<163, 151, 95, 0, 149, 63, 81, 220, 74, 101, 219, 175, 240, 97, 153, 167, 249, 229, 144,
@@ -84,6 +84,79 @@ defmodule Blockchain.Contract.MessageCallTest do
 
       assert actual_accounts == expected_accounts
       assert state |> MerklePatriciaTree.Trie.Inspector.all_keys() |> Enum.count() == 2
+    end
+
+    test "returns error tuple if message call fails", %{db: db} do
+      code = MachineCode.compile([:push1, 2, :add])
+
+      state =
+        db
+        |> Trie.new()
+        |> Account.put_account(<<0x10::160>>, %Account{balance: 10})
+        |> Account.put_account(<<0x20::160>>, %Account{balance: 20})
+        |> Account.put_code(<<0x20::160>>, code)
+
+      params = %Contract.MessageCall{
+        state: state,
+        sender: <<0x10::160>>,
+        originator: <<0x10::160>>,
+        recipient: <<0x20::160>>,
+        contract: <<0x20::160>>,
+        available_gas: 1000,
+        gas_price: 1,
+        value: 5,
+        apparent_value: 5,
+        data: <<1, 2, 3>>,
+        stack_depth: 5,
+        block_header: %Block.Header{nonce: 1}
+      }
+
+      assert {:error, {^state, gas, sub_state, output}} = Contract.message_call(params)
+      assert gas == 0
+      assert SubState.empty?(sub_state)
+      assert output == :failed
+    end
+
+    test "returns error tuple if message call is reverted", %{db: db} do
+      code =
+        MachineCode.compile([
+          :push1,
+          3,
+          :push1,
+          5,
+          :add,
+          :push1,
+          0x00,
+          :revert
+        ])
+
+      state =
+        db
+        |> Trie.new()
+        |> Account.put_account(<<0x10::160>>, %Account{balance: 10})
+        |> Account.put_account(<<0x20::160>>, %Account{balance: 20})
+        |> Account.put_code(<<0x20::160>>, code)
+
+      params = %Contract.MessageCall{
+        state: state,
+        sender: <<0x10::160>>,
+        originator: <<0x10::160>>,
+        recipient: <<0x20::160>>,
+        contract: <<0x20::160>>,
+        available_gas: 1000,
+        gas_price: 1,
+        value: 5,
+        apparent_value: 5,
+        data: <<1, 2, 3>>,
+        stack_depth: 5,
+        block_header: %Block.Header{nonce: 1},
+        config: EVM.Configuration.Byzantium.new()
+      }
+
+      assert {:error, {^state, gas, sub_state, output}} = Contract.message_call(params)
+      assert gas == 985
+      assert SubState.empty?(sub_state)
+      assert output == :failed
     end
   end
 end

--- a/apps/blockchain/test/blockchain/state_test.exs
+++ b/apps/blockchain/test/blockchain/state_test.exs
@@ -273,7 +273,7 @@ defmodule Blockchain.StateTest do
 
       {state, logs} =
         case result do
-          {state, _, logs} -> {state, logs}
+          {state, _, logs, _tx_status} -> {state, logs}
           _ -> {pre_state, []}
         end
 

--- a/apps/blockchain/test/blockchain/transaction_test.exs
+++ b/apps/blockchain/test/blockchain/transaction_test.exs
@@ -5,7 +5,7 @@ defmodule Blockchain.TransactionTest do
   doctest Blockchain.Transaction
 
   alias ExthCrypto.Hash.Keccak
-  alias Blockchain.{Account, Transaction, Contract}
+  alias Blockchain.{Account, Transaction}
   alias Blockchain.Transaction.Signature
   alias MerklePatriciaTree.Trie
   alias EVM.MachineCode
@@ -328,7 +328,7 @@ defmodule Blockchain.TransactionTest do
         nonce: 6
       }
 
-      contract_address = Contract.Address.new(sender.address, sender.nonce)
+      contract_address = Account.Address.new(sender.address, sender.nonce)
 
       machine_code =
         MachineCode.compile([
@@ -435,7 +435,7 @@ defmodule Blockchain.TransactionTest do
 
       assert beneficiary_account == %Account{balance: gas * gas_price}
 
-      contract_address = Contract.Address.new(sender.address, sender.nonce)
+      contract_address = Account.Address.new(sender.address, sender.nonce)
       refute Account.exists?(Account.get_account(state, contract_address))
     end
   end


### PR DESCRIPTION
Resolves https://github.com/poanetwork/mana/issues/394

Summary
========

Adds a transaction status of `0` for failure and `1` for success. This transaction status is included in the transaction receipts if the block number is past the Byzantium hardfork.

More detail
===========

* We update `Transaction.execute`, as well as `MessageCall.execute` and `ContractCreate.execute` to return the status specified as Gamma^z in section 6, Transaction Execution, of the Yellow Paper (0 for failure, 1 for success).

* After the Bynzatium fork, the transaction receipt's state root should include a `0` if the transaction failed or a `1` if it succeeded. This is EIP 658.