### PR TITLE
Add debugging tools documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,33 @@ If running properly, you will see a timestamp in hr/min/sec/millisec and a runni
 - When running the script mainnet fails on block [179098](https://etherscan.io/txs?block=179098) with a `gas_used_mismatch` and `state_root_mismatch` errors.
 - Ropsten fails on block [11](https://ropsten.etherscan.io/txs?block=11) with a `state_root_mismatch` error as well.
 
+### Helpful debugging tools
+
+When trying to debug why the `sync_with_infura` script is failing to verify a
+block, we have found [etherscan] to be very helpful. Take block `177610` for
+example,
+
+We can look at the [block information], and dive into the [transaction
+information]. From that page, the "Tools & Utilities" dropdown provides very
+helpful debugging tools. Two of the most valuable are [Geth DebugTrace] and
+[Remix Debugger],
+
+- `Geth DebugTrace` allows us to compare each operation and its gas consumption
+against our implementation.
+
+- `Remix Debugger` allows us to compare the stack against our implementation's
+  stack for each cycle of the virtual machine.
+
+To log the operation, gas consumption, and stack in our application, please see
+the EVM README's [example setup].
+
+[etherscan]: https://etherscan.io/
+[block information]: https://etherscan.io/block/177610
+[transaction information]: https://etherscan.io/tx/0x7f79a541615694029d845e31f2f362484679c1b9a3fd8588822a33a0e13383f4
+[Geth DebugTrace]: https://etherscan.io/vmtrace?txhash=0x7f79a541615694029d845e31f2f362484679c1b9a3fd8588822a33a0e13383f4
+[Remix Debugger]: http://etherscan.io/remix?txhash=0x7f79a541615694029d845e31f2f362484679c1b9a3fd8588822a33a0e13383f4
+[example setup]: https://github.com/poanetwork/mana/tree/master/apps/evm#example-setup
+
 # Testing
 
 Run:

--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ against our implementation.
 - `Remix Debugger` allows us to compare the stack against our implementation's
   stack for each cycle of the virtual machine.
 
+NOTE: for the `Remix Debugger`, you may want to add the block number at the top
+before pressing the play button.
+
 To log the operation, gas consumption, and stack in our application, please see
 the EVM README's [example setup].
 

--- a/apps/evm/README.md
+++ b/apps/evm/README.md
@@ -39,16 +39,19 @@ The following example is from [Ethereum Virtual Machine in Elixir](https://www.b
 2. Add the input/output code to print debugging information.
    - Go to `lib/evm/vm.ex`.
 
-   - Find the `cycle/3` method and **add the IO code**.
+   - Find the `cycle/3` method and **add the logger code** before the return value
       ```elixir
       def cycle(machine_state, sub_state, exec_env) do
       operation = MachineCode.current_operation(machine_state, exec_env)
       inputs = Operation.inputs(operation, machine_state)
-      
-      IO.puts("stack:")
-      IO.inspect(machine_state.stack)
-      IO.puts("operation: #{operation.sym}")
-      
+
+      # more code
+
+      final_machine_state
+      |> EVM.Logger.log_stack()
+      |> EVM.Logger.log_state(operation)
+
+      {final_machine_state, n_sub_state, n_exec_env}
       ```
    - Save the file.
 
@@ -80,7 +83,7 @@ iex> env = %EVM.ExecEnv{
 }
 ```
 
-For this test, we are only interested in the `machine_code` field. It is represented as a binary. 
+For this test, we are only interested in the `machine_code` field. It is represented as a binary.
 
 ### Decompile the Code to View the Machine Operations
 

--- a/apps/evm/lib/evm/logger.ex
+++ b/apps/evm/lib/evm/logger.ex
@@ -3,15 +3,24 @@ defmodule EVM.Logger do
   alias EVM.{Operation, MachineState}
 
   @doc """
+  Helper function to log the stack given the machine state
+  """
+  @spec log_stack(MachineState.t()) :: MachineState.t()
+  def log_stack(machine_state) do
+    Logger.debug(fn -> "Stack: #{inspect(machine_state.stack)}" end)
+    machine_state
+  end
+
+  @doc """
   This function logs state in the same format as Parity's `evm-debug` function. This makes comparing implementations and debugging easier.
 
   `cargo test --features "json-tests evm/evm-debug-tests" --release -- BlockchainTests_GeneralStateTest_stSystemOperationsTest --nocapture`
   """
-
-  @spec log_state(EVM.Operation.Metadata.t(), MachineState.t()) :: nil
-  def log_state(operation, machine_state) do
+  @spec log_state(MachineState.t(), EVM.Operation.Metadata.t()) :: MachineState.t()
+  def log_state(machine_state, operation) do
     log_opcode_and_gas_left(operation, machine_state)
     log_inputs(operation, machine_state)
+    machine_state
   end
 
   defp log_opcode_and_gas_left(operation, machine_state) do


### PR DESCRIPTION
While debugging why the blockchain would not sync past block `177610`, we discovered some helpful debugging tools. This commit documents those in the main README, and we also update the EVM README to use the `EVM.Logger`.