### PR TITLE
cache storage operations

### DIFF
--- a/apps/blockchain/lib/blockchain/account.ex
+++ b/apps/blockchain/lib/blockchain/account.ex
@@ -627,4 +627,14 @@ defmodule Blockchain.Account do
   def reset_account(state, address) do
     put_account(state, address, %__MODULE__{})
   end
+
+  @spec empty_keccak() :: binary()
+  def empty_keccak do
+    @empty_keccak
+  end
+
+  @spec empty_trie() :: binary()
+  def empty_trie do
+    @empty_trie
+  end
 end

--- a/apps/blockchain/lib/blockchain/contract/create_contract.ex
+++ b/apps/blockchain/lib/blockchain/contract/create_contract.ex
@@ -197,7 +197,7 @@ defmodule Blockchain.Contract.CreateContract do
     if params.new_account_address do
       params.new_account_address
     else
-      sender_account = Account.get_account(params.account_interface.state, params.sender)
+      {sender_account, _} = AccountInterface.account(params.account_interface, params.sender)
       Account.Address.new(params.sender, sender_account.nonce)
     end
   end

--- a/apps/blockchain/lib/blockchain/contract/create_contract.ex
+++ b/apps/blockchain/lib/blockchain/contract/create_contract.ex
@@ -51,7 +51,7 @@ defmodule Blockchain.Contract.CreateContract do
   def execute(params) do
     original_account_interface = params.account_interface
     contract_address = new_account_address(params)
-    {account, _} = AccountInterface.account(original_account_interface, contract_address)
+    account = AccountInterface.account(original_account_interface, contract_address)
 
     if is_nil(account) || Account.uninitialized_contract?(account) do
       result = {rem_gas, _, _, output} = create(params, contract_address)
@@ -129,7 +129,7 @@ defmodule Blockchain.Contract.CreateContract do
 
   @spec init_account(t, EVM.address()) :: AccountInterface.t()
   defp init_account(params, address) do
-    {account, _code} = AccountInterface.account(params.account_interface, address)
+    account = AccountInterface.account(params.account_interface, address)
 
     account_interface =
       if is_nil(account) do
@@ -197,7 +197,7 @@ defmodule Blockchain.Contract.CreateContract do
     if params.new_account_address do
       params.new_account_address
     else
-      {sender_account, _} = AccountInterface.account(params.account_interface, params.sender)
+      sender_account = AccountInterface.account(params.account_interface, params.sender)
       Account.Address.new(params.sender, sender_account.nonce)
     end
   end

--- a/apps/blockchain/lib/blockchain/contract/create_contract.ex
+++ b/apps/blockchain/lib/blockchain/contract/create_contract.ex
@@ -135,7 +135,7 @@ defmodule Blockchain.Contract.CreateContract do
       if is_nil(account) do
         AccountInterface.reset_account(params.account_interface, address)
       else
-        params.account_interface.state
+        params.account_interface
       end
 
     AccountInterface.transfer_wei!(account_interface, params.sender, address, params.endowment)

--- a/apps/blockchain/lib/blockchain/contract/create_contract.ex
+++ b/apps/blockchain/lib/blockchain/contract/create_contract.ex
@@ -51,7 +51,7 @@ defmodule Blockchain.Contract.CreateContract do
   def execute(params) do
     original_account_interface = params.account_interface
     contract_address = new_account_address(params)
-    account = Account.get_account(original_account_interface.state, contract_address)
+    {account, _} = AccountInterface.account(original_account_interface, contract_address)
 
     if is_nil(account) || Account.uninitialized_contract?(account) do
       result = {rem_gas, _, _, output} = create(params, contract_address)
@@ -77,13 +77,16 @@ defmodule Blockchain.Contract.CreateContract do
     end
   end
 
-  @spec increment_nonce_of_touched_account(EVM.state(), EVM.Configuration.t(), EVM.address()) ::
-          EVM.state()
-  defp increment_nonce_of_touched_account(state, config, address) do
+  @spec increment_nonce_of_touched_account(
+          AccountInterface.t(),
+          EVM.Configuration.t(),
+          EVM.address()
+        ) :: AccountInterface.t()
+  defp increment_nonce_of_touched_account(account_interface, config, address) do
     if EVM.Configuration.increment_nonce_on_create?(config) do
-      Account.increment_nonce(state, address)
+      AccountInterface.increment_account_nonce(account_interface, address)
     else
-      state
+      account_interface
     end
   end
 
@@ -99,13 +102,10 @@ defmodule Blockchain.Contract.CreateContract do
 
   @spec create(t(), EVM.address()) :: {EVM.state(), EVM.Gas.t(), EVM.SubState.t()}
   defp create(params, address) do
-    state_with_blank_contract =
+    account_interface =
       params
       |> init_account(address)
       |> increment_nonce_of_touched_account(params.config, address)
-
-    account_interface =
-      AccountInterface.new(state_with_blank_contract, params.account_interface.cache)
 
     # Create an execution environment for a create contract call.
     # This is defined in Eq.(88), Eq.(89), Eq.(90), Eq.(91), Eq.(92),
