### PR TITLE
Turns EVM.address => Account.Address in interface

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,21 +17,21 @@ jobs:
 
       - restore_cache:
           keys:
-            - v3-env-cache-{{ arch }}-{{ .Branch }}
-            - v3-env-cache-{{ .Branch }}
-            - v3-env-cache
+            - v4-env-cache-{{ arch }}-{{ .Branch }}
+            - v4-env-cache-{{ .Branch }}
+            - v4-env-cache
 
       - restore_cache:
           keys:
-            - v3-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
-            - v3-mix-cache-{{ .Branch }}
-            - v3-mix-cache
+            - v4-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+            - v4-mix-cache-{{ .Branch }}
+            - v4-mix-cache
 
       - restore_cache:
           keys:
-            - v3-build-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
-            - v3-build-cache-{{ .Branch }}
-            - v3-build-cache
+            - v4-build-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+            - v4-build-cache-{{ .Branch }}
+            - v4-build-cache
 
       - run: echo 'export PATH=~/.cargo/bin:$PATH' >> $BASH_ENV
 
@@ -40,41 +40,41 @@ jobs:
           no_output_timeout: 2400
 
       - save_cache:
-          key: v3-env-cache-{{ arch }}-{{ .Branch }}
+          key: v4-env-cache-{{ arch }}-{{ .Branch }}
           paths:
             - $HOME/.cargo
             - $HOME/.rustup
 
       - save_cache:
-          key: v3-env-cache-{{ .Branch }}
+          key: v4-env-cache-{{ .Branch }}
           paths:
             - $HOME/.cargo
             - $HOME/.rustup
 
       - save_cache:
-          key: v3-env-cache
+          key: v4-env-cache
           paths:
             - $HOME/.cargo
             - $HOME/.rustup
 
       - save_cache:
-          key: v3-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+          key: v4-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
           paths: "deps"
       - save_cache:
-          key: v3-mix-cache-{{ .Branch }}
+          key: v4-mix-cache-{{ .Branch }}
           paths: "deps"
       - save_cache:
-          key: v3-mix-cache
+          key: v4-mix-cache
           paths: "deps"
 
       - save_cache:
-          key: v3-build-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+          key: v4-build-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
           paths: "_build"
       - save_cache:
-          key: v3-build-cache-{{ .Branch }}
+          key: v4-build-cache-{{ .Branch }}
           paths: "_build"
       - save_cache:
-          key: v3-build-cache
+          key: v4-build-cache
           paths: "_build"
 
       - run:
@@ -123,26 +123,26 @@ jobs:
 
       - restore_cache:
           keys:
-            - v3-build-cache-{{ .Branch }}
-            - v3-build-cache
+            - v4-build-cache-{{ .Branch }}
+            - v4-build-cache
 
       - restore_cache:
           keys:
-            - v3-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
-            - v3-mix-cache-{{ .Branch }}
-            - v3-mix-cache
+            - v4-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+            - v4-mix-cache-{{ .Branch }}
+            - v4-mix-cache
 
       - restore_cache:
           keys:
-            - v3-env-cache-{{ arch }}-{{ .Branch }}
-            - v3-env-cache-{{ .Branch }}
-            - v3-env-cache
+            - v4-env-cache-{{ arch }}-{{ .Branch }}
+            - v4-env-cache-{{ .Branch }}
+            - v4-env-cache
 
       - restore_cache:
           keys:
-            - v3-plt-cache-{{ ".tool-versions" }}-{{ checksum "mix.lock" }}
-            - v3-plt-cache-{{ ".tool-versions" }}-{{ checksum "mix.exs" }}
-            - v3-plt-cache-{{ ".tool-versions" }}
+            - v4-plt-cache-{{ ".tool-versions" }}-{{ checksum "mix.lock" }}
+            - v4-plt-cache-{{ ".tool-versions" }}-{{ checksum "mix.exs" }}
+            - v4-plt-cache-{{ ".tool-versions" }}
 
       - run:
           name: Unpack PLT cache
@@ -162,17 +162,17 @@ jobs:
             cp ~/.mix/dialyxir*.plt plts/
 
       - save_cache:
-          key: v3-plt-cache-{{ ".tool-versions" }}-{{ checksum "mix.lock" }}
+          key: v4-plt-cache-{{ ".tool-versions" }}-{{ checksum "mix.lock" }}
           paths:
             - plts
 
       - save_cache:
