### PR TITLE
Add mix state_tests.run task

### DIFF
--- a/.dialyzer.ignore-warnings
+++ b/.dialyzer.ignore-warnings
@@ -181,6 +181,7 @@ apps/blockchain/lib/blockchain/interface/account_interface.ex
 apps/blockchain/scripts/generate_state_tests.ex
 
 -------------------------------
-# Ignores blockchain test runner
+# Ignores test runners
 -------------------------------
 apps/blockchain/test/support/blockchain_test_runner.ex
+apps/blockchain/test/support/state_test_runner.ex

--- a/apps/blockchain/lib/blockchain/chain.ex
+++ b/apps/blockchain/lib/blockchain/chain.ex
@@ -161,7 +161,7 @@ defmodule Blockchain.Chain do
     end
   end
 
-  defp evm_config(hardfork) do
+  def evm_config(hardfork) do
     case hardfork do
       "Frontier" ->
         EVM.Configuration.Frontier.new()

--- a/apps/blockchain/lib/mix/tasks/common_tests.run.ex
+++ b/apps/blockchain/lib/mix/tasks/common_tests.run.ex
@@ -21,6 +21,7 @@ defmodule Mix.Tasks.CommonTests.Run do
   ## Command line options
 
   * `--fork` - the name of the hardfork to run (optional)