@@ -119,7 +119,7 @@ defmodule Blockchain.Contract.CreateContract do
       value_in_wei: params.endowment,
       machine_code: params.init_code,
       stack_depth: params.stack_depth,
-      block_interface: BlockInterface.new(params.block_header, state_with_blank_contract.db),
+      block_interface: BlockInterface.new(params.block_header, account_interface.state.db),
       account_interface: account_interface,
       config: params.config
     }
@@ -127,20 +127,18 @@ defmodule Blockchain.Contract.CreateContract do
     EVM.VM.run(params.available_gas, exec_env)
   end
 
-  @spec init_account(t, EVM.address()) :: EVM.state()
+  @spec init_account(t, EVM.address()) :: AccountInterface.t()
   defp init_account(params, address) do
-    account = Account.get_account(params.account_interface.state, address)
+    {account, _code} = AccountInterface.account(params.account_interface, address)
 
-    state =
+    account_interface =
       if is_nil(account) do
-        params.account_interface.state
-        |> Account.put_account(address, %Account{})
+        AccountInterface.reset_account(params.account_interface, address)
       else
         params.account_interface.state
       end
 
-    state
-    |> Account.transfer!(params.sender, address, params.endowment)
+    AccountInterface.transfer_wei!(account_interface, params.sender, address, params.endowment)
   end
 
   @spec finalize(
@@ -174,9 +172,7 @@ defmodule Blockchain.Contract.CreateContract do
           if insufficient_gas do
             modified_account_interface
           else
-            new_state = Account.put_code(modified_account_interface.state, address, output)
-
-            AccountInterface.new(new_state, modified_account_interface.cache)
+            AccountInterface.put_code(modified_account_interface, address, output)
           end
 
         sub_state = SubState.add_touched_account(accrued_sub_state, address)

--- a/apps/blockchain/lib/blockchain/interface/account_interface.ex
+++ b/apps/blockchain/lib/blockchain/interface/account_interface.ex
@@ -389,8 +389,9 @@ defimpl EVM.Interface.AccountInterface, for: Blockchain.Interface.AccountInterfa
           AccountInterface.t()
   def put_storage(account_interface, evm_address, key, value) do
     address = Account.Address.from(evm_address)
+    {account, _code} = BlockchainAccountInterface.account(account_interface, address)
 
-    if Account.get_account(account_interface.state, address) do
+    if account do
       updated_cache = Cache.update_current_value(account_interface.cache, address, key, value)
 
       %{account_interface | cache: updated_cache}
@@ -402,8 +403,9 @@ defimpl EVM.Interface.AccountInterface, for: Blockchain.Interface.AccountInterfa
   @spec remove_storage(AccountInterface.t(), EVM.address(), integer()) :: AccountInterface.t()
   def remove_storage(account_interface, evm_address, key) do
     address = Account.Address.from(evm_address)
+    {account, _code} = BlockchainAccountInterface.account(account_interface, address)
 
-    if Account.get_account(account_interface.state, address) do
+    if account do
       updated_cache = Cache.remove_current_value(account_interface.cache, address, key)
 
       %{account_interface | cache: updated_cache}

--- a/apps/blockchain/lib/blockchain/interface/account_interface.ex
+++ b/apps/blockchain/lib/blockchain/interface/account_interface.ex
@@ -99,6 +99,35 @@ defmodule Blockchain.Interface.AccountInterface do
     %{account_interface | cache: updated_cache}
   end
 
+  @spec machine_code(t(), Address.t()) :: {:ok, binary()} | :not_found
+  def machine_code(account_interface, address) do
+    {_account, code} = account(account_interface, address)
+
+    case code do
+      nil -> Account.get_machine_code(account_interface.state, address)
+      code -> {:ok, code}
+    end
+  end
+
+  @spec clear_balance(t(), Address.t()) :: t()
+  def clear_balance(account_interface, address) do
+    {account, code} = account(account_interface, address)
+
+    updated_account = %{account | balance: 0}
+
+    updated_cache =
+      Cache.update_account(account_interface.cache, address, {updated_account, code})
+
+    %{account_interface | cache: updated_cache}
+  end
+
+  @spec reset_account(t(), Address.t()) :: t()
+  def reset_account(account_interface, address) do
+    updated_cache = Cache.update_account(account_interface.cache, address, {%Account{}, nil})
+
+    %{account_interface | cache: updated_cache}
+  end
+
   @spec account(t(), Address.t()) :: Account.t() | {Account.t(), EVM.MachineCode.t()} | nil
   def account(account_interface, address) do
     found_account =

--- a/apps/blockchain/lib/blockchain/interface/account_interface.ex
+++ b/apps/blockchain/lib/blockchain/interface/account_interface.ex
@@ -86,6 +86,9 @@ defmodule Blockchain.Interface.AccountInterface do
       from_account.balance < wei ->
         raise("sender account insufficient wei")
 
+      from == to ->
+        account_interface
+
       true ->
         {to_account, to_account_code} = account(account_interface, to)
         to_account = to_account || %Account{}

--- a/apps/blockchain/lib/blockchain/interface/account_interface.ex
+++ b/apps/blockchain/lib/blockchain/interface/account_interface.ex
@@ -42,9 +42,9 @@ defmodule Blockchain.Interface.AccountInterface do
 
   @spec commit(t()) :: t()
   def commit(account_interface) do
-    account_interface
-    |> commit_accounts()
-    |> commit_storage()
+    account_interface.cache
+    |> Cache.commit(account_interface.state)
+    |> new()
   end
 
   @spec commit_storage(t()) :: t()

--- a/apps/blockchain/lib/blockchain/interface/account_interface.ex
+++ b/apps/blockchain/lib/blockchain/interface/account_interface.ex
@@ -281,6 +281,7 @@ defimpl EVM.Interface.AccountInterface, for: Blockchain.Interface.AccountInterfa
       iex> {account_interface, nonce} =
       ...> MerklePatriciaTree.Test.random_ets_db()
       ...> |> MerklePatriciaTree.Trie.new()
+      ...> |> Blockchain.Account.reset_account(<<1::160>>)
       ...> |> Blockchain.Interface.AccountInterface.new()
       ...> |> EVM.Interface.AccountInterface.increment_account_nonce(<<1::160>>)
       iex> nonce
@@ -297,9 +298,9 @@ defimpl EVM.Interface.AccountInterface, for: Blockchain.Interface.AccountInterfa
     updated_account_interface =
       BlockchainAccountInterface.increment_account_nonce(account_interface, address)
 
-    {account, _code} = BlockchainAccountInterface.account(account_interface, address)
+    {account, _code} = BlockchainAccountInterface.account(updated_account_interface, address)
 
-    {updated_account_interface, account.nonce}
+    {updated_account_interface, account.nonce - 1}
   end
 
   @doc """
@@ -469,7 +470,7 @@ defimpl EVM.Interface.AccountInterface, for: Blockchain.Interface.AccountInterfa
       ...> |> Blockchain.Account.put_code(<<0x20::160>>, EVM.MachineCode.compile([:push1, 3, :push1, 5, :add, :push1, 0x00, :mstore, :push1, 32, :push1, 0, :return]))
       ...> |> Blockchain.Interface.AccountInterface.new()
       ...> |> EVM.Interface.AccountInterface.message_call(<<0x10::160>>, <<0x10::160>>, <<0x20::160>>, <<0x20::160>>, 1000, 1, 5, 5, <<1, 2, 3>>, 5, %Block.Header{nonce: 1})
-      iex> account_interface.state.root_hash
+      iex> Blockchain.Interface.AccountInterface.commit(account_interface).state.root_hash
       <<163, 151, 95, 0, 149, 63, 81, 220, 74, 101, 219, 175, 240, 97, 153, 167, 249, 229, 144, 75, 101, 233, 126, 177, 8, 188, 105, 165, 28, 248, 67, 156>>
   """
   @spec message_call(
@@ -535,7 +536,7 @@ defimpl EVM.Interface.AccountInterface, for: Blockchain.Interface.AccountInterfa
       ...> |> Blockchain.Account.put_account(<<0x10::160>>, %Blockchain.Account{balance: 11, nonce: 5})
       ...> |> Blockchain.Interface.AccountInterface.new()
       ...> |> EVM.Interface.AccountInterface.create_contract(<<0x10::160>>, <<0x10::160>>, 1000, 1, 5, EVM.MachineCode.compile([:push1, 3, :push1, 5, :add, :push1, 0x00, :mstore, :push1, 32, :push1, 0, :return]), 5, %Block.Header{nonce: 1}, nil,  EVM.Configuration.Frontier.new())
-      iex> account_interface.state.root_hash
+      ...> Blockchain.Interface.AccountInterface.commit(account_interface).state.root_hash
       <<226, 121, 240, 77, 157, 98, 127, 111, 137, 201, 186, 41, 100, 239,
               227, 209, 92, 247, 21, 58, 119, 4, 191, 255, 84, 144, 86, 99, 178,
               157, 145, 31>>

--- a/apps/blockchain/lib/blockchain/interface/account_interface/cache.ex
+++ b/apps/blockchain/lib/blockchain/interface/account_interface/cache.ex
@@ -62,6 +62,13 @@ defmodule Blockchain.Interface.AccountInterface.Cache do
     %{cache_struct | accounts_cache: updated_accounts_cache}
   end
 
+  @spec commit(t(), EVM.state()) :: EVM.state()
+  def commit(cache_struct, state) do
+    committed_storage = commit_storage(cache_struct, state)
+
+    commit_accounts(cache_struct, committed_storage)
+  end
+
   @spec commit_storage(t(), EVM.state()) :: EVM.state()
   def commit_storage(cache_struct, state) do
     cache_struct

--- a/apps/blockchain/lib/blockchain/interface/account_interface/cache.ex
+++ b/apps/blockchain/lib/blockchain/interface/account_interface/cache.ex
@@ -64,9 +64,9 @@ defmodule Blockchain.Interface.AccountInterface.Cache do
 
   @spec commit(t(), EVM.state()) :: EVM.state()
   def commit(cache_struct, state) do
-    committed_storage = commit_storage(cache_struct, state)
+    committed_accounts = commit_accounts(cache_struct, state)
 
-    commit_accounts(cache_struct, committed_storage)
+    commit_storage(cache_struct, committed_accounts)
   end
 
   @spec commit_storage(t(), EVM.state()) :: EVM.state()

--- a/apps/blockchain/lib/blockchain/transaction.ex
+++ b/apps/blockchain/lib/blockchain/transaction.ex
@@ -283,7 +283,7 @@ defmodule Blockchain.Transaction do
   end
 
   defp contract_creation_response({:ok, {account_interface, remaining_gas, sub_state}}) do
-    state = AccountInterface.commit_storage(account_interface)
+    state = AccountInterface.commit(account_interface).state
 
     {state, remaining_gas, sub_state, @success_status}
   end
@@ -293,7 +293,7 @@ defmodule Blockchain.Transaction do
   end
 
   defp message_call_response({:ok, {account_interface, remaining_gas, sub_state, _output}}) do
-    state = AccountInterface.commit_storage(account_interface)
+    state = AccountInterface.commit(account_interface).state
 
     {state, remaining_gas, sub_state, @success_status}
   end

--- a/apps/blockchain/test/blockchain/contract/create_contract_test.exs
+++ b/apps/blockchain/test/blockchain/contract/create_contract_test.exs
@@ -150,7 +150,7 @@ defmodule Blockchain.Contract.CreateContractTest do
         block_header: %Block.Header{nonce: 1}
       }
 
-      {_, {account_interface, gas, sub_state}} = Contract.create(params)
+      {_, {account_interface, _gas, _sub_state}} = Contract.create(params)
       state = AccountInterface.commit(account_interface).state
 
       addresses = [<<0x10::160>>, Account.Address.new(<<0x10::160>>, 2)]

--- a/apps/blockchain/test/blockchain/contract/create_contract_test.exs
+++ b/apps/blockchain/test/blockchain/contract/create_contract_test.exs
@@ -150,7 +150,8 @@ defmodule Blockchain.Contract.CreateContractTest do
         block_header: %Block.Header{nonce: 1}
       }
 
