### PR TITLE
Validate before executing transactions

### DIFF
--- a/apps/blockchain/lib/blockchain/block.ex
+++ b/apps/blockchain/lib/blockchain/block.ex
@@ -715,8 +715,8 @@ defmodule Blockchain.Block do
          config
        ) do
     state = Trie.new(db, header.state_root)
-    # TODO: How do we deal with invalid transactions
-    {new_state, gas_used, logs} = Transaction.execute(state, trx, header, config)
+
+    {new_state, gas_used, logs} = Transaction.execute_with_validation(state, trx, header, config)
 
     total_gas_used = block.header.gas_used + gas_used
 

--- a/apps/blockchain/lib/blockchain/transaction.ex
+++ b/apps/blockchain/lib/blockchain/transaction.ex
@@ -160,8 +160,8 @@ defmodule Blockchain.Transaction do
   @doc """
   Validates the validity of a transaction and then executes it if transaction is valid.
   """
-  @spec execute_with_validation(EVM.state(), t, Header.t()) ::
-          {EVM.state(), Gas.t(), EVM.SubState.logs(), EVM.Configuration.t()}
+  @spec execute_with_validation(EVM.state(), t, Header.t(), EVM.Configuration.t()) ::
+          {EVM.state(), Gas.t(), EVM.SubState.logs()}
   def execute_with_validation(
         state,
         tx,
@@ -170,8 +170,9 @@ defmodule Blockchain.Transaction do
       ) do
     validation_result = Validity.validate(state, tx, block_header, config)
 
-    with :valid <- validation_result do
-      execute(state, tx, block_header, config)
+    case validation_result do
+      :valid -> execute(state, tx, block_header, config)
+      {:invalid, _} -> {state, 0, []}
     end
   end
 

--- a/apps/blockchain/test/blockchain/block_test.exs
+++ b/apps/blockchain/test/blockchain/block_test.exs
@@ -285,8 +285,6 @@ defmodule Blockchain.BlockTest do
       sender =
         <<126, 95, 69, 82, 9, 26, 105, 18, 93, 93, 252, 183, 184, 194, 101, 144, 41, 57, 91, 223>>
 
-      contract_address = Contract.Address.new(sender, 6)
-
       assembly = [
         :push1,
         3,
@@ -325,7 +323,8 @@ defmodule Blockchain.BlockTest do
 
       block_header = %Header{
         state_root: state.root_hash,
-        beneficiary: beneficiary
+        beneficiary: beneficiary,
+        gas_limit: 900_000_000
       }
 
       block = %Block{header: block_header, transactions: []}
@@ -359,6 +358,7 @@ defmodule Blockchain.BlockTest do
 
       assert Block.get_transaction(block, 0, db) == expected_transaction
 
+      contract_address = Contract.Address.new(sender, 6)
       addresses = [sender, beneficiary, contract_address]
 
       actual_accounts =


### PR DESCRIPTION
Why:

We should be using `Transaction.execute_with_validation` in our blockchain block instead of skipping validations with `Transaction.execute`. We were skipping these previously because it was causing some blockchain common tests to fail but I think we want to check our transactions are valid to get all the tests passing eventually.

This PR:

Uses `Transaction.execute_with_validation` in `apps/blockchain/lib/blockchain/block.ex` and makes the required changes to our existing tests. Due to https://github.com/ethereum/tests/issues/503 we needed to introduce a `check_account_validity` to handle cases where the sender account doesn't exist. This removes the invalid case of `missing_account` as if the account is missing but there is a cost for the transaction, the transaction will still be invalid but for a different reason (such as `over_gas_limit`)