### PR TITLE
 EIP-1283

### DIFF
--- a/.dialyzer.ignore-warnings
+++ b/.dialyzer.ignore-warnings
@@ -54,7 +54,7 @@ apps/evm/lib/evm/gas.ex:308: Function operation_cost/2 has no local return
 apps/evm/lib/evm/gas.ex:308: The call 'Elixir.EVM.Gas':operation_cost(__@1::any(),__@2::any(),'nil','nil') breaks the contract (atom(),['Elixir.EVM':val()],['Elixir.EVM':val()],'Elixir.EVM.MachineState':t()) -> t() | 'nil'
 apps/evm/lib/evm/gas.ex:308: Function operation_cost/3 has no local return
 apps/evm/lib/evm/gas.ex:308: The call 'Elixir.EVM.Gas':operation_cost(__@1::any(),__@2::any(),__@3::any(),'nil') breaks the contract (atom(),['Elixir.EVM':val()],['Elixir.EVM':val()],'Elixir.EVM.MachineState':t()) -> t() | 'nil'
-apps/evm/lib/evm/gas.ex:573: Function gas_cost_for_nested_operation/2 will never be called
+apps/evm/lib/evm/gas.ex:577: Function gas_cost_for_nested_operation/2 will never be called
 apps/evm/lib/evm/machine_state.ex:53: Function subtract_gas/2 has no local return
 apps/evm/lib/evm/operation/environmental_information.ex:114: Function calldataload/2 has no local return
 apps/evm/lib/evm/operation/environmental_information.ex:117: The call 'Elixir.EVM.Helpers':decode_signed(binary()) breaks the contract (integer() | 'nil') -> 'Elixir.EVM':val() | 'nil'

--- a/apps/blockchain/lib/blockchain/contract/message_call.ex
+++ b/apps/blockchain/lib/blockchain/contract/message_call.ex
@@ -112,7 +112,8 @@ defmodule Blockchain.Contract.MessageCall do
         {:error, {params.state, gas, SubState.empty(), :failed}}
 
       _ ->
-        {:ok, {exec_env.account_interface.state, gas, sub_state, output}}
+        commited_state = AccountInterface.commit_storage(exec_env.account_interface)
+        {:ok, {commited_state, gas, sub_state, output}}
     end
   end
 end