-      {_, {%{state: state}, gas, sub_state}} = Contract.create(params)
+      {_, {acount_interface, gas, sub_state}} = Contract.create(params)
+      state = AccountInterface.commit(account_interface).state
 
       addresses = [<<0x10::160>>, Account.Address.new(<<0x10::160>>, 2)]
       actual_accounts = Account.get_accounts(state, addresses)

--- a/apps/blockchain/test/blockchain/contract/create_contract_test.exs
+++ b/apps/blockchain/test/blockchain/contract/create_contract_test.exs
@@ -34,7 +34,8 @@ defmodule Blockchain.Contract.CreateContractTest do
         block_header: %Block.Header{nonce: 1}
       }
 
-      {_, {%{state: state}, gas, sub_state}} = Contract.create(params)
+      {_, {account_interface, gas, sub_state}} = Contract.create(params)
+      state = AccountInterface.commit(account_interface).state
 
       expected_root_hash =
         <<9, 235, 32, 146, 153, 242, 209, 192, 224, 61, 214, 174, 48, 24, 148, 28, 51, 254, 7, 82,

--- a/apps/blockchain/test/blockchain/contract/create_contract_test.exs
+++ b/apps/blockchain/test/blockchain/contract/create_contract_test.exs
@@ -150,7 +150,7 @@ defmodule Blockchain.Contract.CreateContractTest do
         block_header: %Block.Header{nonce: 1}
       }
 
