### PR TITLE
return account_interface instead of state

### DIFF
--- a/apps/blockchain/lib/blockchain/contract/create_contract.ex
+++ b/apps/blockchain/lib/blockchain/contract/create_contract.ex
@@ -47,26 +47,30 @@ defmodule Blockchain.Contract.CreateContract do
           config: EVM.Configuration.t()
         }
 
-  @spec execute(t()) :: {:ok | :error, {EVM.state(), EVM.Gas.t(), EVM.SubState.t()}}
+  @spec execute(t()) :: {:ok | :error, {AccountInterface.t(), EVM.Gas.t(), EVM.SubState.t()}}
   def execute(params) do
-    original_state = params.account_interface.state
+    original_account_interface = params.account_interface
     contract_address = new_account_address(params)
-    account = Account.get_account(original_state, contract_address)
+    account = Account.get_account(original_account_interface.state, contract_address)
 
     if Account.exists?(account) do
       cond do
         account_will_collide?(account) ->
-          error(original_state)
+          error(original_account_interface)
 
         account.nonce == 0 && Account.is_simple_account?(account) &&
             not_in_contract_create_transaction?(params) ->
           new_state =
-            increment_nonce_of_touched_account(original_state, params.config, contract_address)
+            increment_nonce_of_touched_account(
+              original_account_interface.state,
+              params.config,
+              contract_address
+            )
 
-          {:ok, {new_state, params.available_gas, SubState.empty()}}
+          {:ok, {AccountInterface.new(new_state), params.available_gas, SubState.empty()}}
 
         true ->
-          {:ok, {original_state, 0, SubState.empty()}}
+          {:ok, {original_account_interface, 0, SubState.empty()}}
       end
     else
       result = {rem_gas, _, _, output} = create(params, contract_address)
@@ -79,8 +83,8 @@ defmodule Blockchain.Contract.CreateContract do
       # point immediately prior to balance transfer.
       #
       case output do
-        :failed -> error(original_state)
-        {:revert, _} -> {:error, {original_state, rem_gas, SubState.empty()}}
+        :failed -> error(original_account_interface)
+        {:revert, _} -> {:error, {original_account_interface, rem_gas, SubState.empty()}}
         _ -> finalize(result, params, contract_address)
       end
     end
@@ -157,19 +161,19 @@ defmodule Blockchain.Contract.CreateContract do
           EVM.address()
         ) :: {:ok | :error, {EVM.state(), EVM.Gas.t(), EVM.SubState.t()}}
   defp finalize({remaining_gas, accrued_sub_state, exec_env, output}, params, address) do
-    original_state = params.account_interface.state
+    original_account_interface = params.account_interface
     contract_creation_cost = creation_cost(output)
     insufficient_gas = remaining_gas < contract_creation_cost
 
     cond do
       insufficient_gas && EVM.Configuration.fail_contract_creation_lack_of_gas?(params.config) ->
-        {:error, {original_state, 0, SubState.empty()}}
+        {:error, {original_account_interface, 0, SubState.empty()}}
 
       EVM.Configuration.limit_contract_code_size?(params.config, byte_size(output)) ->
-        {:error, {original_state, 0, SubState.empty()}}
+        {:error, {original_account_interface, 0, SubState.empty()}}
 
       true ->
-        commited_state = AccountInterface.commit_storage(exec_env.account_interface)
+        modified_account_interface = exec_env.account_interface
 
         resultant_gas =
           if insufficient_gas do
@@ -178,16 +182,18 @@ defmodule Blockchain.Contract.CreateContract do
             remaining_gas - contract_creation_cost
           end
 
-        resultant_state =
+        resultant_account_interface =
           if insufficient_gas do
-            commited_state
+            modified_account_interface
           else
-            Account.put_code(commited_state, address, output)
+            new_state = Account.put_code(modified_account_interface.state, address, output)
+
+            AccountInterface.new(new_state, modified_account_interface.cache)
           end
 
         sub_state = SubState.add_touched_account(accrued_sub_state, address)
 
-        {:ok, {resultant_state, resultant_gas, sub_state}}
+        {:ok, {resultant_account_interface, resultant_gas, sub_state}}
     end
   end
 

--- a/apps/blockchain/lib/blockchain/contract/create_contract.ex
+++ b/apps/blockchain/lib/blockchain/contract/create_contract.ex
@@ -113,9 +113,9 @@ defmodule Blockchain.Contract.CreateContract do
     account.nonce > 0 || !Account.is_simple_account?(account)
   end
 