--- a/apps/blockchain/lib/blockchain/interface/account_interface.ex
+++ b/apps/blockchain/lib/blockchain/interface/account_interface.ex
@@ -26,14 +26,15 @@ defmodule Blockchain.Interface.AccountInterface do
         state: %MerklePatriciaTree.Trie{
           db: { MerklePatriciaTree.DB.ETS, :account_interface_new },
           root_hash: <<86, 232, 31, 23, 27, 204, 85, 166, 255, 131, 69, 230, 146, 192, 248, 110, 91, 72, 224, 27, 153, 108, 173, 192, 1, 98, 47, 181, 227, 99, 180, 33>>
-        }
+        },
+        cache: %Blockchain.Interface.AccountInterface.Cache{cache: %{}}
       }
   """
-  @spec new(EVM.state()) :: t
-  def new(state) do
+  @spec new(EVM.state(), Cache.t()) :: t
+  def new(state, cache \\ %Cache{}) do
     %__MODULE__{
       state: state,
-      cache: %Cache{}
+      cache: cache
     }
   end
 
@@ -371,7 +372,7 @@ defimpl EVM.Interface.AccountInterface, for: Blockchain.Interface.AccountInterfa
     contract = Account.Address.from(evm_contract)
 
     params = %Contract.MessageCall{
-      state: account_interface.state,
+      account_interface: account_interface,
       sender: sender,
       originator: originator,
       recipient: recipient,
@@ -435,7 +436,7 @@ defimpl EVM.Interface.AccountInterface, for: Blockchain.Interface.AccountInterfa
     originator = Account.Address.from(evm_originator)
 
     params = %Contract.CreateContract{
-      state: account_interface.state,
+      account_interface: account_interface,
       sender: sender,
       originator: originator,
       available_gas: available_gas,

--- a/apps/blockchain/lib/blockchain/interface/account_interface/cache.ex
+++ b/apps/blockchain/lib/blockchain/interface/account_interface/cache.ex
@@ -1,0 +1,71 @@
+defmodule Blockchain.Interface.AccountInterface.Cache do
+  alias Blockchain.Account.Address
+  defstruct cache: %{}
+
+  @type key_cache() :: %{
+          integer() => %{current_value: integer() | :deleted, initial_value: integer() | nil}
+        }
+  @type account_cache :: %{Address.t() => key_cache()}
+  @type t :: %__MODULE__{
+          cache: account_cache()
+        }
+
+  @spec get_current_value(t(), Address.t(), integer()) :: integer() | nil
+  def get_current_value(cache_struct, address, key) do
+    get_key_value(cache_struct.cache, address, key, :current_value)
+  end
+
+  @spec get_initial_value(t(), Address.t(), integer()) :: integer() | nil
+  def get_initial_value(cache_struct, address, key) do
+    get_key_value(cache_struct.cache, address, key, :initial_value)
+  end
+
+  @spec update_current_value(t(), Address.t(), integer(), integer()) :: t()
+  def update_current_value(cache_struct, address, key, value) do
+    cache_update = %{key => %{current_value: value}}
+
+    updated_cache = update_key_cache(cache_struct.cache, address, cache_update)
+
+    %{cache_struct | cache: updated_cache}
+  end
+
+  @spec add_initial_value(t(), Address.t(), integer(), integer()) :: t()
+  def add_initial_value(cache_struct, address, key, value) do
+    cache_update = %{key => %{initial_value: value}}
+
+    updated_cache = update_key_cache(cache_struct.cache, address, cache_update)
+
+    %{cache_struct | cache: updated_cache}
+  end
+
+  @spec remove_current_value(t(), Address.t(), integer()) :: t()
+  def remove_current_value(cache_struct, address, key) do
+    cache_update = %{key => %{current_value: :deleted}}
+
+    updated_cache = update_key_cache(cache_struct.cache, address, cache_update)
+
+    %{cache_struct | cache: updated_cache}
+  end
+
+  @spec to_list(t()) :: list()
+  def to_list(cache_struct) do
+    Map.to_list(cache_struct.cache)
+  end
+
+  defp get_key_value(cache, address, key, value_name) do
+    with account_cache = %{} <- Map.get(cache, address),
+         key_cache = %{} <- Map.get(account_cache, key) do
+      Map.get(key_cache, value_name)
+    end
+  end
+
+  defp update_key_cache(cache, address, key_cache_update) do
+    cache_update = %{address => key_cache_update}
+
+    Map.merge(cache, cache_update, fn _k, account_cache, new_account_cache ->
+      Map.merge(account_cache, new_account_cache, fn _k, old_key_cache, new_key_cache ->
+        Map.merge(old_key_cache, new_key_cache, fn _k, _old_value, new_value -> new_value end)
+      end)
+    end)
+  end
+end

--- a/apps/blockchain/lib/blockchain/transaction.ex
+++ b/apps/blockchain/lib/blockchain/transaction.ex
@@ -9,6 +9,7 @@ defmodule Blockchain.Transaction do
   alias Blockchain.Transaction.Validity
   alias Block.Header
   alias EVM.{Gas, Configuration, SubState}
+  alias Blockchain.Interface.AccountInterface
 
   # nonce: T_n
   # gas_price: T_p
@@ -237,9 +238,11 @@ defmodule Blockchain.Transaction do
     # gas is equal to what was just subtracted from sender account less intrinsic gas cost
     gas = tx.gas_limit - intrinsic_gas_cost(tx, config)
 
+    account_interface = AccountInterface.new(state)
+
     if contract_creation?(tx) do
       %Contract.CreateContract{
-        state: state,
+        account_interface: account_interface,
         sender: sender,
         originator: originator,
         available_gas: gas,
@@ -254,7 +257,7 @@ defmodule Blockchain.Transaction do
       |> contract_creation_response()
     else
       %Contract.MessageCall{
-        state: state,
+        account_interface: account_interface,
         sender: sender,
         originator: originator,
         recipient: tx.to,

--- a/apps/blockchain/test/blockchain/contract/create_contract_test.exs
+++ b/apps/blockchain/test/blockchain/contract/create_contract_test.exs
@@ -5,6 +5,7 @@ defmodule Blockchain.Contract.CreateContractTest do
   alias Blockchain.{Account, Contract}
   alias EVM.{SubState, MachineCode}
   alias MerklePatriciaTree.{Trie, DB}
+  alias Blockchain.Interface.AccountInterface
 
   setup do
     db = MerklePatriciaTree.Test.random_ets_db(:contract_test)
@@ -21,7 +22,7 @@ defmodule Blockchain.Contract.CreateContractTest do
         |> Account.put_account(<<0x10::160>>, account)
 
       params = %Contract.CreateContract{
-        state: state,
+        account_interface: AccountInterface.new(state),
         sender: <<0x10::160>>,
         originator: <<0x10::160>>,
         available_gas: 100_000_000,
@@ -76,7 +77,7 @@ defmodule Blockchain.Contract.CreateContractTest do
         |> Account.put_account(collision_account_address, collision_account)
 
       params = %Contract.CreateContract{
-        state: state,
+        account_interface: AccountInterface.new(state),
         sender: account_address,
         originator: account_address,
         available_gas: 100_000_000,
@@ -104,7 +105,7 @@ defmodule Blockchain.Contract.CreateContractTest do
         |> Account.put_account(collision_account_address, collision_account)
 
       params = %Contract.CreateContract{
-        state: state,
+        account_interface: AccountInterface.new(state),
         sender: account_address,
         originator: account_address,
         available_gas: 100_000_000,

--- a/apps/blockchain/test/blockchain/contract/message_call_test.exs
+++ b/apps/blockchain/test/blockchain/contract/message_call_test.exs
@@ -5,6 +5,7 @@ defmodule Blockchain.Contract.MessageCallTest do
   alias Blockchain.{Account, Contract}
   alias EVM.{SubState, MachineCode}
   alias MerklePatriciaTree.{Trie, DB}
+  alias Blockchain.Interface.AccountInterface
 
   setup do
     db = MerklePatriciaTree.Test.random_ets_db(:message_call_test)
@@ -39,7 +40,7 @@ defmodule Blockchain.Contract.MessageCallTest do
         |> Account.put_code(<<0x20::160>>, code)
 
       params = %Contract.MessageCall{
-        state: state,
+        account_interface: AccountInterface.new(state),
         sender: <<0x10::160>>,
         originator: <<0x10::160>>,
         recipient: <<0x20::160>>,
@@ -97,7 +98,7 @@ defmodule Blockchain.Contract.MessageCallTest do
         |> Account.put_code(<<0x20::160>>, code)
 
       params = %Contract.MessageCall{
-        state: state,
+        account_interface: AccountInterface.new(state),
         sender: <<0x10::160>>,
         originator: <<0x10::160>>,
         recipient: <<0x20::160>>,
@@ -138,7 +139,7 @@ defmodule Blockchain.Contract.MessageCallTest do
         |> Account.put_code(<<0x20::160>>, code)
 
       params = %Contract.MessageCall{
-        state: state,
+        account_interface: AccountInterface.new(state),
         sender: <<0x10::160>>,
         originator: <<0x10::160>>,
         recipient: <<0x20::160>>,

--- a/apps/blockchain/test/blockchain/interface/account_interface/cache_test.exs
+++ b/apps/blockchain/test/blockchain/interface/account_interface/cache_test.exs
@@ -1,0 +1,127 @@
+defmodule Blockchain.Interface.AccountInterface.CacheTest do
+  use ExUnit.Case, async: true
+
+  alias Blockchain.Interface.AccountInterface.Cache
+
+  alias Blockchain.Interface.AccountInterface.Cache
+
+  describe "update_current_value/4" do
+    test "sets current_value" do
+      cache = %Cache{cache: %{}}
+
+      address = <<1>>
+      key = 2
+      value = 5
+
+      result = Cache.update_current_value(cache, address, key, value)
+      expected_result = %{<<1>> => %{2 => %{current_value: 5}}}
+
+      assert result.cache == expected_result
+    end
+
+    test "updates current_value" do
+      cache = %Cache{cache: %{<<1>> => %{2 => %{current_value: 5}}}}
+
+      address = <<1>>
+      key = 2
+      value = 6
+
+      result = Cache.update_current_value(cache, address, key, value)
+      expected_result = %{<<1>> => %{2 => %{current_value: 6}}}
+
+      assert result.cache == expected_result
+    end
+  end
+
+  describe "add_initial_value/4" do
+    test "sets initial_value" do
+      cache = %Cache{cache: %{}}
+
+      address = <<1>>
+      key = 2
+      value = 5
+
+      result = Cache.add_initial_value(cache, address, key, value)
+      expected_result = %{<<1>> => %{2 => %{initial_value: 5}}}
+
+      assert result.cache == expected_result
+    end
+
+    test "updates initial_value" do
+      cache = %Cache{cache: %{<<1>> => %{2 => %{initial_value: 5}}}}
+
+      address = <<1>>
+      key = 2
+      value = 6
+
+      result = Cache.add_initial_value(cache, address, key, value)
+      expected_result = %{<<1>> => %{2 => %{initial_value: 6}}}
+
+      assert result.cache == expected_result
+    end
+  end
+
+  describe "get_current_value/3" do
+    test "gets current_value when key cache exists" do
+      cache = %Cache{cache: %{<<1>> => %{2 => %{current_value: 5}}}}
+
+      address = <<1>>
+      key = 2
+
+      result = Cache.get_current_value(cache, address, key)
+
+      assert result == 5
+    end
+
+    test "gets current_value when key cache does not exist" do
+      cache = %Cache{cache: %{<<1>> => %{9 => %{current_value: 5}}}}
+
+      address = <<1>>
+      key = 2
+
+      result = Cache.get_current_value(cache, address, key)
+
+      assert is_nil(result)
+    end
+  end
+
+  describe "get_initial_current/3" do
+    test "gets initial_value when key cache exists" do
+      cache = %Cache{cache: %{<<1>> => %{2 => %{initial_value: 5}}}}
+
+      address = <<1>>
+      key = 2
+
+      result = Cache.get_initial_value(cache, address, key)
+
+      assert result == 5
+    end
+
+    test "gets initial_value when key cache does not exist" do
+      cache = %Cache{cache: %{<<1>> => %{9 => %{initial_value: 5}}}}
+
+      address = <<1>>
+      key = 2
+
+      result = Cache.get_initial_value(cache, address, key)
+
+      assert is_nil(result)
+    end
+  end
+
+  describe "remove_current_value/3" do
+    test "deleted current value" do
+      cache = %Cache{cache: %{<<1>> => %{2 => %{initial_value: 5}}}}
+
+      address = <<1>>
+      key = 2
+
+      result =
+        cache
+        |> Cache.remove_current_value(address, key)
+        |> Cache.get_current_value(address, key)
+
+      assert result == :deleted
+    end
+  end
+end

--- a/apps/evm/lib/evm/configuration.ex
+++ b/apps/evm/lib/evm/configuration.ex
@@ -108,4 +108,8 @@ defprotocol EVM.Configuration do
   # EIP1014
   @spec has_create2?(t) :: boolean()
   def has_create2?(t)
+
+  # EIP1283
+  @spec eip1283_sstore_gas_cost_changed?(t) :: boolean()
+  def eip1283_sstore_gas_cost_changed?(t)
 end

--- a/apps/evm/lib/evm/configuration/byzantium.ex
+++ b/apps/evm/lib/evm/configuration/byzantium.ex
@@ -103,4 +103,8 @@ defimpl EVM.Configuration, for: EVM.Configuration.Byzantium do
 
   @spec has_create2?(Configuration.t()) :: boolean()
   def has_create2?(config), do: Configuration.has_create2?(config.fallback_config)
+
+  @spec eip1283_sstore_gas_cost_changed?(Configuration.t()) :: boolean()
+  def eip1283_sstore_gas_cost_changed?(config),
+    do: Configuration.eip1283_sstore_gas_cost_changed?(config.fallback_config)
 end

--- a/apps/evm/lib/evm/configuration/constantinople.ex
+++ b/apps/evm/lib/evm/configuration/constantinople.ex
@@ -3,7 +3,8 @@ defmodule EVM.Configuration.Constantinople do
             has_shift_operations: true,
             has_extcodehash: true,
             has_create2: true,
-            eip1283_sstore_gas_cost_changed: true
+            # temporarily disabled (no common tests yet) https://github.com/ethereum/tests/issues/483
+            eip1283_sstore_gas_cost_changed: false
 
   def new do
     %__MODULE__{}

--- a/apps/evm/lib/evm/configuration/constantinople.ex
+++ b/apps/evm/lib/evm/configuration/constantinople.ex
@@ -2,7 +2,8 @@ defmodule EVM.Configuration.Constantinople do
   defstruct fallback_config: EVM.Configuration.Byzantium.new(),
             has_shift_operations: true,
             has_extcodehash: true,
-            has_create2: true
+            has_create2: true,
+            eip1283_sstore_gas_cost_changed: true
 
   def new do
     %__MODULE__{}
@@ -100,4 +101,8 @@ defimpl EVM.Configuration, for: EVM.Configuration.Constantinople do
 
   @spec has_create2?(Configuration.t()) :: boolean()
   def has_create2?(config), do: config.has_create2
+
+  @spec eip1283_sstore_gas_cost_changed?(Configuration.t()) :: boolean()
+  def eip1283_sstore_gas_cost_changed?(config),
+    do: config.eip1283_sstore_gas_cost_changed
 end

--- a/apps/evm/lib/evm/configuration/eip150.ex
+++ b/apps/evm/lib/evm/configuration/eip150.ex
@@ -106,4 +106,8 @@ defimpl EVM.Configuration, for: EVM.Configuration.EIP150 do
 
   @spec has_create2?(Configuration.t()) :: boolean()
   def has_create2?(config), do: Configuration.has_create2?(config.fallback_config)
+
+  @spec eip1283_sstore_gas_cost_changed?(Configuration.t()) :: boolean()
+  def eip1283_sstore_gas_cost_changed?(config),
+    do: Configuration.eip1283_sstore_gas_cost_changed?(config.fallback_config)
 end

--- a/apps/evm/lib/evm/configuration/eip158.ex
+++ b/apps/evm/lib/evm/configuration/eip158.ex
@@ -98,4 +98,8 @@ defimpl EVM.Configuration, for: EVM.Configuration.EIP158 do
 
   @spec has_create2?(Configuration.t()) :: boolean()
   def has_create2?(config), do: Configuration.has_create2?(config.fallback_config)
+
+  @spec eip1283_sstore_gas_cost_changed?(Configuration.t()) :: boolean()
+  def eip1283_sstore_gas_cost_changed?(config),
+    do: Configuration.eip1283_sstore_gas_cost_changed?(config.fallback_config)
 end

--- a/apps/evm/lib/evm/configuration/frontier.ex
+++ b/apps/evm/lib/evm/configuration/frontier.ex
@@ -24,7 +24,8 @@ defmodule EVM.Configuration.Frontier do
             has_ec_pairing_builtin: false,
             has_shift_operations: false,
             has_extcodehash: false,
-            has_create2: false
+            has_create2: false,
+            eip1283_sstore_gas_cost_changed: false
 
   def new do
     %__MODULE__{}
@@ -112,4 +113,7 @@ defimpl EVM.Configuration, for: EVM.Configuration.Frontier do
 
   @spec has_create2?(Configuration.t()) :: boolean()
   def has_create2?(config), do: config.has_create2
+
+  @spec eip1283_sstore_gas_cost_changed?(Configuration.t()) :: boolean()
+  def eip1283_sstore_gas_cost_changed?(config), do: config.eip1283_sstore_gas_cost_changed
 end

--- a/apps/evm/lib/evm/configuration/homestead.ex
+++ b/apps/evm/lib/evm/configuration/homestead.ex
@@ -99,4 +99,8 @@ defimpl EVM.Configuration, for: EVM.Configuration.Homestead do
 
   @spec has_create2?(Configuration.t()) :: boolean()
   def has_create2?(config), do: Configuration.has_create2?(config.fallback_config)
+
+  @spec eip1283_sstore_gas_cost_changed?(Configuration.t()) :: boolean()
+  def eip1283_sstore_gas_cost_changed?(config),
+    do: Configuration.eip1283_sstore_gas_cost_changed?(config.fallback_config)
 end

--- a/apps/evm/lib/evm/exec_env.ex
+++ b/apps/evm/lib/evm/exec_env.ex
@@ -70,6 +70,11 @@ defmodule EVM.ExecEnv do
     AccountInterface.get_storage(account_interface, address, key)
   end
 
+  @spec get_initial_storage(t(), integer()) :: atom() | {:ok, integer()}
+  def get_initial_storage(%{account_interface: account_interface, address: address}, key) do
+    AccountInterface.get_initial_storage(account_interface, address, key)
+  end
+
   @spec get_balance(t()) :: EVM.Wei.t()
   def get_balance(%{account_interface: account_interface, address: address}) do
     AccountInterface.get_account_balance(account_interface, address)

--- a/apps/evm/lib/evm/interface/account_interface.ex
+++ b/apps/evm/lib/evm/interface/account_interface.ex
@@ -38,6 +38,10 @@ defprotocol EVM.Interface.AccountInterface do
           {:ok, integer()} | :account_not_found | :key_not_found
   def get_storage(t, address, key)
 
+  @spec get_initial_storage(t, EVM.address(), integer()) ::
+          {:ok, integer()} | :account_not_found | :key_not_found
+  def get_initial_storage(t, address, key)
+
   @spec put_storage(t, EVM.address(), integer(), integer()) :: t
   def put_storage(t, address, key, value)
 

--- a/apps/evm/lib/evm/interface/mock/mock_account_interface.ex
+++ b/apps/evm/lib/evm/interface/mock/mock_account_interface.ex
@@ -98,7 +98,6 @@ defimpl EVM.Interface.AccountInterface, for: EVM.Interface.Mock.MockAccountInter
     }
   end
 
-  # TODO: Integrate new interface
   @spec get_storage(EVM.Interface.AccountInterface.t(), EVM.address(), integer()) ::
           {:ok, integer()} | :account_not_found | :key_not_found
   def get_storage(mock_account_interface, address, key) do
@@ -112,6 +111,12 @@ defimpl EVM.Interface.AccountInterface, for: EVM.Interface.Mock.MockAccountInter
           value -> {:ok, value}
         end
     end
+  end
+
+  @spec get_initial_storage(EVM.Interface.AccountInterface.t(), EVM.address(), integer()) ::
+          {:ok, integer()} | :account_not_found | :key_not_found
+  def get_initial_storage(mock_account_interface, address, key) do
+    get_storage(mock_account_interface, address, key)
   end
 
   @spec put_storage(EVM.Interface.AccountInterface.t(), EVM.address(), integer(), integer()) ::

--- a/apps/evm/lib/evm/refunds.ex
+++ b/apps/evm/lib/evm/refunds.ex
@@ -4,8 +4,7 @@ defmodule EVM.Refunds do
     MachineCode,
     MachineState,
     Operation,
-    SubState,
-    Configuration
+    SubState
   }
 
   @moduledoc """