-      {_, {acount_interface, gas, sub_state}} = Contract.create(params)
+      {_, {account_interface, gas, sub_state}} = Contract.create(params)
       state = AccountInterface.commit(account_interface).state
 
       addresses = [<<0x10::160>>, Account.Address.new(<<0x10::160>>, 2)]

--- a/apps/blockchain/test/blockchain/contract/message_call_test.exs
+++ b/apps/blockchain/test/blockchain/contract/message_call_test.exs
@@ -55,7 +55,7 @@ defmodule Blockchain.Contract.MessageCallTest do
       }
 
       {:ok, {account_interface, gas, sub_state, output}} = Contract.message_call(params)
-      state = account_interface.state
+      state = AccountInterface.commit(account_interface).state
 
       expected_root_hash =
         <<163, 151, 95, 0, 149, 63, 81, 220, 74, 101, 219, 175, 240, 97, 153, 167, 249, 229, 144,

--- a/apps/blockchain/test/blockchain/interface/account_interface/cache_test.exs
+++ b/apps/blockchain/test/blockchain/interface/account_interface/cache_test.exs
@@ -247,7 +247,7 @@ defmodule Blockchain.Interface.AccountInterface.CacheTest do
         code_hash: <<0x01, 0x02>>
       }
 
-      cache = %Cache{accounts_cache: %{address => new_account}}
+      cache = %Cache{accounts_cache: %{address => {new_account, nil}}}
 
       committed_state = Cache.commit_accounts(cache, state)
 

