### PR TITLE
Create common_tests.run mix task

### DIFF
--- a/.dialyzer.ignore-warnings
+++ b/.dialyzer.ignore-warnings
@@ -175,3 +175,8 @@ apps/blockchain/lib/blockchain/interface/account_interface.ex
 # Ignores state test generation script
 -------------------------------
 apps/blockchain/scripts/generate_state_tests.ex
+
+-------------------------------
+# Ignores blockchain test runner
+-------------------------------
+apps/blockchain/test/support/blockchain_test_runner.ex

--- a/apps/blockchain/lib/blockchain/chain.ex
+++ b/apps/blockchain/lib/blockchain/chain.ex
@@ -124,6 +124,67 @@ defmodule Blockchain.Chain do
     }
   end
 
+  @doc """
+  Gets a test chain configuration (along with the respective EVM configuration)
+  based on a hardfork.
+
+  ## Examples
+
+      iex> Blockchain.Chain.get_config("Frontier").name
+      "Frontier (Test)"
+  """
+  def test_config(hardfork) when is_binary(hardfork) do
+    config = evm_config(hardfork)
+
+    case hardfork do
+      "Frontier" ->
+        load_chain(:frontier_test, config)
+
+      "Homestead" ->
+        load_chain(:homestead_test, config)
+
+      "EIP150" ->
+        load_chain(:eip150_test, config)
+
+      "EIP158" ->
+        load_chain(:eip150_test, config)
+
+      "Byzantium" ->
+        load_chain(:byzantium_test, config)
+
+      "Constantinople" ->
+        load_chain(:constantinople_test, config)
+
+      _ ->
+        nil
+    end
+  end
+
+  defp evm_config(hardfork) do
+    case hardfork do
+      "Frontier" ->
+        EVM.Configuration.Frontier.new()
+
+      "Homestead" ->
+        EVM.Configuration.Homestead.new()
+
+      "EIP150" ->
+        EVM.Configuration.EIP150.new()
+
+      "EIP158" ->
+        EVM.Configuration.EIP158.new()
+
+      "Byzantium" ->
+        EVM.Configuration.Byzantium.new()
+
+      "Constantinople" ->
+        EVM.Configuration.Constantinople.new()
+
+      _ ->
+        nil
+    end
+  end
+
   @spec get_engine({String.t(), map}) :: {String.t(), engine()}
   defp get_engine({engine, %{"params" => params}}) do
     config = %{

--- a/apps/blockchain/lib/blockchain/chain.ex
+++ b/apps/blockchain/lib/blockchain/chain.ex
@@ -130,7 +130,7 @@ defmodule Blockchain.Chain do
 
   ## Examples
 
-      iex> Blockchain.Chain.get_config("Frontier").name
+      iex> Blockchain.Chain.test_config("Frontier").name
       "Frontier (Test)"
   """
   def test_config(hardfork) when is_binary(hardfork) do

--- a/apps/blockchain/lib/blockchain/mix/tasks/common_tests.run.ex
+++ b/apps/blockchain/lib/blockchain/mix/tasks/common_tests.run.ex
@@ -1,0 +1,64 @@
+defmodule Mix.Tasks.CommonTests.Run do
+  use Mix.Task
+
+  require Logger
+
+  @shortdoc "Runs a single blockchain common test"
+
+  @moduledoc """
+  Runs a single blockchain common test.
+
+  Note that this must be run with `MIX_ENV=test`.
+
+  ## Example
+
+  From the blockchain app,
+
+  ```
+  MIX_ENV=test mix common_tests.run "stSpecialTest/failed_tx" --fork "EIP158"
+  ```
+
+  ## Command line options
+
+  * `--fork` - the name of the hardfork to run (optional)
+  """
+
+  @preferred_cli_env :test
+  @switches [test: :string, fork: :string]
+  @aliases [hardfork: :fork]
+
+  def run(args) do
+    {opts, [test_name | _]} = OptionParser.parse!(args, switches: @switches, aliases: @aliases)
+    hardfork = Keyword.get(opts, :fork, :all)
+
+    test_name
+    |> find_full_name()
+    |> BlockchainTestRunner.run(hardfork)
+    |> Enum.map(&log_result/1)
+  end
+
+  defp log_result({:pass, {fork, name, _ex, _act}}) do
+    Mix.shell().info("[#{fork}] #{name} passed")
+  end
+
+  defp log_result({:fail, {fork, name, expected, actual}}) do
+    message = """
+
+    [#{fork}] #{name} failed:
+
+      Expected: #{Base.encode16(expected, case: :lower)},
+      Actual: #{Base.encode16(actual, case: :lower)}
+    """
+
+    Mix.shell().error(message)
+  end
+
+  defp find_full_name(name) do
+    EthCommonTest.Helpers.ethereum_common_tests_path()
+    |> Path.join("/BlockchainTests/**/*.json")
+    |> Path.wildcard()
+    |> Enum.find(fn full_name ->
+      String.contains?(full_name, name)
+    end)
+  end
+end

--- a/apps/blockchain/test/blockchain_test.exs
+++ b/apps/blockchain/test/blockchain_test.exs
@@ -3,10 +3,7 @@ defmodule BlockchainTest do
 
   import EthCommonTest.Helpers
 
-  alias Blockchain.{Blocktree, Account, Transaction, Chain}
-  alias MerklePatriciaTree.Trie
-  alias Blockchain.Account.Storage
-  alias Block.Header
+  alias Blockchain.Chain
 
   doctest Blockchain
 
@@ -96,8 +93,12 @@ defmodule BlockchainTest do
     grouped_test_per_fork()
     |> Task.async_stream(&run_tests(&1), timeout: @ten_minutes)
     |> Enum.flat_map(fn {:ok, results} -> results end)
+    |> Enum.filter(&failing_test?/1)
     |> make_assertions()
   end
+
+  defp failing_test?({:fail, _}), do: true
+  defp failing_test?(_), do: false
 
   defp grouped_test_per_fork do
     for fork <- forks_with_existing_implementation(),
@@ -117,11 +118,7 @@ defmodule BlockchainTest do
     tests
     |> Stream.reject(&known_fork_failures?(&1, fork))
     |> Enum.flat_map(fn json_test_path ->
-      json_test_path
-      |> read_test()
-      |> Stream.filter(&fork_test?(&1, fork))
-      |> Stream.map(&run_test/1)
-      |> Enum.filter(&failing_test?/1)
+      BlockchainTestRunner.run(json_test_path, fork)
     end)
   end
 
@@ -133,16 +130,6 @@ defmodule BlockchainTest do
     end)
   end
 
-  defp read_test(path) do
-    path
-    |> File.read!()
-    |> Poison.decode!()
-  end
-
-  defp fork_test?({_test_name, json_test}, fork) do
-    fork == json_test["network"]
-  end
-
   defp forks_with_existing_implementation do
     @failing_tests
     |> Map.keys()
@@ -151,24 +138,8 @@ defmodule BlockchainTest do
 
   defp fork_without_implementation?(fork) do
     fork
-    |> load_chain()
+    |> Chain.test_config()
     |> is_nil()
-  end
-
-  defp run_test({test_name, json_test}) do
-    fork = json_test["network"]
-    chain = load_chain(fork)
-
-    state = populate_prestate(json_test)
-
-    blocktree =
-      create_blocktree()
-      |> add_genesis_block(json_test, state, chain)
-      |> add_blocks(json_test, state, chain)
-
-    best_block_hash = maybe_hex(json_test["lastblockhash"])
-
-    {fork, test_name, best_block_hash, blocktree.best_block.block_hash}
   end
 
   defp make_assertions([]), do: assert(true)
@@ -192,220 +163,6 @@ defmodule BlockchainTest do
 
   defp single_error_message({fork, test_name, expected, actual}) do
     "[#{fork}] #{test_name}: expected #{inspect(expected)}, but received #{inspect(actual)}"
-  end
-
-  defp failing_test?({_fork, _test_name, expected, actual}) do
-    expected != actual
-  end
-
-  defp load_chain(hardfork) do
-    config = evm_config(hardfork)
-
-    case hardfork do
-      "Frontier" ->
-        Chain.load_chain(:frontier_test, config)
-
-      "Homestead" ->
-        Chain.load_chain(:homestead_test, config)
-
-      "EIP150" ->
-        Chain.load_chain(:eip150_test, config)
-
-      "EIP158" ->
-        Chain.load_chain(:eip150_test, config)
-
-      "Byzantium" ->
-        Chain.load_chain(:byzantium_test, config)
-
-      "Constantinople" ->
-        Chain.load_chain(:constantinople_test, config)
-
-      _ ->
-        nil
-    end
-  end
-
-  defp evm_config(hardfork) do
-    case hardfork do
-      "Frontier" ->
-        EVM.Configuration.Frontier.new()
-
-      "Homestead" ->
-        EVM.Configuration.Homestead.new()
-
-      "EIP150" ->
-        EVM.Configuration.EIP150.new()
-
-      "EIP158" ->
-        EVM.Configuration.EIP158.new()
-
-      "Byzantium" ->
-        EVM.Configuration.Byzantium.new()
-
-      "Constantinople" ->
-        EVM.Configuration.Constantinople.new()
-
-      _ ->
-        nil
-    end
-  end
-
-  defp add_genesis_block(blocktree, json_test, state, chain) do
-    block =
-      if json_test["genesisRLP"] do
-        {:ok, block} = Blockchain.Block.decode_rlp(json_test["genesisRLP"])
-
-        block
-      end
-
-    genesis_block = block_from_json(block, json_test["genesisBlockHeader"])
-
-    {:ok, blocktree} =
-      Blocktree.verify_and_add_block(
-        blocktree,
-        chain,
-        genesis_block,
-        state.db,
-        false,
-        maybe_hex(json_test["genesisBlockHeader"]["hash"])
-      )
-
-    blocktree
-  end
-
-  defp create_blocktree do
-    Blocktree.new_tree()
-  end
-
-  defp add_blocks(blocktree, json_test, state, chain) do
-    Enum.reduce(json_test["blocks"], blocktree, fn json_block, acc ->
-      block = json_block["rlp"] |> Blockchain.Block.decode_rlp()
-
-      case block do
-        {:ok, block} ->
-          block =
-            block_from_json(
-              block,
-              json_block["blockHeader"],
-              json_block["transactions"],
-              json_block["uncleHeaders"]
-            )
-
-          case Blocktree.verify_and_add_block(acc, chain, block, state.db) do
-            {:ok, blocktree} -> blocktree
-            _ -> acc
-          end
-
-        _ ->
-          acc
-      end
-    end)
-  end
-
-  defp block_from_json(block, json_header, json_transactions \\ [], json_ommers \\ []) do
-    block = block || %Blockchain.Block{}
-    header = header_from_json(json_header)
-    transactions = transactions_from_json(json_transactions)
-    ommers = ommers_from_json(json_ommers)
-
-    %{block | header: header, transactions: transactions, ommers: ommers}
-  end
-
-  defp header_from_json(json_header) do
-    %Header{
-      parent_hash: maybe_hex(json_header["parentHash"]),
-      ommers_hash: maybe_hex(json_header["uncleHash"]),
-      beneficiary: maybe_hex(json_header["coinbase"]),
-      state_root: maybe_hex(json_header["stateRoot"]),
-      transactions_root: maybe_hex(json_header["transactionsTrie"]),
-      receipts_root: maybe_hex(json_header["receiptTrie"]),
-      logs_bloom: maybe_hex(json_header["bloom"]),
-      difficulty: load_integer(json_header["difficulty"]),
-      number: load_integer(json_header["number"]),
-      gas_limit: load_integer(json_header["gasLimit"]),
-      gas_used: load_integer(json_header["gasUsed"]),
-      timestamp: load_integer(json_header["timestamp"]),
-      extra_data: maybe_hex(json_header["extraData"]),
-      mix_hash: maybe_hex(json_header["mixHash"]),
-      nonce: maybe_hex(json_header["nonce"])
-    }
-  end
-
-  defp ommers_from_json(json_ommers) do
-    Enum.map(json_ommers || [], fn json_ommer ->
-      %Header{
-        parent_hash: maybe_hex(json_ommer["parentHash"]),
-        ommers_hash: maybe_hex(json_ommer["uncleHash"]),
-        beneficiary: maybe_hex(json_ommer["coinbase"]),
-        state_root: maybe_hex(json_ommer["stateRoot"]),
-        transactions_root: maybe_hex(json_ommer["transactionsTrie"]),
-        receipts_root: maybe_hex(json_ommer["receiptTrie"]),
-        logs_bloom: maybe_hex(json_ommer["bloom"]),
-        difficulty: load_integer(json_ommer["difficulty"]),
-        number: load_integer(json_ommer["number"]),
-        gas_limit: load_integer(json_ommer["gasLimit"]),
-        gas_used: load_integer(json_ommer["gasUsed"]),
-        timestamp: load_integer(json_ommer["timestamp"]),
-        extra_data: maybe_hex(json_ommer["extraData"]),
-        mix_hash: maybe_hex(json_ommer["mixHash"]),
-        nonce: maybe_hex(json_ommer["nonce"])
-      }
-    end)
-  end
-
-  defp transactions_from_json(json_transactions) do
-    Enum.map(json_transactions || [], fn json_transaction ->
-      init =
-        if maybe_hex(json_transaction["to"]) == <<>> do
-          maybe_hex(json_transaction["data"])
-        else
-          ""
-        end
-
-      %Transaction{
-        nonce: load_integer(json_transaction["nonce"]),
-        gas_price: load_integer(json_transaction["gasPrice"]),
-        gas_limit: load_integer(json_transaction["gasLimit"]),
-        to: maybe_hex(json_transaction["to"]),
-        value: load_integer(json_transaction["value"]),
-        v: load_integer(json_transaction["v"]),
-        r: load_integer(json_transaction["r"]),
-        s: load_integer(json_transaction["s"]),
-        data: maybe_hex(json_transaction["data"]),
-        init: init
-      }
-    end)
-  end
-
-  defp populate_prestate(json_test) do
-    db = MerklePatriciaTree.Test.random_ets_db()
-
-    state = %Trie{
-      db: db,
-      root_hash: maybe_hex(json_test["genesisBlockHeader"]["stateRoot"])
-    }
-
-    Enum.reduce(json_test["pre"], state, fn {address, account}, state ->
-      storage = %Trie{
-        root_hash: Trie.empty_trie_root_hash(),
-        db: db
-      }
-
-      storage =
-        Enum.reduce(account["storage"], storage, fn {key, value}, trie ->
-          Storage.put(trie.db, trie.root_hash, load_integer(key), load_integer(value))
-        end)
-
-      new_account = %Account{
-        nonce: load_integer(account["nonce"]),
-        balance: load_integer(account["balance"]),
-        storage_root: storage.root_hash
-      }
-
-      state
-      |> Account.put_account(maybe_hex(address), new_account)
-      |> Account.put_code(maybe_hex(address), maybe_hex(account["code"]))
-    end)
   end
 
   defp tests do

--- a/apps/blockchain/test/support/blockchain_test_runner.ex
+++ b/apps/blockchain/test/support/blockchain_test_runner.ex
@@ -1,0 +1,207 @@
+defmodule BlockchainTestRunner do
+  import EthCommonTest.Helpers
+
+  alias Blockchain.{Blocktree, Account, Transaction, Chain}
+  alias MerklePatriciaTree.Trie
+  alias Blockchain.Account.Storage
+  alias Block.Header
+
+  def run(json_test_path, fork) do
+    json_test_path
+    |> read_test()
+    |> Stream.filter(&fork_test?(&1, fork))
+    |> Enum.map(&run_test/1)
+  end
+
+  defp read_test(path) do
+    path
+    |> File.read!()
+    |> Poison.decode!()
+  end
+
+  defp fork_test?({_test_name, json_test}, fork) do
+    fork == json_test["network"]
+  end
+
+  defp run_test({test_name, json_test}) do
+    fork = json_test["network"]
+    chain = Chain.test_config(fork)
+
+    state = populate_prestate(json_test)
+
+    blocktree =
+      create_blocktree()
+      |> add_genesis_block(json_test, state, chain)
+      |> add_blocks(json_test, state, chain)
+
+    expected_block_hash = maybe_hex(json_test["lastblockhash"])
+
+    result({fork, test_name, expected_block_hash, blocktree.best_block.block_hash})
+  end
+
+  defp result({_fork, _name, expected, actual} = result) do
+    if expected == actual do
+      {:pass, result}
+    else
+      {:fail, result}
+    end
+  end
+
+  defp create_blocktree do
+    Blocktree.new_tree()
+  end
+
+  defp add_genesis_block(blocktree, json_test, state, chain) do
+    block =
+      if json_test["genesisRLP"] do
+        {:ok, block} = Blockchain.Block.decode_rlp(json_test["genesisRLP"])
+
+        block
+      end
+
+    genesis_block = block_from_json(block, json_test["genesisBlockHeader"])
+
+    {:ok, blocktree} =
+      Blocktree.verify_and_add_block(
+        blocktree,
+        chain,
+        genesis_block,
+        state.db,
+        false,
+        maybe_hex(json_test["genesisBlockHeader"]["hash"])
+      )
+
+    blocktree
+  end
+
+  defp add_blocks(blocktree, json_test, state, chain) do
+    Enum.reduce(json_test["blocks"], blocktree, fn json_block, acc ->
+      block = json_block["rlp"] |> Blockchain.Block.decode_rlp()
+
+      case block do
+        {:ok, block} ->
+          block =
+            block_from_json(
+              block,
+              json_block["blockHeader"],
+              json_block["transactions"],
+              json_block["uncleHeaders"]
+            )
+
+          case Blocktree.verify_and_add_block(acc, chain, block, state.db) do
+            {:ok, blocktree} -> blocktree
+            _ -> acc
+          end
+
+        _ ->
+          acc
+      end
+    end)
+  end
+
+  defp block_from_json(block, json_header, json_transactions \\ [], json_ommers \\ []) do
+    block = block || %Blockchain.Block{}
+    header = header_from_json(json_header)
+    transactions = transactions_from_json(json_transactions)
+    ommers = ommers_from_json(json_ommers)
+
+    %{block | header: header, transactions: transactions, ommers: ommers}
+  end
+
+  defp header_from_json(json_header) do
+    %Header{
+      parent_hash: maybe_hex(json_header["parentHash"]),
+      ommers_hash: maybe_hex(json_header["uncleHash"]),
+      beneficiary: maybe_hex(json_header["coinbase"]),
+      state_root: maybe_hex(json_header["stateRoot"]),
+      transactions_root: maybe_hex(json_header["transactionsTrie"]),
+      receipts_root: maybe_hex(json_header["receiptTrie"]),
+      logs_bloom: maybe_hex(json_header["bloom"]),
+      difficulty: load_integer(json_header["difficulty"]),
+      number: load_integer(json_header["number"]),
+      gas_limit: load_integer(json_header["gasLimit"]),
+      gas_used: load_integer(json_header["gasUsed"]),
+      timestamp: load_integer(json_header["timestamp"]),
+      extra_data: maybe_hex(json_header["extraData"]),
+      mix_hash: maybe_hex(json_header["mixHash"]),
+      nonce: maybe_hex(json_header["nonce"])
+    }
+  end
+
+  defp ommers_from_json(json_ommers) do
+    Enum.map(json_ommers || [], fn json_ommer ->
+      %Header{
+        parent_hash: maybe_hex(json_ommer["parentHash"]),
+        ommers_hash: maybe_hex(json_ommer["uncleHash"]),
+        beneficiary: maybe_hex(json_ommer["coinbase"]),
+        state_root: maybe_hex(json_ommer["stateRoot"]),
+        transactions_root: maybe_hex(json_ommer["transactionsTrie"]),
+        receipts_root: maybe_hex(json_ommer["receiptTrie"]),
+        logs_bloom: maybe_hex(json_ommer["bloom"]),
+        difficulty: load_integer(json_ommer["difficulty"]),
+        number: load_integer(json_ommer["number"]),
+        gas_limit: load_integer(json_ommer["gasLimit"]),
+        gas_used: load_integer(json_ommer["gasUsed"]),
+        timestamp: load_integer(json_ommer["timestamp"]),
+        extra_data: maybe_hex(json_ommer["extraData"]),
+        mix_hash: maybe_hex(json_ommer["mixHash"]),
+        nonce: maybe_hex(json_ommer["nonce"])
+      }
+    end)
+  end
+
+  defp transactions_from_json(json_transactions) do
+    Enum.map(json_transactions || [], fn json_transaction ->
+      init =
+        if maybe_hex(json_transaction["to"]) == <<>> do
+          maybe_hex(json_transaction["data"])
+        else
+          ""
+        end
+
+      %Transaction{
+        nonce: load_integer(json_transaction["nonce"]),
+        gas_price: load_integer(json_transaction["gasPrice"]),
+        gas_limit: load_integer(json_transaction["gasLimit"]),
+        to: maybe_hex(json_transaction["to"]),
+        value: load_integer(json_transaction["value"]),
+        v: load_integer(json_transaction["v"]),
+        r: load_integer(json_transaction["r"]),
+        s: load_integer(json_transaction["s"]),
+        data: maybe_hex(json_transaction["data"]),
+        init: init
+      }
+    end)
+  end
+
+  defp populate_prestate(json_test) do
+    db = MerklePatriciaTree.Test.random_ets_db()
+
+    state = %Trie{
+      db: db,
+      root_hash: maybe_hex(json_test["genesisBlockHeader"]["stateRoot"])
+    }
+
+    Enum.reduce(json_test["pre"], state, fn {address, account}, state ->
+      storage = %Trie{
+        root_hash: Trie.empty_trie_root_hash(),
+        db: db
+      }
+
+      storage =
+        Enum.reduce(account["storage"], storage, fn {key, value}, trie ->
+          Storage.put(trie.db, trie.root_hash, load_integer(key), load_integer(value))
+        end)
+
+      new_account = %Account{
+        nonce: load_integer(account["nonce"]),
+        balance: load_integer(account["balance"]),
+        storage_root: storage.root_hash
+      }
+
+      state
+      |> Account.put_account(maybe_hex(address), new_account)
+      |> Account.put_code(maybe_hex(address), maybe_hex(account["code"]))
+    end)
+  end
+end


### PR DESCRIPTION
What changed?
============

Creates `mix common_tests.run` mix task to run a single blockchain test file, with an optional hardfork.

This task uses much of the same logic as does the `blockchain_test.exs` test. So we extract a `BlockchainTestRunner` module to house all that common logic related to running a single blockchain test file.

Why?
===

When we debug failing blockchain tests, it is often hard to run a single test. It is possible to do so by modifying certain pieces of the `test/blockchain_test.exs` file, but that requires some knowledge of the structure of the test setup, and it is both cumbersome and time consuming. With this new mix task, we can simply specify the file we need to run and it will run that test.


A note on mix task
==================

The advantage of creating this helpful script as a `mix` task (rather than just creating it as we have created other scripts) is that it allows us to have some clear documentation.

- `mix help` will list all the task available in the project, including `common_tests.run`. It will use the `@shortdoc` for that.

![screen shot 2018-09-25 at 9 07 20 am](https://user-images.githubusercontent.com/3245976/46016351-88f82980-c0a2-11e8-9bed-818e6460b1ef.png)


- `mix help common_tests.run` will give a full description of the mix task, using the information found in `moduledoc`.

![screen shot 2018-09-25 at 9 07 41 am](https://user-images.githubusercontent.com/3245976/46016354-8c8bb080-c0a2-11e8-855f-95e04e4104fa.png)