@@ -14,8 +13,6 @@ defmodule EVM.Refunds do
 
   @type t :: EVM.val()
 
-  # Refund given (added into refund counter) when the storage value is set to zero from non-zero.
-  @storage_refund 15_000
   # Refund given (added into refund counter) for destroying an account.
   @selfdestruct_refund 24_000
 
@@ -86,70 +83,8 @@ defmodule EVM.Refunds do
 
   # `SSTORE` operations produce a refund when storage is set to zero from some non-zero value.
   def refund(:sstore, [key, new_value], _machine_state, _sub_state, exec_env) do
-    if Configuration.eip1283_sstore_gas_cost_changed?(exec_env.config) do
-      eip1283_sstore_refund([key, new_value], exec_env)
-    else
-      case ExecEnv.get_storage(exec_env, key) do
-        {:ok, value} ->
-          if value != 0 && new_value == 0 do
-            @storage_refund
-          else
-            0
-          end
-
-        _ ->
-          0
-      end
-    end
+    EVM.Refunds.Sstore.refund({key, new_value}, exec_env)
   end
 
   def refund(_opcode, _stack, _machine_state, _sub_state, _exec_env), do: 0
-
-  # credo:disable-for-next-line
-  defp eip1283_sstore_refund([key, new_value], exec_env) do
-    initial_value = get_initial_value(exec_env, key)
-    current_value = get_current_value(exec_env, key)
-
-    cond do
-      current_value == new_value ->
-        0
-
-      initial_value == current_value && initial_value == 0 ->
-        0
-
-      initial_value == current_value && initial_value != 0 && new_value == 0 ->
-        15_000
-
-      initial_value != current_value && initial_value != 0 && current_value == 0 ->
-        -15_000
-
-      initial_value != current_value && initial_value != 0 && new_value == 0 ->
-        15_000
-
-      initial_value != current_value && initial_value == new_value && initial_value == 0 ->
-        19_800
-
-      initial_value != current_value && initial_value == new_value && initial_value != 0 ->
-        4_800
-
-      true ->
-        0
-    end
-  end
-
-  defp get_initial_value(exec_env, key) do
-    case ExecEnv.get_initial_storage(exec_env, key) do
-      :account_not_found -> 0
-      :key_not_found -> 0
-      {:ok, value} -> value
-    end
-  end
-
-  defp get_current_value(exec_env, key) do
-    case ExecEnv.get_storage(exec_env, key) do
-      :account_not_found -> 0
-      :key_not_found -> 0
-      {:ok, value} -> value
-    end
-  end
 end

