### PR TITLE
Update blockchain_test pattern matching

### DIFF
--- a/apps/blockchain/test/blockchain_test.exs
+++ b/apps/blockchain/test/blockchain_test.exs
@@ -161,7 +161,7 @@ defmodule BlockchainTest do
     """
   end
 
-  defp single_error_message({fork, test_name, expected, actual}) do
+  defp single_error_message({:fail, {fork, test_name, expected, actual}}) do
     "[#{fork}] #{test_name}: expected #{inspect(expected)}, but received #{inspect(actual)}"
   end
 


### PR DESCRIPTION
What changed?
=============

This is something that was missed in https://github.com/poanetwork/mana/pull/444

The `BlockchainTestRunner` now returns test results with `{:pass, result}` or `{:fail, result}`, where `result` is equivalent to what used to be returned from the same logic before `BlockchainTestRunner` was extracted. The filtering logic for test failures was updated correctly to expect the `{:fail, _}` tuple, but the error message constructor was not updated to expect it. We update that here.