-  @spec error(EVM.state()) :: {:error, EVM.state(), 0, SubState.t()}
-  defp error(state) do
-    {:error, {state, 0, SubState.empty()}}
+  @spec error(AccountInterface.t()) :: {:error, {AccountInterface.t(), 0, SubState.t()}}
+  defp error(account_interface) do
+    {:error, {account_interface, 0, SubState.empty()}}
   end
 
   @spec create(t(), EVM.address()) :: {EVM.state(), EVM.Gas.t(), EVM.SubState.t()}
@@ -159,7 +159,7 @@ defmodule Blockchain.Contract.CreateContract do
           {EVM.Gas.t(), EVM.SubState.t(), EVM.ExecEnv.t(), EVM.VM.output()},
           t(),
           EVM.address()
-        ) :: {:ok | :error, {EVM.state(), EVM.Gas.t(), EVM.SubState.t()}}
+        ) :: {:ok | :error, {AccountInterface.t(), EVM.Gas.t(), EVM.SubState.t()}}
   defp finalize({remaining_gas, accrued_sub_state, exec_env, output}, params, address) do
     original_account_interface = params.account_interface
     contract_creation_cost = creation_cost(output)

--- a/apps/blockchain/lib/blockchain/contract/message_call.ex
+++ b/apps/blockchain/lib/blockchain/contract/message_call.ex
@@ -64,7 +64,7 @@ defmodule Blockchain.Contract.MessageCall do
   TODO: Add serious (less trivial) test cases in `contract_test.exs`
   """
   @spec execute(t()) ::
-          {:ok | :error, {EVM.state(), EVM.Gas.t(), EVM.SubState.t(), EVM.VM.output()}}
+          {:ok | :error, {AccountInterface.t(), EVM.Gas.t(), EVM.SubState.t(), EVM.VM.output()}}
   def execute(params) do
     original_state = params.account_interface.state
     run = MessageCall.get_run_function(params.recipient, params.config)
@@ -107,14 +107,13 @@ defmodule Blockchain.Contract.MessageCall do
     # point immediately prior to balance transfer.
     case output do
       :failed ->
-        {:error, {original_state, 0, SubState.empty(), :failed}}
+        {:error, {params.account_interface, 0, SubState.empty(), :failed}}
 
       {:revert, _output} ->
-        {:error, {original_state, gas, SubState.empty(), :failed}}
+        {:error, {params.account_interface, gas, SubState.empty(), :failed}}
 
       _ ->
-        commited_state = AccountInterface.commit_storage(exec_env.account_interface)
-        {:ok, {commited_state, gas, sub_state, output}}
+        {:ok, {exec_env.account_interface, gas, sub_state, output}}
     end
   end
 end

--- a/apps/blockchain/lib/blockchain/interface/account_interface.ex
+++ b/apps/blockchain/lib/blockchain/interface/account_interface.ex
@@ -382,9 +382,9 @@ defimpl EVM.Interface.AccountInterface, for: Blockchain.Interface.AccountInterfa
       block_header: block_header
     }
 
-    {_, {state, gas, sub_state, output}} = Contract.message_call(params)
+    {_status, result} = Contract.message_call(params)
 
-    {Map.put(account_interface, :state, state), gas, sub_state, output}
+    result
   end
 
   @doc """
@@ -445,10 +445,7 @@ defimpl EVM.Interface.AccountInterface, for: Blockchain.Interface.AccountInterfa
       config: config
     }
 