--- a/apps/evm/lib/evm/refunds.ex
+++ b/apps/evm/lib/evm/refunds.ex
@@ -87,45 +87,7 @@ defmodule EVM.Refunds do
   # `SSTORE` operations produce a refund when storage is set to zero from some non-zero value.
   def refund(:sstore, [key, new_value], _machine_state, _sub_state, exec_env) do
     if Configuration.eip1283_sstore_gas_cost_changed?(exec_env.config) do
-      initial_value =
-        case ExecEnv.get_initial_storage(exec_env, key) do
-          :account_not_found -> 0
-          :key_not_found -> 0
-          {:ok, value} -> value
-        end
-
-      current_value =
-        case ExecEnv.get_storage(exec_env, key) do
-          :account_not_found -> 0
-          :key_not_found -> 0
-          {:ok, value} -> value
-        end
-
-      cond do
-        current_value == new_value ->
-          0
-
-        initial_value == current_value && initial_value == 0 ->
-          0
-
-        initial_value == current_value && initial_value != 0 && new_value == 0 ->
-          15_000
-
-        initial_value != current_value && initial_value != 0 && current_value == 0 ->
-          -15_000
-
-        initial_value != current_value && initial_value != 0 && new_value == 0 ->
-          15_000
-
-        initial_value != current_value && initial_value == new_value && initial_value == 0 ->
-          19_800
-
-        initial_value != current_value && initial_value == new_value && initial_value != 0 ->
-          4_800
-
-        true ->
-          0
-      end
+      eip1283_sstore_refund([key, new_value], exec_env)
     else
       case ExecEnv.get_storage(exec_env, key) do
         {:ok, value} ->