--- a/apps/blockchain/test/blockchain/interface/account_interface/cache_test.exs
+++ b/apps/blockchain/test/blockchain/interface/account_interface/cache_test.exs
@@ -15,11 +15,11 @@ defmodule Blockchain.Interface.AccountInterface.CacheTest do
       result = Cache.update_current_value(cache, address, key, value)
       expected_result = %{<<1>> => %{2 => %{current_value: 5}}}
 
-      assert result.cache == expected_result
+      assert result.storage_cache == expected_result
     end
 
     test "updates current_value" do
-      cache = %Cache{cache: %{<<1>> => %{2 => %{current_value: 5}}}}
+      cache = %Cache{storage_cache: %{<<1>> => %{2 => %{current_value: 5}}}}
 
       address = <<1>>
       key = 2
@@ -28,7 +28,7 @@ defmodule Blockchain.Interface.AccountInterface.CacheTest do
       result = Cache.update_current_value(cache, address, key, value)
       expected_result = %{<<1>> => %{2 => %{current_value: 6}}}
 
-      assert result.cache == expected_result
+      assert result.storage_cache == expected_result
     end
   end
 
@@ -43,11 +43,11 @@ defmodule Blockchain.Interface.AccountInterface.CacheTest do
       result = Cache.add_initial_value(cache, address, key, value)
       expected_result = %{<<1>> => %{2 => %{initial_value: 5}}}
 
-      assert result.cache == expected_result
+      assert result.storage_cache == expected_result
     end
 
     test "updates initial_value" do
-      cache = %Cache{cache: %{<<1>> => %{2 => %{initial_value: 5}}}}
+      cache = %Cache{storage_cache: %{<<1>> => %{2 => %{initial_value: 5}}}}
 
       address = <<1>>
       key = 2
@@ -56,13 +56,13 @@ defmodule Blockchain.Interface.AccountInterface.CacheTest do
       result = Cache.add_initial_value(cache, address, key, value)
       expected_result = %{<<1>> => %{2 => %{initial_value: 6}}}
 
-      assert result.cache == expected_result
+      assert result.storage_cache == expected_result
     end
   end
 
   describe "current_value/3" do
     test "gets current_value when key cache exists" do
-      cache = %Cache{cache: %{<<1>> => %{2 => %{current_value: 5}}}}
+      cache = %Cache{storage_cache: %{<<1>> => %{2 => %{current_value: 5}}}}
 
       address = <<1>>
       key = 2
@@ -73,7 +73,7 @@ defmodule Blockchain.Interface.AccountInterface.CacheTest do
     end
 
     test "gets current_value when key cache does not exist" do
-      cache = %Cache{cache: %{<<1>> => %{9 => %{current_value: 5}}}}
+      cache = %Cache{storage_cache: %{<<1>> => %{9 => %{current_value: 5}}}}
 
       address = <<1>>
       key = 2
@@ -86,7 +86,7 @@ defmodule Blockchain.Interface.AccountInterface.CacheTest do
 
   describe "initial_current/3" do
     test "gets initial_value when key cache exists" do
-      cache = %Cache{cache: %{<<1>> => %{2 => %{initial_value: 5}}}}
+      cache = %Cache{storage_cache: %{<<1>> => %{2 => %{initial_value: 5}}}}
 
       address = <<1>>
       key = 2
@@ -97,7 +97,7 @@ defmodule Blockchain.Interface.AccountInterface.CacheTest do
     end
 
     test "gets initial_value when key cache does not exist" do
-      cache = %Cache{cache: %{<<1>> => %{9 => %{initial_value: 5}}}}
+      cache = %Cache{storage_cache: %{<<1>> => %{9 => %{initial_value: 5}}}}
 
       address = <<1>>
       key = 2
@@ -110,7 +110,7 @@ defmodule Blockchain.Interface.AccountInterface.CacheTest do
 
   describe "remove_current_value/3" do
     test "deleted current value" do
-      cache = %Cache{cache: %{<<1>> => %{2 => %{initial_value: 5}}}}
+      cache = %Cache{storage_cache: %{<<1>> => %{2 => %{initial_value: 5}}}}
 
       address = <<1>>
       key = 2
@@ -121,6 +121,43 @@ defmodule Blockchain.Interface.AccountInterface.CacheTest do
         |> Cache.current_value(address, key)
 
       assert result == :deleted
+    end
+  end
+
+  describe "update_account/3" do
+    test "adds new account to the cache" do
+      account = %Account{
+        nonce: 5,
+        balance: 10,
+        storage_root: <<0x00, 0x01>>,
+        code_hash: <<0x01, 0x02>>
+      }
+
+      address = <<1>>
+
+      cache = %Cache{}
+
+      updated_cache = Cache.update_account(cache, address, account)
+
+      assert updated_cache.accounts_cache == %{address => account}
+    end
+
+    test "updates the account in the cache" do
+      account = %Account{
+        nonce: 5,
+        balance: 10,
+        storage_root: <<0x00, 0x01>>,
+        code_hash: <<0x01, 0x02>>
+      }
+
+      address = <<1>>
+      code = <<5>>
+
+      cache = %Cache{accounts_cache: %{address => account}}
+
+      updated_cache = Cache.update_account(cache, address, {account, code})
+
+      assert updated_cache.accounts_cache == %{address => {account, code}}
     end
   end
 
