### PR TITLE
Do not remove storage in Account.del_account

### DIFF
--- a/apps/blockchain/lib/blockchain/account.ex
+++ b/apps/blockchain/lib/blockchain/account.ex
@@ -218,9 +218,7 @@ defmodule Blockchain.Account do
       nil ->
         state
 
-      acc ->
-        storage_trie = Trie.new(state.db, acc.storage_root)
-        Trie.Storage.delete(storage_trie)
+      _acc ->
         Trie.remove(state, Keccak.kec(address))
     end
   end

--- a/apps/blockchain/test/blockchain/account_test.exs
+++ b/apps/blockchain/test/blockchain/account_test.exs
@@ -6,7 +6,6 @@ defmodule Blockchain.AccountTest do
   alias ExthCrypto.Hash.Keccak
   alias MerklePatriciaTree.Trie
   alias Blockchain.Account
-  alias Blockchain.Account.Storage
 
   test "serialize and deserialize" do
     acct = %Account{
@@ -22,30 +21,6 @@ defmodule Blockchain.AccountTest do
              |> ExRLP.encode()
              |> ExRLP.decode()
              |> Account.deserialize()
-  end
-
-  test "cleans up storage when account is deleted" do
-    db = MerklePatriciaTree.Test.random_ets_db()
-    address = <<0x01::160>>
-
-    account = %Account{
-      nonce: 0,
-      balance: 0,
-      code_hash: Keccak.kec(<<>>),
-      storage_root: Trie.empty_trie_root_hash()
-    }
-
-    state =
-      db
-      |> Trie.new()
-      |> Account.put_account(address, account)
-      |> Account.put_storage(address, 42, 1)
-
-    account = Account.get_account(state, address)
-    Account.del_account(state, address)
-    value = Storage.fetch(db, account.storage_root, 42)
-
-    assert value == nil
   end
 
   test "valid empty state_root" do
@@ -153,5 +128,34 @@ defmodule Blockchain.AccountTest do
     assert state.root_hash ==
              <<192, 238, 234, 193, 139, 21, 7, 152, 194, 188, 80, 192, 211, 109, 186, 215, 229,
                222, 21, 222, 121, 230, 139, 179, 23, 132, 217, 128, 6, 17, 167, 54>>
+  end
+
+  test "deleting account does not remove storage root hash equal to another account's" do
+    db = MerklePatriciaTree.Test.random_ets_db()
+    address = <<0x01::160>>
+    address2 = <<0x02::160>>
+    key = 0
+    value = 1
+
+    state =
+      Trie.new(db)
+      |> Account.put_account(address, build_account())
+      |> Account.put_account(address2, build_account())
+      |> Account.put_storage(address, key, value)
+      |> Account.put_storage(address2, key, value)
+      |> Account.del_account(address2)
+
+    {:ok, storage} = Account.get_storage(state, address, key)
+
+    assert storage == value
+  end
+
+  defp build_account() do
+    %Account{
+      nonce: 0,
+      balance: 10,
+      code_hash: Keccak.kec(<<>>),
+      storage_root: Trie.empty_trie_root_hash()
+    }
   end
 end


### PR DESCRIPTION
Closes https://github.com/poanetwork/mana/issues/424

What?
=====

The deletion of storage currently has problems. We have encountered an
issue in block `179098` where we are trying to load values from storage
(via `SLOAD`) but the storage was previously deleted (in block `116172`)
because the account in that block has the _exact same storage root_ as
the account in block `179098`. Since deleting the storage of an account
means deleting the trie found at the storage root of that account,
deleting the storage in block `116172` removed the storage for block
`179098`.

Data from block `116172`:
------------------------

transaction number:
"0x47ba29b3a6598bc3f3bc79627f87bfee909edf7090314efac26fa58c8f81e916"

Account that was self destroyed:
"0x49e77af7f52eec4b042a52b957c96df1d7c1d31b"

Data from block `179098`:
------------------------
transaction number:
"0x65ac7e42338d8dee38ecb0525bee45bbdf8b3ad77c4478797adf166d3c7bf9b5"

Account that performed SLOAD and returned 0 incorrectly:
"0x9168414b724033d9ab0bc6dba06e26c851190953"

Co-authored-by: Matthew Sumner <matt.m.sumner@gmail.com>