@@ -142,4 +104,52 @@ defmodule EVM.Refunds do
   end
 
   def refund(_opcode, _stack, _machine_state, _sub_state, _exec_env), do: 0
+
+  # credo:disable-for-next-line
+  defp eip1283_sstore_refund([key, new_value], exec_env) do
+    initial_value = get_initial_value(exec_env, key)
+    current_value = get_current_value(exec_env, key)
+
+    cond do
+      current_value == new_value ->
+        0
+
+      initial_value == current_value && initial_value == 0 ->
+        0
+
+      initial_value == current_value && initial_value != 0 && new_value == 0 ->
+        15_000
+
+      initial_value != current_value && initial_value != 0 && current_value == 0 ->
+        -15_000
+
+      initial_value != current_value && initial_value != 0 && new_value == 0 ->
+        15_000
+
+      initial_value != current_value && initial_value == new_value && initial_value == 0 ->
+        19_800
+
+      initial_value != current_value && initial_value == new_value && initial_value != 0 ->
+        4_800
+
+      true ->
+        0
+    end
+  end
+
+  defp get_initial_value(exec_env, key) do
+    case ExecEnv.get_initial_storage(exec_env, key) do
+      :account_not_found -> 0
+      :key_not_found -> 0
+      {:ok, value} -> value
+    end
+  end
+
+  defp get_current_value(exec_env, key) do
+    case ExecEnv.get_storage(exec_env, key) do
+      :account_not_found -> 0
+      :key_not_found -> 0
+      {:ok, value} -> value
+    end
+  end
 end