@@ -135,7 +172,7 @@ defmodule Blockchain.Interface.AccountInterface.CacheTest do
       # we need to create a blank account
       state_with_account = Account.reset_account(state, address)
 
-      cache = %Cache{cache: %{address => %{key => %{current_value: value}}}}
+      cache = %Cache{storage_cache: %{address => %{key => %{current_value: value}}}}
 
       updated_state = Cache.commit(cache, state_with_account)
 
@@ -159,7 +196,7 @@ defmodule Blockchain.Interface.AccountInterface.CacheTest do
 
       {:ok, ^value} = Account.get_storage(state_with_account, address, key)
 
-      cache = %Cache{cache: %{address => %{key => %{current_value: :deleted}}}}
+      cache = %Cache{storage_cache: %{address => %{key => %{current_value: :deleted}}}}
 
       updated_state = Cache.commit(cache, state_with_account)
 

--- a/apps/blockchain/test/blockchain/interface/account_interface_test.exs
+++ b/apps/blockchain/test/blockchain/interface/account_interface_test.exs
@@ -221,13 +221,9 @@ defmodule Blockchain.Interface.AccountInterfaceTest do
 
       assert result == %Blockchain.Account{
                balance: 0,
-               code_hash:
-                 <<197, 210, 70, 1, 134, 247, 35, 60, 146, 126, 125, 178, 220, 199, 3, 192, 229,
-                   0, 182, 83, 202, 130, 39, 59, 123, 250, 216, 4, 93, 133, 164, 112>>,
+               code_hash: Account.empty_keccak(),
                nonce: 0,
-               storage_root:
-                 <<86, 232, 31, 23, 27, 204, 85, 166, 255, 131, 69, 230, 146, 192, 248, 110, 91,
-                   72, 224, 27, 153, 108, 173, 192, 1, 98, 47, 181, 227, 99, 180, 33>>
+               storage_root: Account.empty_trie()
              }
     end
   end

--- a/apps/blockchain/test/blockchain/interface/account_interface_test.exs
+++ b/apps/blockchain/test/blockchain/interface/account_interface_test.exs
@@ -21,7 +21,7 @@ defmodule Blockchain.Interface.AccountInterfaceTest do
       address = <<1>>
       state_with_account = Account.reset_account(state, address)
 
-      {result, nil} =
+      result =
         state_with_account
         |> AccountInterface.new()
         |> AccountInterface.increment_account_nonce(address)
@@ -56,13 +56,11 @@ defmodule Blockchain.Interface.AccountInterfaceTest do
         |> AccountInterface.new()
         |> AccountInterface.transfer_wei!(from_account_address, to_account_address, transfer_wei)
 
-      {new_from_account, nil} =
-        AccountInterface.account(updated_account_interface, from_account_address)
+      new_from_account = AccountInterface.account(updated_account_interface, from_account_address)
 
       assert new_from_account.balance == from_account_balance - transfer_wei
 
-      {new_to_account, nil} =
-        AccountInterface.account(updated_account_interface, to_account_address)
+      new_to_account = AccountInterface.account(updated_account_interface, to_account_address)
 
       assert new_to_account.balance == transfer_wei
     end
@@ -78,7 +76,7 @@ defmodule Blockchain.Interface.AccountInterfaceTest do
         |> Account.reset_account(address)
         |> AccountInterface.new()
         |> AccountInterface.put_code(address, code)
-        |> AccountInterface.account(address)
+        |> AccountInterface.account_with_code(address)
 
       assert account.code_hash ==
                <<241, 136, 94, 218, 84, 183, 160, 83, 49, 140, 212, 30, 32, 147, 34, 13, 171, 21,
@@ -133,7 +131,7 @@ defmodule Blockchain.Interface.AccountInterfaceTest do
         code_hash: <<0x01, 0x02>>
       }
 
-      {found_account, _} =
+      found_account =
         state
         |> Account.put_account(address, account)
         |> AccountInterface.new()
@@ -155,7 +153,7 @@ defmodule Blockchain.Interface.AccountInterfaceTest do
         code_hash: <<0x01, 0x02>>
       }
 
-      {found_account, _} =
+      found_account =
         state
         |> Account.put_account(address, account)
         |> AccountInterface.new()
@@ -177,7 +175,7 @@ defmodule Blockchain.Interface.AccountInterfaceTest do
         code_hash: <<0x01, 0x02>>
       }
 
-      {found_account, _} =
+      found_account =
         state
         |> Account.put_account(address, account)
         |> AccountInterface.new()
