### PR TITLE
Handle Disconnect, Ping, and Status packets

### DIFF
--- a/apps/ex_wire/.iex.exs
+++ b/apps/ex_wire/.iex.exs
@@ -1,0 +1,1 @@
+alias ExWire.{PeerSupervisor}

--- a/apps/ex_wire/config/dev.exs
+++ b/apps/ex_wire/config/dev.exs
@@ -2,7 +2,10 @@ use Mix.Config
 
 config :ex_wire,
   network_adapter: {ExWire.Adapter.UDP, NetworkClient},
-  sync: false,
+  sync: true,
+  private_key:
+    <<10, 122, 189, 137, 166, 190, 127, 238, 229, 16, 211, 182, 104, 78, 138, 37, 146, 116, 90,
+      68, 76, 86, 168, 24, 200, 155, 0, 99, 58, 226, 211, 30>>,
   discovery: true,
   node_discovery: [
     network_adapter: {ExWire.Adapter.UDP, NetworkClient},

--- a/apps/ex_wire/lib/ex_wire.ex
+++ b/apps/ex_wire/lib/ex_wire.ex
@@ -20,7 +20,7 @@ defmodule ExWire do
         db = MerklePatriciaTree.DB.RocksDB.init(db_name())
 
         [
-          worker(ExWire.PeerSupervisor, [ExWire.Config.bootnodes()]),
+          supervisor(ExWire.PeerSupervisor, [:ok]),
           worker(ExWire.Sync, [db])
         ]
       else

--- a/apps/ex_wire/lib/ex_wire/p2p/server.ex
+++ b/apps/ex_wire/lib/ex_wire/p2p/server.ex
@@ -34,6 +34,20 @@ defmodule ExWire.P2P.Server do
   end
 
   @doc """
+  Child spec definition to be used by a supervisor when wanting to supervise an
+  outbound TCP connection.
+
+  We spawn a temporary child process for each outbound connection.
+  """
+  def child_spec([:outbound, peer, subscribers]) do
+    %{
+      id: ExWire.P2P.Outbound,
+      start: {__MODULE__, :start_link, [:outbound, peer, subscribers]},
+      restart: :temporary
+    }
+  end
+
+  @doc """
   Starts an outbound or inbound peer to peer connection.
   """
   def start_link(:outbound, peer, subscribers \\ []) do

--- a/apps/ex_wire/lib/ex_wire/packet/status.ex
+++ b/apps/ex_wire/lib/ex_wire/packet/status.ex
@@ -50,6 +50,25 @@ defmodule ExWire.Packet.Status do
   ]
 
   @doc """
+  Create a Status packet to return
+
+  Note: we are currently reflecting values based on the packet received, but
+  that should not be the case. We should provide the total difficulty of the
+  best chain found in the block header, the best hash, and the genesis hash of
+  our blockchain.
+  """
+  @spec new(t) :: t
+  def new(packet) do
+    %__MODULE__{
+      protocol_version: ExWire.Config.protocol_version(),
+      network_id: ExWire.Config.network_id(),
+      total_difficulty: packet.total_difficulty,
+      best_hash: packet.genesis_hash,
+      genesis_hash: packet.genesis_hash
+    }
+  end
+
+  @doc """
   Given a Status packet, serializes for transport over Eth Wire Protocol.
 
   ## Examples

--- a/apps/ex_wire/lib/ex_wire/sync.ex
+++ b/apps/ex_wire/lib/ex_wire/sync.ex
@@ -79,7 +79,7 @@ defmodule ExWire.Sync do
           Logger.debug(fn -> "[Sync] Requesting block body #{header.number}" end)
 
           # TODO: Bulk up these requests?
-          PeerSupervisor.send_packet(PeerSupervisor, %ExWire.Packet.GetBlockBodies{
+          PeerSupervisor.send_packet(%ExWire.Packet.GetBlockBodies{
             hashes: [header_hash]
           })
         end
@@ -148,7 +148,7 @@ defmodule ExWire.Sync do
 
     Logger.debug(fn -> "[Sync] Requesting block #{next_number}" end)
 
-    ExWire.PeerSupervisor.send_packet(ExWire.PeerSupervisor, %ExWire.Packet.GetBlockHeaders{
+    ExWire.PeerSupervisor.send_packet(%ExWire.Packet.GetBlockHeaders{
       block_identifier: next_number,
       max_headers: 1,
       skip: 0,


### PR DESCRIPTION
This is part of https://github.com/poanetwork/mana/issues/166 and https://github.com/poanetwork/mana/issues/167.

Summary
========

The networking layer was not handling Disconnect, Ping, and Status packages. The first two are DEVp2p and the Status packet is the first packet that must be sent for the Ethereum Wire Protocol (after the encrypted and DEVp2p handshakes).

Details
========

Adding Subscribers to Connection struct
-----------------------------------------

First we add `subscribers` to `ExWire.P2P.Connection` struct. For a while I was resisting doing this since I wanted `P2P` to be a pure module without having to know about the socket connection. Ideally it could just respond something like `{:send, packet}` and the `P2P.Server` would handle the actual communication to the socket.

The current implementation of `P2P`, however, is not pure, and it has knowledge of the socket (it's part of the `Connection` struct). So we are including `subscriptions` in there for now, especially since there is a function (`notify_subscribers`) which assumes the struct will have the subscribers in there.

This needs to be handled because our networking layer is technically broken without this part. 

Adds a rough implementation of handling `Packet.Disconnect`, `Packet.Ping`, and `Packet.Status`:
-----------------------------------

* `Disconnect` is a `DEVp2p` message. It can be sent by a peer at any point after the encrypted handshake. It signifies that a disconnect is imminent and that we should disconnect. So we should terminate the TCP connection.

* `Ping` (and `Pong`) are `DEVp2p` messages that should not be delegated to the subscribers. That is, they are related to the networking side of things (ie. "is this node alive?") and not to the blockchain side of things (e.g. "GetBlockHeaders").

* `Packet.Status` is an eth wire protocol packet, and as such, it is possible it should not reside in `P2P` but that it should live with the rest of the packets that are delegated to the subscribers. But since it is the first packet that must come from all eth wire packets, and since it requires a response, we include it here for now. It's also important to note that the status message requires fields like `total_difficulty` and `best_hash`, values which we do not yet know about our blockchain, so we are simply mirroring what we get from the other node for now.

Other changes
-------------

* Makes PeerSupervisor (previously a regular supervisor) into a DynamicSupervisor. This means it can dynamically start children nodes, which will be outbound `ExWire.P2P.Server`s. We add a `PeerSupervisor.start_child/1` function that takes in a peer enode url to start the outbound server.