--- a/apps/evm/lib/evm/refunds/sstore.ex
+++ b/apps/evm/lib/evm/refunds/sstore.ex
@@ -1,0 +1,73 @@
+defmodule EVM.Refunds.Sstore do
+  alias EVM.{ExecEnv, Configuration}
+
+  # Refund given (added into refund counter) when the storage value is set to zero from non-zero.
+  @storage_refund 15_000
+
+  @spec refund({integer(), integer()}, ExecEnv.t()) :: integer()
+  def refund({key, new_value}, exec_env) do
+    if Configuration.eip1283_sstore_gas_cost_changed?(exec_env.config) do
+      eip1283_sstore_refund([key, new_value], exec_env)
+    else
+      case ExecEnv.get_storage(exec_env, key) do
+        {:ok, value} ->
+          if value != 0 && new_value == 0 do
+            @storage_refund
+          else
+            0
+          end
+
+        _ ->
+          0
+      end
+    end
+  end
+
+  # credo:disable-for-next-line
+  defp eip1283_sstore_refund([key, new_value], exec_env) do
+    initial_value = get_initial_value(exec_env, key)
+    current_value = get_current_value(exec_env, key)
+
+    cond do
+      current_value == new_value ->
+        0
+
+      initial_value == current_value && initial_value == 0 ->
+        0
+
+      initial_value == current_value && initial_value != 0 && new_value == 0 ->
+        15_000
+
+      initial_value != current_value && initial_value != 0 && current_value == 0 ->
+        -15_000
+
+      initial_value != current_value && initial_value != 0 && new_value == 0 ->
+        15_000
+
+      initial_value != current_value && initial_value == new_value && initial_value == 0 ->
+        19_800
+
+      initial_value != current_value && initial_value == new_value && initial_value != 0 ->
+        4_800
+
+      true ->
+        0
+    end
+  end
+
+  defp get_initial_value(exec_env, key) do
+    case ExecEnv.get_initial_storage(exec_env, key) do
+      :account_not_found -> 0
+      :key_not_found -> 0
+      {:ok, value} -> value
+    end
+  end
+
+  defp get_current_value(exec_env, key) do
+    case ExecEnv.get_storage(exec_env, key) do
+      :account_not_found -> 0
+      :key_not_found -> 0
+      {:ok, value} -> value
+    end
+  end
+end


### PR DESCRIPTION
Resolves https://github.com/poanetwork/mana/issues/431

I created a cache for account storage modification in evm, So now we won't modify Merkle Patricia trie storage on sstore operations and only commit account storage changes on successful transaction execution ( for both message calls and contract creations).