-    {status, {state, gas, sub_state}} = Contract.create(params)
-
-    n_account_interface = Map.put(account_interface, :state, state)
-    {status, {n_account_interface, gas, sub_state}}
+    Contract.create(params)
   end
 
   @doc """

--- a/apps/blockchain/lib/blockchain/transaction.ex
+++ b/apps/blockchain/lib/blockchain/transaction.ex
@@ -282,20 +282,24 @@ defmodule Blockchain.Transaction do
     {state, gas, new_sub_state, status}
   end
 
-  defp contract_creation_response({:ok, {state, remaining_gas, sub_state}}) do
+  defp contract_creation_response({:ok, {account_interface, remaining_gas, sub_state}}) do
+    state = AccountInterface.commit_storage(account_interface)
+
     {state, remaining_gas, sub_state, @success_status}
   end
 
-  defp contract_creation_response({:error, {state, remaining_gas, sub_state}}) do
-    {state, remaining_gas, sub_state, @failure_status}
+  defp contract_creation_response({:error, {account_interface, remaining_gas, sub_state}}) do
+    {account_interface.state, remaining_gas, sub_state, @failure_status}
   end
 
-  defp message_call_response({:ok, {state, remaining_gas, sub_state, _output}}) do
+  defp message_call_response({:ok, {account_interface, remaining_gas, sub_state, _output}}) do
+    state = AccountInterface.commit_storage(account_interface)
+
     {state, remaining_gas, sub_state, @success_status}
   end
 
-  defp message_call_response({:error, {state, remaining_gas, sub_state, _output}}) do
-    {state, remaining_gas, sub_state, @failure_status}
+  defp message_call_response({:error, {account_interface, remaining_gas, sub_state, _output}}) do
+    {account_interface.state, remaining_gas, sub_state, @failure_status}
   end
 
   @spec calculate_gas_usage(t, Gas.t(), EVM.SubState.t()) :: {Gas.t(), Gas.t()}

--- a/apps/blockchain/test/blockchain/contract/create_contract_test.exs
+++ b/apps/blockchain/test/blockchain/contract/create_contract_test.exs
@@ -33,7 +33,8 @@ defmodule Blockchain.Contract.CreateContractTest do
         block_header: %Block.Header{nonce: 1}
       }
 
-      {_, {state, gas, sub_state}} = Contract.create(params)
+      {_, {account_interface, gas, sub_state}} = Contract.create(params)
+      state = account_interface.state
 
       expected_root_hash =
         <<9, 235, 32, 146, 153, 242, 209, 192, 224, 61, 214, 174, 48, 24, 148, 28, 51, 254, 7, 82,
@@ -88,7 +89,9 @@ defmodule Blockchain.Contract.CreateContractTest do
         block_header: %Block.Header{nonce: 1}
       }
 
-      assert {:error, {^state, 0, sub_state}} = Contract.create(params)
+      {:error, {account_interface, 0, sub_state}} = Contract.create(params)
+      assert state == account_interface.state
+
       assert SubState.empty?(sub_state)
     end
 
@@ -116,7 +119,9 @@ defmodule Blockchain.Contract.CreateContractTest do
         block_header: %Block.Header{nonce: 1}
       }
 
-      assert {:error, {^state, 0, sub_state}} = Contract.create(params)
+      {:error, {account_interface, 0, sub_state}} = Contract.create(params)
+      assert state == account_interface.state
+
       assert SubState.empty?(sub_state)
     end
   end

--- a/apps/blockchain/test/blockchain/contract/message_call_test.exs
+++ b/apps/blockchain/test/blockchain/contract/message_call_test.exs
@@ -54,7 +54,8 @@ defmodule Blockchain.Contract.MessageCallTest do
         block_header: %Block.Header{nonce: 1}
       }
 
-      {:ok, {state, gas, sub_state, output}} = Contract.message_call(params)
+      {:ok, {account_interface, gas, sub_state, output}} = Contract.message_call(params)
+      state = account_interface.state
 
       expected_root_hash =
         <<163, 151, 95, 0, 149, 63, 81, 220, 74, 101, 219, 175, 240, 97, 153, 167, 249, 229, 144,
@@ -112,7 +113,9 @@ defmodule Blockchain.Contract.MessageCallTest do
         block_header: %Block.Header{nonce: 1}
       }
 
-      assert {:error, {^state, gas, sub_state, output}} = Contract.message_call(params)
+      assert {:error, {account_interface, gas, sub_state, output}} = Contract.message_call(params)
+      assert account_interface.state == state
+
       assert gas == 0
       assert SubState.empty?(sub_state)
       assert output == :failed
@@ -154,7 +157,9 @@ defmodule Blockchain.Contract.MessageCallTest do
         config: EVM.Configuration.Byzantium.new()
       }
 
-      assert {:error, {^state, gas, sub_state, output}} = Contract.message_call(params)
+      assert {:error, {account_interface, gas, sub_state, output}} = Contract.message_call(params)
+      assert account_interface.state == state
+
       assert gas == 985
       assert SubState.empty?(sub_state)
       assert output == :failed


### PR DESCRIPTION
Part of https://github.com/poanetwork/mana/issues/416

To work with cache instead of permanent storage in evm we need to add accounts state (balance changes etc) caching to `AccountInterface`. 

Currently, we are returning state with applied changes from `CreateContract` and `MessageCall` modules.
 
Changes:
- return account_interface from `CreateContract` and `MessageCall` to apply changes in `Transaction` module