-          key: v3-plt-cache-{{ ".tool-versions" }}-{{ checksum "mix.exs" }}
+          key: v4-plt-cache-{{ ".tool-versions" }}-{{ checksum "mix.exs" }}
           paths:
             - plts
 
       - save_cache:
-          key: v3-plt-cache-{{ ".tool-versions" }}
+          key: v4-plt-cache-{{ ".tool-versions" }}
           paths:
             - plts
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If running properly, you will see a timestamp in hr/min/sec/millisec and a runni
 
 ### Infura sync issues
 
-- When running the script mainnet fails on block [116523](https://etherscan.io/txs?block=116524) with a `state_root_mismatch` error. We believe [this transaction](https://etherscan.io/tx/0x5dd753ec16e8bf9429f7583b7cf7d4302daeb9616660051b8038da0f4b9f3e41) is causing the issue.
+- When running the script mainnet fails on block [179098](https://etherscan.io/txs?block=179098) with a `gas_used_mismatch` and `state_root_mismatch` errors.
 - Ropsten fails on block [11](https://ropsten.etherscan.io/txs?block=11) with a `state_root_mismatch` error as well.
 
 # Testing

--- a/apps/blockchain/lib/blockchain/account/address.ex
+++ b/apps/blockchain/lib/blockchain/account/address.ex
@@ -1,11 +1,13 @@
-defmodule Blockchain.Contract.Address do
+defmodule Blockchain.Account.Address do
   @moduledoc """
-  Contract address functions and constants.
+  Represents an account's address
   """
 
   alias ExthCrypto.Hash.Keccak
 
+  @type t :: <<_::160>>
   @size 160
+  @size_in_bytes 20
 
   @doc """
   Determines the address of a new contract
@@ -17,20 +19,28 @@ defmodule Blockchain.Contract.Address do
 
   ## Examples
 
-      iex> Blockchain.Contract.Address.new(<<0x01::160>>, 1)
+      iex> Blockchain.Account.Address.new(<<0x01::160>>, 1)
       <<82, 43, 50, 148, 230, 208, 106, 162, 90, 208, 241, 184, 137, 18, 66, 227, 53, 211, 180, 89>>
 
-      iex> Blockchain.Contract.Address.new(<<0x01::160>>, 2)
+      iex> Blockchain.Account.Address.new(<<0x01::160>>, 2)
       <<83, 91, 61, 122, 37, 47, 160, 52, 237, 113, 240, 197, 62, 192, 198, 247, 132, 203, 100, 225>>
-
-      iex> Blockchain.Contract.Address.new(<<0x02::160>>, 3)
-      <<30, 208, 147, 166, 216, 88, 183, 173, 67, 180, 70, 173, 88, 244, 201, 236, 9, 101, 145, 49>>
   """
-  @spec new(EVM.address(), integer()) :: EVM.address()
+  @spec new(EVM.address(), integer()) :: t()
   def new(sender, nonce) do
     [sender, nonce - 1]
     |> ExRLP.encode()
     |> Keccak.kec()
     |> BitHelper.mask_bitstring(@size)
+  end
+
+  @spec from(binary() | integer()) :: t()
+  def from(raw_address) when is_integer(raw_address) do
+    raw_address
+    |> :binary.encode_unsigned()
+    |> from()
+  end
+
+  def from(raw_address) when is_binary(raw_address) do
+    BitHelper.pad(raw_address, @size_in_bytes)
   end
 end

--- a/apps/blockchain/lib/blockchain/contract/create_contract.ex
+++ b/apps/blockchain/lib/blockchain/contract/create_contract.ex
@@ -6,7 +6,6 @@ defmodule Blockchain.Contract.CreateContract do
 
   alias Blockchain.Interface.{BlockInterface, AccountInterface}
   alias Block.Header
-  alias Blockchain.Contract.Address
   alias Blockchain.Account
   alias EVM.{SubState, Gas}
 
@@ -49,7 +48,7 @@ defmodule Blockchain.Contract.CreateContract do
   @spec execute(t()) :: {EVM.state(), EVM.Gas.t(), EVM.SubState.t()}
   def execute(params) do
     sender_account = Account.get_account(params.state, params.sender)
-    contract_address = Address.new(params.sender, sender_account.nonce)
+    contract_address = Account.Address.new(params.sender, sender_account.nonce)
     account = Account.get_account(params.state, contract_address)
 
     if Account.exists?(account) do

--- a/apps/blockchain/test/blockchain/account/address_test.exs
+++ b/apps/blockchain/test/blockchain/account/address_test.exs
@@ -1,0 +1,57 @@
+defmodule Blockchain.Account.AddressTest do
+  use ExUnit.Case, async: true
+
+  doctest Blockchain.Account.Address
+
+  alias Blockchain.Account.Address
+
+  @hex_address_in_block_177610 "00bca629f698d95a3ab6a2b379cac78c952eb75c"
+  @int_address_in_block_177610 4_207_015_016_149_197_627_205_197_234_001_106_133_891_069_788
+
+  describe "new/2" do
+    test "generates a new address from an address and nonce" do
+      sender = <<0x02::160>>
+
+      expected_address =
+        <<30, 208, 147, 166, 216, 88, 183, 173, 67, 180, 70, 173, 88, 244, 201, 236, 9, 101, 145,
+          49>>
+
+      address = Address.new(sender, 3)
+
+      assert address == expected_address
+    end
+  end
+
+  describe "from/1" do
+    test "returns same binary if it is 160 bit binary" do
+      raw = <<1::160>>
+
+      address = Address.from(raw)
+
+      assert address == raw
+    end
+
+    test "pads a binary if it is less than 160 bits" do
+      raw = <<1, 2, 3>>
+
+      address = Address.from(raw)
+
+      assert address == :binary.copy(<<0>>, 17) <> raw
+    end
+
+    test "raises if binary has more than 160 bits" do
+      raw = <<1::168>>
+
+      assert_raise(RuntimeError, "Binary too long for padding", fn -> Address.from(raw) end)
+    end
+
+    test "takes an integer and returns a 160 bit encoded/unsigned binary" do
+      raw = @int_address_in_block_177610
+      expected = Base.decode16!(@hex_address_in_block_177610, case: :lower)
+
+      address = Address.from(raw)
+
+      assert address == expected
+    end
+  end
+end

--- a/apps/blockchain/test/blockchain/block_test.exs
+++ b/apps/blockchain/test/blockchain/block_test.exs
@@ -5,7 +5,7 @@ defmodule Blockchain.BlockTest do
   doctest Blockchain.Block
 
   alias Block.Header
-  alias Blockchain.{Chain, Account, Contract, Block, Transaction, Genesis}
+  alias Blockchain.{Chain, Account, Block, Transaction, Genesis}
   alias EVM.MachineCode
   alias MerklePatriciaTree.Trie
 
@@ -358,7 +358,7 @@ defmodule Blockchain.BlockTest do
 
       assert Block.get_transaction(block, 0, db) == expected_transaction
 
-      contract_address = Contract.Address.new(sender, 6)
+      contract_address = Account.Address.new(sender, 6)
       addresses = [sender, beneficiary, contract_address]
 
       actual_accounts =

--- a/apps/blockchain/test/blockchain/contract/create_contract_test.exs
+++ b/apps/blockchain/test/blockchain/contract/create_contract_test.exs
@@ -42,7 +42,7 @@ defmodule Blockchain.Contract.CreateContractTest do
       assert gas == 99_993_576
       assert SubState.empty?(sub_state)
 
-      addresses = [<<0x10::160>>, Contract.Address.new(<<0x10::160>>, 5)]
+      addresses = [<<0x10::160>>, Account.Address.new(<<0x10::160>>, 5)]
       actual_accounts = Account.get_accounts(state, addresses)
 
       expected_accounts = [
@@ -58,7 +58,7 @@ defmodule Blockchain.Contract.CreateContractTest do
 
       assert actual_accounts == expected_accounts
 
-      contract_address = Contract.Address.new(<<0x10::160>>, 5)
+      contract_address = Account.Address.new(<<0x10::160>>, 5)
       assert Account.get_machine_code(state, contract_address) == {:ok, <<0x08::256>>}
       assert state |> Trie.Inspector.all_keys() |> Enum.count() == 2
     end
@@ -67,7 +67,7 @@ defmodule Blockchain.Contract.CreateContractTest do
       account = %Account{balance: 11, nonce: 5}
       account_address = <<0x10::160>>
       collision_account = %Account{nonce: 1}
-      collision_account_address = Contract.Address.new(account_address, account.nonce)
+      collision_account_address = Account.Address.new(account_address, account.nonce)
 
       state =
         db
@@ -95,7 +95,7 @@ defmodule Blockchain.Contract.CreateContractTest do
       account = %Account{balance: 11, nonce: 5}
       account_address = <<0x10::160>>
       collision_account = %Account{code_hash: build_sample_code(), nonce: 0}
-      collision_account_address = Contract.Address.new(account_address, account.nonce)
+      collision_account_address = Account.Address.new(account_address, account.nonce)
 
       state =
         db

--- a/apps/blockchain/test/blockchain/transaction_test.exs
+++ b/apps/blockchain/test/blockchain/transaction_test.exs
@@ -126,7 +126,7 @@ defmodule Blockchain.TransactionTest do
 
       sender_account = %Account{balance: 400_000, nonce: 5}
 
-      contract_address = Contract.Address.new(sender_address, 6)
+      contract_address = Account.Address.new(sender_address, 6)
       machine_code = MachineCode.compile([:stop])
 
       tx =
@@ -183,7 +183,7 @@ defmodule Blockchain.TransactionTest do
       sender =
         <<126, 95, 69, 82, 9, 26, 105, 18, 93, 93, 252, 183, 184, 194, 101, 144, 41, 57, 91, 223>>
 
-      contract_address = Contract.Address.new(sender, 6)
+      contract_address = Account.Address.new(sender, 6)
 
       assembly = [
         :push1,
@@ -248,7 +248,7 @@ defmodule Blockchain.TransactionTest do
       sender =
         <<126, 95, 69, 82, 9, 26, 105, 18, 93, 93, 252, 183, 184, 194, 101, 144, 41, 57, 91, 223>>
 
-      contract_address = Contract.Address.new(sender, 6)
+      contract_address = Account.Address.new(sender, 6)
 
       assembly = [
         :push1,

--- a/apps/evm/lib/evm/address.ex
+++ b/apps/evm/lib/evm/address.ex
@@ -38,13 +38,12 @@ defmodule EVM.Address do
   @doc """
   Returns an address given an address and a nonce.
   """
-  @spec new(integer(), integer()) :: non_neg_integer()
+  @spec new(integer(), integer()) :: binary()
   def new(address, nonce) do
     [address, nonce]
     |> ExRLP.encode()
     |> Keccak.kec()
     |> EVM.Helpers.take_n_last_bytes(@size)
-    |> :binary.decode_unsigned()
   end
 
   @doc """

--- a/apps/evm/lib/evm/operation/system.ex
+++ b/apps/evm/lib/evm/operation/system.ex
@@ -77,18 +77,20 @@ defmodule EVM.Operation.System do
       end
 
     # Note if was exception halt or other failure on stack
-    result =
+    new_address =
       if status == :ok do
         nonce = AccountInterface.get_account_nonce(exec_env.account_interface, exec_env.address)
 
         Address.new(exec_env.address, nonce)
       else
-        0
+        <<0>>
       end
+
+    new_address_for_machine_state = :binary.decode_unsigned(new_address)
 
     machine_state = %{
       machine_state
-      | stack: Stack.push(machine_state.stack, result),
+      | stack: Stack.push(machine_state.stack, new_address_for_machine_state),
         gas: n_gas + remaining_gas
     }
 
@@ -97,7 +99,7 @@ defmodule EVM.Operation.System do
     sub_state =
       n_sub_state
       |> SubState.merge(sub_state)
-      |> SubState.add_touched_account(result)
+      |> SubState.add_touched_account(new_address)
 
     %{
       machine_state: machine_state,

--- a/apps/ex_wire/config/dev.exs
+++ b/apps/ex_wire/config/dev.exs
@@ -2,7 +2,7 @@ use Mix.Config
 
 config :ex_wire,
   network_adapter: {ExWire.Adapter.UDP, NetworkClient},
-  sync: true,
+  sync: false,
   private_key:
     <<10, 122, 189, 137, 166, 190, 127, 238, 229, 16, 211, 182, 104, 78, 138, 37, 146, 116, 90,
       68, 76, 86, 168, 24, 200, 155, 0, 99, 58, 226, 211, 30>>,


### PR DESCRIPTION
Block number 177610 in the mainnet has an account that is pushed into
the stack as an integer. The account when represented as an integer does
not have a leading zero, but when represented as hex, it has `00` as its
first two characters.

This led to a subtle bug, where the balance of the account in question
seemed to be zero, when in reality we were checking the wrong account's
balance.

To fix this issue, we ensure that the addresses coming from the EVM (via
the account interface) are all turned into
`Blockchain.Account.Addresses` which must have `160` bits. If they are
short, as was the case in the bug, we pad them.

Additionally:
------------

The SubState's touched accounts should have the binary format for the
address of an account. The `create` system operation was passing the
result of turning an address and nonce into an unsigned integer into the
substate. It should have been passing the `exec_env.address` instead.