+  * `--hardfork` - alias for `--fork`
   """
 
   @preferred_cli_env :test

--- a/apps/blockchain/lib/mix/tasks/state_tests.run.ex
+++ b/apps/blockchain/lib/mix/tasks/state_tests.run.ex
@@ -1,0 +1,81 @@
+defmodule Mix.Tasks.StateTests.Run do
+  use Mix.Task
+
+  require Logger
+
+  @shortdoc "Runs a single state common test"
+
+  @moduledoc """
+  Runs a single state common test.
+
+  Note that this must be run with `MIX_ENV=test`.
+
+  ## Example
+
+  From the blockchain app,
+
+  ```
+  MIX_ENV=test mix state_tests.run "stRevertTest/RevertInCallCode" --fork "Byzantium"
+  ```
+
+  ## Command line options
+
+  * `--fork` - the name of the hardfork to run (optional)
+  * `--hardfork` - alias for `--fork`
+  """
+
+  @preferred_cli_env :test
+  @switches [test: :string, fork: :string]
+  @aliases [hardfork: :fork]
+
+  def run(args) do
+    {opts, [test_name | _]} = OptionParser.parse!(args, switches: @switches, aliases: @aliases)
+    hardfork = Keyword.get(opts, :fork, :all)
+
+    test_name
+    |> find_full_name()
+    |> StateTestRunner.run(hardfork)
+    |> Enum.map(&log_result/1)
+  end
+
+  defp log_result(result = %{state_root_mismatch: true}) do
+    message = """
+
+    [#{result.hardfork}] #{result.test_name} state root mismatch:
+
+      Expected: #{encode(result.state_root_expected)},
+      Actual: #{encode(result.state_root_actual)}
+    """
+
+    Mix.shell().error(message)
+  end
+
+  defp log_result(result = %{logs_hash_mismatch: true}) do
+    message = """
+
+    [#{result.hardfork}] #{result.test_name} logs hash mismatch:
+
+      Expected: #{encode(result.logs_hash_expected)},
+      Actual: #{encode(result.logs_hash_actual)}
+    """
+
+    Mix.shell().error(message)
+  end
+
+  defp log_result(%{hardfork: fork, test_name: name}) do
+    Mix.shell().info("[#{fork}] #{name} passed")
+  end
+
+  def encode(value) do
+    Base.encode16(value, case: :lower)
+  end
+
+  defp find_full_name(name) do
+    EthCommonTest.Helpers.ethereum_common_tests_path()
+    |> Path.join("/GeneralStateTests/**/*.json")
+    |> Path.wildcard()
+    |> Enum.find(fn full_name ->
+      String.contains?(full_name, name)
+    end)
+  end
+end

--- a/apps/blockchain/test/blockchain/state_test.exs
+++ b/apps/blockchain/test/blockchain/state_test.exs
@@ -1,9 +1,6 @@
 defmodule Blockchain.StateTest do
   alias MerklePatriciaTree.Trie
-  alias Blockchain.{Account, Transaction}
-  alias Blockchain.Interface.AccountInterface
-  alias Blockchain.Account.Storage
-  alias ExthCrypto.Hash.Keccak
+  alias Blockchain.{Account, Chain}
 
   use EthCommonTest.Harness
   use ExUnit.Case, async: true
@@ -158,20 +155,8 @@ defmodule Blockchain.StateTest do
   defp run_tests({fork, tests}) do
     tests
     |> Stream.reject(&known_fork_failure?(&1, fork))
-    |> Enum.flat_map(fn test_path ->
-      test_path
-      |> read_state_test_file()
-      |> Stream.filter(&fork_test?(&1, fork))
-      |> Stream.flat_map(&run_test(&1, fork))
-      |> Enum.filter(&failed_test?/1)
-    end)
-  end
-
-  defp fork_test?({_test_name, test_data}, fork) do
-    case Map.fetch(test_data["post"], fork) do
-      {:ok, _test_data} -> true
-      _ -> false
-    end
+    |> Enum.flat_map(&StateTestRunner.run(&1, fork))
+    |> Enum.filter(&failed_test?/1)
   end
 
   defp forks_with_existing_implementation do
@@ -182,7 +167,7 @@ defmodule Blockchain.StateTest do
 
   defp fork_without_implementation?(fork) do
     fork
-    |> configuration()
+    |> Chain.evm_config()
     |> is_nil()
   end
 
@@ -203,73 +188,6 @@ defmodule Blockchain.StateTest do
     test_name = Enum.fetch!(path_elements, -1)
 
     Path.join(group_name, test_name)
-  end
-
-  defp run_test({test_name, test}, hardfork) do
-    hardfork_configuration = configuration(hardfork)
-
-    test["post"][hardfork]
-    |> Enum.with_index()
-    |> Enum.map(fn {post, index} ->
-      pre_state = account_interface(test).state
-
-      indexes = post["indexes"]
-      gas_limit_index = indexes["gas"]
-      value_index = indexes["value"]
-      data_index = indexes["data"]
-
-      transaction =
-        %Transaction{
-          nonce: load_integer(test["transaction"]["nonce"]),
-          gas_price: load_integer(test["transaction"]["gasPrice"]),
-          gas_limit: load_integer(Enum.at(test["transaction"]["gasLimit"], gas_limit_index)),
-          to: maybe_hex(test["transaction"]["to"]),
-          value: load_integer(Enum.at(test["transaction"]["value"], value_index))
-        }
-        |> populate_init_or_data(maybe_hex(Enum.at(test["transaction"]["data"], data_index)))
-        |> Transaction.Signature.sign_transaction(maybe_hex(test["transaction"]["secretKey"]))
-
-      result =
-        Transaction.execute_with_validation(
-          pre_state,
-          transaction,
-          %Block.Header{
-            beneficiary: maybe_hex(test["env"]["currentCoinbase"]),
-            difficulty: load_integer(test["env"]["currentDifficulty"]),
-            timestamp: load_integer(test["env"]["currentTimestamp"]),
-            number: load_integer(test["env"]["currentNumber"]),
-            gas_limit: load_integer(test["env"]["currentGasLimit"]),
-            parent_hash: maybe_hex(test["env"]["previousHash"])
-          },
-          hardfork_configuration
-        )
-
-      {state, logs} =
-        case result do
-          {state, _, logs, _tx_status} -> {state, logs}
-          _ -> {pre_state, []}
-        end
-
-      expected_hash =
-        test["post"][hardfork]
-        |> Enum.at(index)
-        |> Map.fetch!("hash")
-        |> maybe_hex()
-
-      expected_logs = test["post"][hardfork] |> Enum.at(index) |> Map.fetch!("logs")
-      logs_hash = logs_hash(logs)
-
-      %{
-        hardfork: hardfork,
-        test_name: test_name,
-        state_root_mismatch: state.root_hash != expected_hash,
-        state_root_expected: expected_hash,
-        state_root_actual: state.root_hash,
-        logs_hash_mismatch: maybe_hex(expected_logs) != logs_hash,
-        logs_hash_expected: maybe_hex(expected_logs),
-        logs_hash_actual: logs_hash
-      }
-    end)
   end
 
   defp failed_test?(%{state_root_mismatch: true}), do: true
@@ -348,39 +266,6 @@ defmodule Blockchain.StateTest do
     "[#{hardfork}] #{test_name}: expected #{inspect(expected)}, but received #{inspect(actual)}"
   end
 
-  def configuration(hardfork) do
-    case hardfork do
-      "Frontier" ->
-        EVM.Configuration.Frontier.new()
-
-      "Homestead" ->
-        EVM.Configuration.Homestead.new()
-
-      "EIP150" ->
-        EVM.Configuration.EIP150.new()
-
-      "EIP158" ->
-        EVM.Configuration.EIP158.new()
-
-      "Byzantium" ->
-        EVM.Configuration.Byzantium.new()
-
-      "Constantinople" ->
-        EVM.Configuration.Constantinople.new()
-
-      _ ->
-        nil
-    end
-  end
-
-  defp populate_init_or_data(tx, data) do
-    if Transaction.contract_creation?(tx) do
-      %{tx | init: data}
-    else
-      %{tx | data: data}
-    end
-  end
-
   def dump_state(state) do
     state
     |> Trie.Inspector.all_values()
@@ -398,58 +283,6 @@ defmodule Blockchain.StateTest do
       IO.puts("  Code Hash")
       IO.puts("  " <> Base.encode16(account.code_hash))
     end)
-  end
-
-  def read_state_test_file(test_path) do
-    test_path
-    |> File.read!()
-    |> Poison.decode!()
-  end
-
-  def account_interface(test) do
-    db = MerklePatriciaTree.Test.random_ets_db()
-
-    state = %Trie{
-      db: db,
-      root_hash: maybe_hex(test["env"]["previousHash"])
-    }
-
-    state =
-      Enum.reduce(test["pre"], state, fn {address, account}, state ->
-        storage = %Trie{
-          root_hash: Trie.empty_trie_root_hash(),
-          db: db
-        }
-
-        storage =
-          Enum.reduce(account["storage"], storage, fn {key, value}, trie ->
-            value = load_integer(value)
-
-            if value == 0 do
-              trie
-            else
-              Storage.put(trie.db, trie.root_hash, load_integer(key), value)
-            end
-          end)
-
-        new_account = %Account{
-          nonce: load_integer(account["nonce"]),
-          balance: load_integer(account["balance"]),
-          storage_root: storage.root_hash
-        }
-
-        state
-        |> Account.put_account(maybe_hex(address), new_account)
-        |> Account.put_code(maybe_hex(address), maybe_hex(account["code"]))
-      end)
-
-    AccountInterface.new(state)
-  end
-
-  defp logs_hash(logs) do
-    logs
-    |> ExRLP.encode()
-    |> Keccak.kec()
   end
 
   defp tests do

--- a/apps/blockchain/test/blockchain/state_test.exs
+++ b/apps/blockchain/test/blockchain/state_test.exs
@@ -1,6 +1,6 @@
 defmodule Blockchain.StateTest do
   alias MerklePatriciaTree.Trie
-  alias Blockchain.Account
+  alias Blockchain.{Account, Chain}
 
   use EthCommonTest.Harness
   use ExUnit.Case, async: true
@@ -167,33 +167,8 @@ defmodule Blockchain.StateTest do
 
   defp fork_without_implementation?(fork) do
     fork
-    |> configuration()
+    |> Chain.evm_config()
     |> is_nil()
-  end
-
-  def configuration(hardfork) do
-    case hardfork do
-      "Frontier" ->
-        EVM.Configuration.Frontier.new()
-
-      "Homestead" ->
-        EVM.Configuration.Homestead.new()
-
-      "EIP150" ->
-        EVM.Configuration.EIP150.new()
-
-      "EIP158" ->
-        EVM.Configuration.EIP158.new()
-
-      "Byzantium" ->
-        EVM.Configuration.Byzantium.new()
-
-      "Constantinople" ->
-        EVM.Configuration.Constantinople.new()
-
-      _ ->
-        nil
-    end
   end
 
   defp known_fork_failure?(json_test_path, hardfork) do

--- a/apps/blockchain/test/blockchain/state_test.exs
+++ b/apps/blockchain/test/blockchain/state_test.exs
@@ -1,6 +1,6 @@
 defmodule Blockchain.StateTest do
   alias MerklePatriciaTree.Trie
-  alias Blockchain.{Account, Chain}
+  alias Blockchain.Account
 
   use EthCommonTest.Harness
   use ExUnit.Case, async: true
@@ -167,8 +167,33 @@ defmodule Blockchain.StateTest do
 
   defp fork_without_implementation?(fork) do
     fork
-    |> Chain.evm_config()
+    |> configuration()
     |> is_nil()
+  end
+
+  def configuration(hardfork) do
+    case hardfork do
+      "Frontier" ->
+        EVM.Configuration.Frontier.new()
+
+      "Homestead" ->
+        EVM.Configuration.Homestead.new()
+
+      "EIP150" ->
+        EVM.Configuration.EIP150.new()
+
+      "EIP158" ->
+        EVM.Configuration.EIP158.new()
+
+      "Byzantium" ->
+        EVM.Configuration.Byzantium.new()
+
+      "Constantinople" ->
+        EVM.Configuration.Constantinople.new()
+
+      _ ->
+        nil
+    end
   end
 
   defp known_fork_failure?(json_test_path, hardfork) do

--- a/apps/blockchain/test/support/state_test_runner.ex
+++ b/apps/blockchain/test/support/state_test_runner.ex
@@ -1,0 +1,180 @@
+defmodule StateTestRunner do
+  alias MerklePatriciaTree.Trie
+  alias Blockchain.{Account, Transaction}
+  alias Blockchain.Interface.AccountInterface
+  alias Blockchain.Account.Storage
+  alias ExthCrypto.Hash.Keccak
+
+  import EthCommonTest.Helpers
+
+  def run(test_path, :all) do
+    ["Byzantium", "Constantinople", "EIP150", "EIP158", "Frontier", "Homestead"]
+    |> Enum.flat_map(&run(test_path, &1))
+  end
+
+  def run(test_path, hardfork) do
+    test_path
+    |> read_state_test_file()
+    |> Stream.filter(&fork_test?(&1, hardfork))
+    |> Enum.flat_map(&run_test(&1, hardfork))
+  end
+
+  defp fork_test?({_test_name, test_data}, fork) do
+    case Map.fetch(test_data["post"], fork) do
+      {:ok, _test_data} -> true
+      _ -> false
+    end
+  end
+
+  defp run_test({test_name, test}, hardfork) do
+    hardfork_configuration = configuration(hardfork)
+
+    test["post"][hardfork]
+    |> Enum.with_index()
+    |> Enum.map(fn {post, index} ->
+      pre_state = account_interface(test).state
+
+      indexes = post["indexes"]
+      gas_limit_index = indexes["gas"]
+      value_index = indexes["value"]
+      data_index = indexes["data"]
+
+      transaction =
+        %Transaction{
+          nonce: load_integer(test["transaction"]["nonce"]),
+          gas_price: load_integer(test["transaction"]["gasPrice"]),
+          gas_limit: load_integer(Enum.at(test["transaction"]["gasLimit"], gas_limit_index)),
+          to: maybe_hex(test["transaction"]["to"]),
+          value: load_integer(Enum.at(test["transaction"]["value"], value_index))
+        }
+        |> populate_init_or_data(maybe_hex(Enum.at(test["transaction"]["data"], data_index)))
+        |> Transaction.Signature.sign_transaction(maybe_hex(test["transaction"]["secretKey"]))
+
+      result =
+        Transaction.execute_with_validation(
+          pre_state,
+          transaction,
+          %Block.Header{
+            beneficiary: maybe_hex(test["env"]["currentCoinbase"]),
+            difficulty: load_integer(test["env"]["currentDifficulty"]),
+            timestamp: load_integer(test["env"]["currentTimestamp"]),
+            number: load_integer(test["env"]["currentNumber"]),
+            gas_limit: load_integer(test["env"]["currentGasLimit"]),
+            parent_hash: maybe_hex(test["env"]["previousHash"])
+          },
+          hardfork_configuration
+        )
+
+      {state, logs} =
+        case result do
+          {state, _, logs, _tx_status} -> {state, logs}
+          _ -> {pre_state, []}
+        end
+
+      expected_hash =
+        test["post"][hardfork]
+        |> Enum.at(index)
+        |> Map.fetch!("hash")
+        |> maybe_hex()
+
+      expected_logs = test["post"][hardfork] |> Enum.at(index) |> Map.fetch!("logs")
+      logs_hash = logs_hash(logs)
+
+      %{
+        hardfork: hardfork,
+        test_name: test_name,
+        state_root_mismatch: state.root_hash != expected_hash,
+        state_root_expected: expected_hash,
+        state_root_actual: state.root_hash,
+        logs_hash_mismatch: maybe_hex(expected_logs) != logs_hash,
+        logs_hash_expected: maybe_hex(expected_logs),
+        logs_hash_actual: logs_hash
+      }
+    end)
+  end
+
+  def configuration(hardfork) do
+    case hardfork do
+      "Frontier" ->
+        EVM.Configuration.Frontier.new()
+
+      "Homestead" ->
+        EVM.Configuration.Homestead.new()
+
+      "EIP150" ->
+        EVM.Configuration.EIP150.new()
+
+      "EIP158" ->
+        EVM.Configuration.EIP158.new()
+
+      "Byzantium" ->
+        EVM.Configuration.Byzantium.new()
+
+      "Constantinople" ->
+        EVM.Configuration.Constantinople.new()
+
+      _ ->
+        nil
+    end
+  end
+
+  defp populate_init_or_data(tx, data) do
+    if Transaction.contract_creation?(tx) do
+      %{tx | init: data}
+    else
+      %{tx | data: data}
+    end
+  end
+
+  def account_interface(test) do
+    db = MerklePatriciaTree.Test.random_ets_db()
+
+    state = %Trie{
+      db: db,
+      root_hash: maybe_hex(test["env"]["previousHash"])
+    }
+
+    state =
+      Enum.reduce(test["pre"], state, fn {address, account}, state ->
+        storage = %Trie{
+          root_hash: Trie.empty_trie_root_hash(),
+          db: db
+        }
+
+        storage =
+          Enum.reduce(account["storage"], storage, fn {key, value}, trie ->
+            value = load_integer(value)
+
+            if value == 0 do
+              trie
+            else
+              Storage.put(trie.db, trie.root_hash, load_integer(key), value)
+            end
+          end)
+
+        new_account = %Account{
+          nonce: load_integer(account["nonce"]),
+          balance: load_integer(account["balance"]),
+          storage_root: storage.root_hash
+        }
+
+        state
+        |> Account.put_account(maybe_hex(address), new_account)
+        |> Account.put_code(maybe_hex(address), maybe_hex(account["code"]))
+      end)
+
+    AccountInterface.new(state)
+  end
+
+  defp logs_hash(logs) do
+    logs
+    |> ExRLP.encode()
+    |> Keccak.kec()
+  end
+
+  def read_state_test_file(test_path) do
+    test_path
+    |> File.read!()
+    |> Poison.decode!()
+  end
+end


### PR DESCRIPTION
What changed?
============

Adds `mix state_tests.run` task to enable us to run a single state test
file quickly. The mix task also takes an optional `--fork` flag to only
run tests in that hardfork.

This task is the counterpart to the blockchain task `mix
common_tests.run` for state tests.

Since this mix task uses much of the same logic as the
`test/blockchain/state_test.exs` we extract that into `StateTestRunner`
module.