@@ -206,7 +204,7 @@ defmodule Blockchain.Interface.AccountInterfaceTest do
         |> Account.reset_account(address)
         |> AccountInterface.new(cache)
 
-      assert AccountInterface.account(account_interface, address) == {account, code}
+      assert AccountInterface.account_with_code(account_interface, address) == {account, code}
     end
 
     test "fetches account from storage", %{state: state} do
@@ -217,7 +215,7 @@ defmodule Blockchain.Interface.AccountInterfaceTest do
         |> Account.reset_account(address)
         |> AccountInterface.new()
 
-      {result, nil} = AccountInterface.account(account_interface, address)
+      result = AccountInterface.account(account_interface, address)
 
       assert result == %Blockchain.Account{
                balance: 0,

--- a/apps/blockchain/test/blockchain/interface/account_interface_test.exs
+++ b/apps/blockchain/test/blockchain/interface/account_interface_test.exs
@@ -86,6 +86,86 @@ defmodule Blockchain.Interface.AccountInterfaceTest do
     end
   end
 
+  describe "machine_code/2" do
+    test "returns machine code from cache", %{state: state} do
+      account = %Account{
+        nonce: 5,
+        balance: 10,
+        storage_root: <<0x00, 0x01>>,
+        code_hash: <<0x01, 0x02>>
+      }
+
+      address = <<1>>
+      code = <<5>>
+      cache = %Cache{accounts_cache: %{address => {account, code}}}
+
+      {:ok, found_code} =
+        state
+        |> AccountInterface.new(cache)
+        |> AccountInterface.machine_code(address)
+
+      assert code == found_code
+    end
+
+    test "returns machine code from storage", %{state: state} do
+      address = <<1>>
+      code = <<5>>
+
+      {:ok, found_code} =
+        state
+        |> Account.reset_account(address)
+        |> Account.put_code(address, code)
+        |> AccountInterface.new()
+        |> AccountInterface.machine_code(address)
+
+      assert found_code == code
+    end
+  end
+
+  describe "clear_balance/2" do
+    test "clears account's balance", %{state: state} do
+      address = <<1>>
+
+      account = %Account{
+        nonce: 5,
+        balance: 10,
+        storage_root: <<0x00, 0x01>>,
+        code_hash: <<0x01, 0x02>>
+      }
+
+      {found_account, _} =
+        state
+        |> Account.put_account(address, account)
+        |> AccountInterface.new()
+        |> AccountInterface.clear_balance(address)
+        |> AccountInterface.account(address)
+
+      assert found_account.balance == 0
+    end
+  end
+
+  describe "reset_account/2" do
+    test "resets account", %{state: state} do
+      address = <<1>>
+
+      account = %Account{
+        nonce: 5,
+        balance: 10,
+        storage_root: <<0x00, 0x01>>,
+        code_hash: <<0x01, 0x02>>
+      }
+
+      {found_account, _} =
+        state
+        |> Account.put_account(address, account)
+        |> AccountInterface.new()
+        |> AccountInterface.reset_account(address)
+        |> AccountInterface.account(address)
+
+      assert found_account == %Account{}
+    end
+  end
+
   describe "account/2" do
     test "fetches account from cache", %{state: state} do
       account = %Account{

--- a/apps/blockchain/test/blockchain/interface/account_interface_test.exs
+++ b/apps/blockchain/test/blockchain/interface/account_interface_test.exs
@@ -2,4 +2,77 @@ defmodule Blockchain.Interface.AccountInterfaceTest do
   use ExUnit.Case, async: true
   doctest Blockchain.Interface.AccountInterface
   doctest EVM.Interface.AccountInterface.Blockchain.Interface.AccountInterface
+
+  alias Blockchain.Account
+  alias Blockchain.Interface.AccountInterface
+  alias Blockchain.Interface.AccountInterface.Cache
+
+  setup do
+    state =
+      :account_interface_test
+      |> MerklePatriciaTree.Test.random_ets_db()
+      |> MerklePatriciaTree.Trie.new()
+
+    {:ok, %{state: state}}
+  end
+
+  describe "increment_account_nonce/2" do
+    test "increments nonce of the account in the casge", %{state: state} do
+      address = <<1>>
+      state_with_account = Account.reset_account(state, address)
+
+      result =
+        state_with_account
+        |> AccountInterface.new()
+        |> AccountInterface.increment_account_nonce(address)
+        |> AccountInterface.increment_account_nonce(address)
+        |> AccountInterface.account(address)
+
+      assert result.nonce == 2
+    end
+  end
+
+  describe "account/2" do
+    test "fetches account from cache", %{state: state} do
+      account = %Account{
+        nonce: 5,
+        balance: 10,
+        storage_root: <<0x00, 0x01>>,
+        code_hash: <<0x01, 0x02>>
+      }
+
+      address = <<1>>
+      code = <<5>>
+      cache = %Cache{accounts_cache: %{address => {account, code}}}
+
+      account_interface =
+        state
+        |> Account.reset_account(address)
+        |> AccountInterface.new(cache)
+
+      assert AccountInterface.account(account_interface, address) == {account, code}
+    end
+
+    test "fetches account from storage", %{state: state} do
+      address = <<1>>
+
+      account_interface =
+        state
+        |> Account.reset_account(address)
+        |> AccountInterface.new()
+
+      result = AccountInterface.account(account_interface, address)
+
+      assert result == %Blockchain.Account{
+               balance: 0,
+               code_hash:
+                 <<197, 210, 70, 1, 134, 247, 35, 60, 146, 126, 125, 178, 220, 199, 3, 192, 229,
+                   0, 182, 83, 202, 130, 39, 59, 123, 250, 216, 4, 93, 133, 164, 112>>,
+               nonce: 0,
+               storage_root:
+                 <<86, 232, 31, 23, 27, 204, 85, 166, 255, 131, 69, 230, 146, 192, 248, 110, 91,
+                   72, 224, 27, 153, 108, 173, 192, 1, 98, 47, 181, 227, 99, 180, 33>>
+             }
+    end
+  end
 end

--- a/apps/blockchain/test/blockchain/interface/account_interface_test.exs
+++ b/apps/blockchain/test/blockchain/interface/account_interface_test.exs
@@ -166,6 +166,28 @@ defmodule Blockchain.Interface.AccountInterfaceTest do
     end
   end
 
+  describe "add_wei/2" do
+    test "adds wei to account's balance", %{state: state} do
+      address = <<1>>
+
+      account = %Account{
+        nonce: 5,
+        balance: 10,
+        storage_root: <<0x00, 0x01>>,
+        code_hash: <<0x01, 0x02>>
+      }
+
+      {found_account, _} =
+        state
+        |> Account.put_account(address, account)
+        |> AccountInterface.new()
+        |> AccountInterface.add_wei(address, 100)
+        |> AccountInterface.account(address)
+
+      assert found_account.balance == 110
+    end
+  end
+
   describe "account/2" do
     test "fetches account from cache", %{state: state} do
       account = %Account{

--- a/apps/blockchain/test/blockchain/interface/account_interface_test.exs
+++ b/apps/blockchain/test/blockchain/interface/account_interface_test.exs
@@ -21,7 +21,7 @@ defmodule Blockchain.Interface.AccountInterfaceTest do
       address = <<1>>
       state_with_account = Account.reset_account(state, address)
 
-      result =
+      {result, nil} =
         state_with_account
         |> AccountInterface.new()
         |> AccountInterface.increment_account_nonce(address)
@@ -29,6 +29,60 @@ defmodule Blockchain.Interface.AccountInterfaceTest do
         |> AccountInterface.account(address)
 
       assert result.nonce == 2
+    end
+  end
+
+  describe "transfer_wei!/4" do
+    test "transfers wei from one account to another reading accounts from the storage", %{
+      state: state
+    } do
+      from_account_address = <<1>>
+      from_account_balance = 6
+      transfer_wei = 2
+
+      from_account = %Blockchain.Account{
+        nonce: 5,
+        balance: from_account_balance,
+        storage_root: <<0x01>>,
+        code_hash: <<0x02>>
+      }
+
+      to_account_address = <<2>>
+
+      updated_account_interface =
+        state
+        |> Account.reset_account(to_account_address)
+        |> Account.put_account(from_account_address, from_account)
+        |> AccountInterface.new()
+        |> AccountInterface.transfer_wei!(from_account_address, to_account_address, transfer_wei)
+
+      {new_from_account, nil} =
+        AccountInterface.account(updated_account_interface, from_account_address)
+
+      assert new_from_account.balance == from_account_balance - transfer_wei
+
+      {new_to_account, nil} =
+        AccountInterface.account(updated_account_interface, to_account_address)
+
+      assert new_to_account.balance == transfer_wei
+    end
+  end
+
+  describe "put_code/3" do
+    test "sets code to the account", %{state: state} do
+      code = <<1, 2, 3>>
+      address = <<2>>
+
+      {account, ^code} =
+        state
+        |> Account.reset_account(address)
+        |> AccountInterface.new()
+        |> AccountInterface.put_code(address, code)
+        |> AccountInterface.account(address)
+
+      assert account.code_hash ==
+               <<241, 136, 94, 218, 84, 183, 160, 83, 49, 140, 212, 30, 32, 147, 34, 13, 171, 21,
+                 214, 83, 129, 177, 21, 122, 54, 51, 168, 59, 253, 92, 146, 57>>
     end
   end
 
@@ -61,7 +115,7 @@ defmodule Blockchain.Interface.AccountInterfaceTest do
         |> Account.reset_account(address)
         |> AccountInterface.new()
 
-      result = AccountInterface.account(account_interface, address)
+      {result, nil} = AccountInterface.account(account_interface, address)
 
       assert result == %Blockchain.Account{
                balance: 0,


### PR DESCRIPTION
with https://github.com/poanetwork/mana/pull/440 resolves https://github.com/poanetwork/mana/issues/416

Changes: 
- Do not modify Merkle Patricia Tree during EVM execution (it's read-only)
- Commit storage changes only on successful EVM execution
- Use temporary storage in EVM