### PR TITLE
Turn EVM.Configuration into a behaviour

### DIFF
--- a/.dialyzer.ignore-warnings
+++ b/.dialyzer.ignore-warnings
@@ -25,17 +25,6 @@
 :0: Unknown function 'Elixir.EVM.Interface.BlockInterface.Port':'__impl__'/1
 :0: Unknown function 'Elixir.EVM.Interface.BlockInterface.Reference':'__impl__'/1
 :0: Unknown function 'Elixir.EVM.Interface.BlockInterface.Tuple':'__impl__'/1
-:0: Unknown function 'Elixir.EVM.Configuration.Atom':'__impl__'/1
-:0: Unknown function 'Elixir.EVM.Configuration.BitString':'__impl__'/1
-:0: Unknown function 'Elixir.EVM.Configuration.Float':'__impl__'/1
-:0: Unknown function 'Elixir.EVM.Configuration.Function':'__impl__'/1
-:0: Unknown function 'Elixir.EVM.Configuration.Integer':'__impl__'/1
-:0: Unknown function 'Elixir.EVM.Configuration.List':'__impl__'/1
-:0: Unknown function 'Elixir.EVM.Configuration.Map':'__impl__'/1
-:0: Unknown function 'Elixir.EVM.Configuration.PID':'__impl__'/1
-:0: Unknown function 'Elixir.EVM.Configuration.Port':'__impl__'/1
-:0: Unknown function 'Elixir.EVM.Configuration.Reference':'__impl__'/1
-:0: Unknown function 'Elixir.EVM.Configuration.Tuple':'__impl__'/1
 
 # evm warnings
 
@@ -45,7 +34,7 @@ apps/evm/lib/evm/functions.ex:213: Function 'is_invalid_jump_destination?'/3 wil
 apps/evm/lib/evm/functions.ex:223: Function 'static_state_modification?'/2 will never be called
 apps/evm/lib/evm/gas.ex:139: Function cost/2 has no local return
 apps/evm/lib/evm/gas.ex:139: Function cost/3 has no local return
-apps/evm/lib/evm/gas.ex:144: The call 'Elixir.EVM.Gas':operation_cost(atom(),_inputs@1::[integer()],_machine_state@1::#{'__struct__':='Elixir.EVM.MachineState', 'active_words':=integer(), 'gas':=integer(), 'last_return_data':=binary(), 'memory':=binary(), 'previously_active_words':=integer(), 'program_counter':=integer(), 'stack':=[integer()]},_exec_env@1::#{'__struct__':='Elixir.EVM.ExecEnv', 'account_interface':=atom(), 'address':=<<_:160>>, 'block_interface':=atom(), 'config':=atom(), 'data':=binary(), 'gas_price':=integer(), 'machine_code':=binary(), 'originator':=<<_:160>>, 'sender':=<<_:160>>, 'stack_depth':=integer(), 'static':=boolean(), 'value_in_wei':=integer()}) breaks the contract (atom(),['Elixir.EVM':val()],['Elixir.EVM':val()],'Elixir.EVM.MachineState':t()) -> t() | 'nil'
+apps/evm/lib/evm/gas.ex:144: The call 'Elixir.EVM.Gas':operation_cost(atom(),_inputs@1::[integer()],_machine_state@1::#{'__struct__':='Elixir.EVM.MachineState', 'active_words':=integer(), 'gas':=integer(), 'last_return_data':=binary(), 'memory':=binary(), 'previously_active_words':=integer(), 'program_counter':=integer(), 'stack':=[integer()]},_exec_env@1::#{'__struct__':='Elixir.EVM.ExecEnv', 'account_interface':=atom(), 'address':=<<_:160>>, 'block_interface':=atom(), 'config':=#{'__struct__':=atom(), atom()=>_}, 'data':=binary(), 'gas_price':=integer(), 'machine_code':=binary(), 'originator':=<<_:160>>, 'sender':=<<_:160>>, 'stack_depth':=integer(), 'static':=boolean(), 'value_in_wei':=integer()}) breaks the contract (atom(),['Elixir.EVM':val()],['Elixir.EVM':val()],'Elixir.EVM.MachineState':t()) -> t() | 'nil'
 apps/evm/lib/evm/gas.ex:309: Function operation_cost/0 has no local return
 apps/evm/lib/evm/gas.ex:309: The call 'Elixir.EVM.Gas':operation_cost('nil','nil','nil','nil') breaks the contract (atom(),['Elixir.EVM':val()],['Elixir.EVM':val()],'Elixir.EVM.MachineState':t()) -> t() | 'nil'
 apps/evm/lib/evm/gas.ex:309: Function operation_cost/1 has no local return
@@ -54,7 +43,7 @@ apps/evm/lib/evm/gas.ex:309: Function operation_cost/2 has no local return
 apps/evm/lib/evm/gas.ex:309: The call 'Elixir.EVM.Gas':operation_cost(__@1::any(),__@2::any(),'nil','nil') breaks the contract (atom(),['Elixir.EVM':val()],['Elixir.EVM':val()],'Elixir.EVM.MachineState':t()) -> t() | 'nil'
 apps/evm/lib/evm/gas.ex:309: Function operation_cost/3 has no local return
 apps/evm/lib/evm/gas.ex:309: The call 'Elixir.EVM.Gas':operation_cost(__@1::any(),__@2::any(),__@3::any(),'nil') breaks the contract (atom(),['Elixir.EVM':val()],['Elixir.EVM':val()],'Elixir.EVM.MachineState':t()) -> t() | 'nil'
-apps/evm/lib/evm/gas.ex:570: Function gas_cost_for_nested_operation/2 will never be called
+apps/evm/lib/evm/gas.ex:576: Function gas_cost_for_nested_operation/2 will never be called
 apps/evm/lib/evm/machine_state.ex:53: Function subtract_gas/2 has no local return
 apps/evm/lib/evm/operation/environmental_information.ex:114: Function calldataload/2 has no local return
 apps/evm/lib/evm/operation/environmental_information.ex:117: The call 'Elixir.EVM.Helpers':decode_signed(binary()) breaks the contract (integer() | 'nil') -> 'Elixir.EVM':val() | 'nil'
@@ -137,11 +126,6 @@ tate_root':=_, _=>_}, _=>_}
 # using erlang 21 while we are using erlang 20. But we cannot yet update to
 # erlang 21 because we need rox to update
 apps/blockchain/lib/blockchain/block.ex:736: Function create_receipt/6 will never be called
-
--------------------------------
-# blockchain/chain.ex
--------------------------------
-apps/blockchain/lib/blockchain/chain.ex:94: Invalid type specification for function 'Elixir.Blockchain.Chain':load_chain/1. The success typing is (atom()) -> #{'__struct__':='Elixir.Blockchain.Chain', 'accounts':=map(), 'engine':=map(), 'genesis':=#{'author':=binary(), 'difficulty':=non_neg_integer(), 'extra_data':=binary(), 'gas_limit':=non_neg_integer(), 'parent_hash':=binary(), 'timestamp':=non_neg_integer()}, 'name':=_, 'nodes':=_, 'params':=#{'account_start_nonce':=non_neg_integer(), 'block_reward':=non_neg_integer(), 'eip155_transition':=_, 'eip86_transition':=non_neg_integer(), 'eip98_transition':=non_neg_integer(), 'gas_limit_bound_divisor':=non_neg_integer(), 'maximum_extra_data_size':=non_neg_integer(), 'min_gas_limit':=non_neg_integer()}}
 
 -------------------------------
 # blockchain/genesis.ex

--- a/apps/blockchain/lib/blockchain/chain.ex
+++ b/apps/blockchain/lib/blockchain/chain.ex
@@ -104,7 +104,7 @@ defmodule Blockchain.Chain do
       iex> Blockchain.Chain.load_chain(:ropsten).genesis.difficulty
       0x100000
   """
-  @spec load_chain(atom(), EVM.Configuration.t()) :: t
+  @spec load_chain(atom(), EVM.Configuration.t() | nil) :: t
   def load_chain(chain, evm_config \\ nil) do
     chain_data = read_chain!(chain)
 
@@ -135,7 +135,7 @@ defmodule Blockchain.Chain do
       "Frontier (Test)"
   """
   def test_config(hardfork) when is_binary(hardfork) do
-    config = evm_config(hardfork)
+    config = EVM.Configuration.hardfork_config(hardfork)
 
     case hardfork do
       "Frontier" ->
@@ -155,31 +155,6 @@ defmodule Blockchain.Chain do
 
       "Constantinople" ->
         load_chain(:constantinople_test, config)
-
-      _ ->
-        nil
-    end
-  end
-
-  def evm_config(hardfork) do
-    case hardfork do
-      "Frontier" ->
-        EVM.Configuration.Frontier.new()
-
-      "Homestead" ->
-        EVM.Configuration.Homestead.new()
-
-      "EIP150" ->
-        EVM.Configuration.EIP150.new()
-
-      "EIP158" ->
-        EVM.Configuration.EIP158.new()
-
-      "Byzantium" ->
-        EVM.Configuration.Byzantium.new()
-
-      "Constantinople" ->
-        EVM.Configuration.Constantinople.new()
 
       _ ->
         nil

--- a/apps/blockchain/lib/blockchain/contract/create_contract.ex
+++ b/apps/blockchain/lib/blockchain/contract/create_contract.ex
@@ -83,7 +83,7 @@ defmodule Blockchain.Contract.CreateContract do
           EVM.address()
         ) :: AccountInterface.t()
   defp increment_nonce_of_touched_account(account_interface, config, address) do
-    if EVM.Configuration.increment_nonce_on_create?(config) do
+    if EVM.Configuration.for(config).increment_nonce_on_create?(config) do
       AccountInterface.increment_account_nonce(account_interface, address)
     else
       account_interface
@@ -152,10 +152,14 @@ defmodule Blockchain.Contract.CreateContract do
     insufficient_gas = remaining_gas < contract_creation_cost
 
     cond do
-      insufficient_gas && EVM.Configuration.fail_contract_creation_lack_of_gas?(params.config) ->
+      insufficient_gas &&
+          EVM.Configuration.for(params.config).fail_contract_creation_lack_of_gas?(params.config) ->
         {:error, {original_account_interface, 0, SubState.empty()}}
 
-      EVM.Configuration.limit_contract_code_size?(params.config, byte_size(output)) ->
+      EVM.Configuration.for(params.config).limit_contract_code_size?(
+        params.config,
+        byte_size(output)
+      ) ->
         {:error, {original_account_interface, 0, SubState.empty()}}
 
       true ->

--- a/apps/blockchain/lib/blockchain/transaction.ex
+++ b/apps/blockchain/lib/blockchain/transaction.ex
@@ -380,7 +380,7 @@ defmodule Blockchain.Transaction do
   end
 
   defp clean_touched_accounts(state, sub_state, config) do
-    if Configuration.clean_touched_accounts?(config) do
+    if Configuration.for(config).clean_touched_accounts?(config) do
       Enum.reduce(sub_state.touched_accounts, state, fn address, new_state ->
         account = Account.get_account(state, address)
 
@@ -433,7 +433,7 @@ defmodule Blockchain.Transaction do
 
   defp transaction_cost(tx, config) do
     if contract_creation?(tx) do
-      Configuration.contract_creation_cost(config)
+      Configuration.for(config).contract_creation_cost(config)
     else
       Gas.g_transaction()
     end

--- a/apps/blockchain/lib/blockchain/transaction/validity.ex
+++ b/apps/blockchain/lib/blockchain/transaction/validity.ex
@@ -43,7 +43,7 @@ defmodule Blockchain.Transaction.Validity do
   @spec validate_signature(Transaction.t(), EVM.Configuration.t()) ::
           :ok | {:invalid, :invalid_signature}
   defp validate_signature(trx, config) do
-    max_s_value = EVM.Configuration.max_signature_s(config)
+    max_s_value = EVM.Configuration.for(config).max_signature_s(config)
 
     if Transaction.Signature.is_signature_valid?(trx.r, trx.s, trx.v, max_s: max_s_value) do
       :ok

--- a/apps/blockchain/scripts/generate_blockchain_tests.ex
+++ b/apps/blockchain/scripts/generate_blockchain_tests.ex
@@ -151,7 +151,7 @@ defmodule GenerateBlockchainTests do
   end
 
   defp load_chain(hardfork) do
-    config = evm_config(hardfork)
+    config = EVM.Configuration.hardfork_config(hardfork)
 
     case hardfork do
       "Frontier" ->
@@ -171,31 +171,6 @@ defmodule GenerateBlockchainTests do
 
       "Constantinople" ->
         Chain.load_chain(:constantinople_test, config)
-
-      _ ->
-        nil
-    end
-  end
-
-  defp evm_config(hardfork) do
-    case hardfork do
-      "Frontier" ->
-        EVM.Configuration.Frontier.new()
-
-      "Homestead" ->
-        EVM.Configuration.Homestead.new()
-
-      "EIP150" ->
-        EVM.Configuration.EIP150.new()
-
-      "EIP158" ->
-        EVM.Configuration.EIP158.new()
-
-      "Byzantium" ->
-        EVM.Configuration.Byzantium.new()
-
-      "Constantinople" ->
-        EVM.Configuration.Constantinople.new()
 
       _ ->
         nil

--- a/apps/blockchain/scripts/generate_state_tests.ex
+++ b/apps/blockchain/scripts/generate_state_tests.ex
@@ -107,7 +107,7 @@ defmodule GenerateStateTests do
     completed_tests =
       test["post"]
       |> Enum.reduce(completed_tests, fn {hardfork, _test_data}, completed_tests ->
-        hardfork_configuration = configuration(hardfork)
+        hardfork_configuration = EVM.Configuration.hardfork_config(hardfork)
 
         if hardfork_configuration do
           run_transaction(
@@ -203,31 +203,6 @@ defmodule GenerateStateTests do
       end)
 
     completed_tests
-  end
-
-  def configuration(hardfork) do
-    case hardfork do
-      "Frontier" ->
-        Frontier.new()
-
-      "Homestead" ->
-        Homestead.new()
-
-      "EIP150" ->
-        EIP150.new()
-
-      "EIP158" ->
-        EIP158.new()
-
-      "Byzantium" ->
-        Byzantium.new()
-
-      "Constantinople" ->
-        Constantinople.new()
-
-      _ ->
-        nil
-    end
   end
 
   defp populate_init_or_data(tx, data) do

--- a/apps/blockchain/test/blockchain/state_test.exs
+++ b/apps/blockchain/test/blockchain/state_test.exs
@@ -1,6 +1,6 @@
 defmodule Blockchain.StateTest do
   alias MerklePatriciaTree.Trie
-  alias Blockchain.{Account, Chain}
+  alias Blockchain.Account
 
   use EthCommonTest.Harness
   use ExUnit.Case, async: true
@@ -167,7 +167,7 @@ defmodule Blockchain.StateTest do
 
   defp fork_without_implementation?(fork) do
     fork
-    |> Chain.evm_config()
+    |> EVM.Configuration.hardfork_config()
     |> is_nil()
   end
 

--- a/apps/blockchain/test/support/state_test_runner.ex
+++ b/apps/blockchain/test/support/state_test_runner.ex
@@ -27,7 +27,7 @@ defmodule StateTestRunner do
   end
 
   defp run_test({test_name, test}, hardfork) do
-    hardfork_configuration = configuration(hardfork)
+    hardfork_configuration = EVM.Configuration.hardfork_config(hardfork)
 
     test["post"][hardfork]
     |> Enum.with_index()
@@ -91,31 +91,6 @@ defmodule StateTestRunner do
         logs_hash_actual: logs_hash
       }
     end)
-  end
-
-  def configuration(hardfork) do
-    case hardfork do
-      "Frontier" ->
-        EVM.Configuration.Frontier.new()
-
-      "Homestead" ->
-        EVM.Configuration.Homestead.new()
-
-      "EIP150" ->
-        EVM.Configuration.EIP150.new()
-
-      "EIP158" ->
-        EVM.Configuration.EIP158.new()
-
-      "Byzantium" ->
-        EVM.Configuration.Byzantium.new()
-
-      "Constantinople" ->
-        EVM.Configuration.Constantinople.new()
-
-      _ ->
-        nil
-    end
   end
 
   defp populate_init_or_data(tx, data) do

--- a/apps/evm/lib/evm/configuration.ex
+++ b/apps/evm/lib/evm/configuration.ex
@@ -1,115 +1,119 @@
-defprotocol EVM.Configuration do
+defmodule EVM.Configuration do
   @moduledoc """
-  Protocol for defining hardfork configurations.
+  Behaviour for hardfork configurations.
   """
 
-  @type t :: module()
+  @type t :: struct()
 
   # EIP2
-  @spec contract_creation_cost(t) :: integer()
-  def contract_creation_cost(t)
+  @callback contract_creation_cost(t) :: integer()
 
   # EIP2
-  @spec fail_contract_creation_lack_of_gas?(t) :: boolean()
-  def fail_contract_creation_lack_of_gas?(t)
+  @callback fail_contract_creation_lack_of_gas?(t) :: boolean()
 
   # EIP2
-  @spec max_signature_s(t) :: atom()
-  def max_signature_s(t)
+  @callback max_signature_s(t) :: atom()
 
   # EIP7
-  @spec has_delegate_call?(t) :: boolean()
-  def has_delegate_call?(t)
+  @callback has_delegate_call?(t) :: boolean()
 
   # EIP150
-  @spec extcodesize_cost(t) :: integer()
-  def extcodesize_cost(t)
+  @callback extcodesize_cost(t) :: integer()
 
   # EIP150
-  @spec extcodecopy_cost(t) :: integer()
-  def extcodecopy_cost(t)
+  @callback extcodecopy_cost(t) :: integer()
 
   # EIP150
-  @spec balance_cost(t) :: integer()
-  def balance_cost(t)
+  @callback balance_cost(t) :: integer()
 
   # EIP150
-  @spec sload_cost(t) :: integer()
-  def sload_cost(t)
+  @callback sload_cost(t) :: integer()
 
   # EIP150
-  @spec call_cost(t) :: integer()
-  def call_cost(t)
+  @callback call_cost(t) :: integer()
 
   # EIP150
-  @spec selfdestruct_cost(t, keyword()) :: integer()
-  def selfdestruct_cost(t, params \\ [])
+  @callback selfdestruct_cost(t, keyword()) :: integer()
 
   # EIP150
-  @spec fail_nested_operation_lack_of_gas?(t) :: boolean()
-  def fail_nested_operation_lack_of_gas?(t)
+  @callback fail_nested_operation_lack_of_gas?(t) :: boolean()
 
   # EIP160
-  @spec exp_byte_cost(t) :: integer()
-  def exp_byte_cost(t)
+  @callback exp_byte_cost(t) :: integer()
 
   # EIP161-a
-  @spec increment_nonce_on_create?(t) :: boolean()
-  def increment_nonce_on_create?(t)
+  @callback increment_nonce_on_create?(t) :: boolean()
 
   # EIP161-b
-  @spec empty_account_value_transfer?(t) :: boolean()
-  def empty_account_value_transfer?(t)
+  @callback empty_account_value_transfer?(t) :: boolean()
 
   # EIP161-cd
-  @spec clean_touched_accounts?(t) :: boolean()
-  def clean_touched_accounts?(t)
+  @callback clean_touched_accounts?(t) :: boolean()
 
   # EIP170
-  @spec limit_contract_code_size?(t, integer) :: boolean()
-  def limit_contract_code_size?(t, size \\ 0)
+  @callback limit_contract_code_size?(t, integer) :: boolean()
 
   # EIP140
-  @spec has_revert?(t) :: boolean()
-  def has_revert?(t)
+  @callback has_revert?(t) :: boolean()
 
   # EIP211
-  @spec support_variable_length_return_value?(t) :: boolean()
-  def support_variable_length_return_value?(t)
+  @callback support_variable_length_return_value?(t) :: boolean()
 
   # EIP214
-  @spec has_static_call?(t) :: boolean()
-  def has_static_call?(t)
+  @callback has_static_call?(t) :: boolean()
 
   # EIP196
-  @spec has_ec_add_builtin?(t) :: boolean()
-  def has_ec_add_builtin?(t)
+  @callback has_ec_add_builtin?(t) :: boolean()
 
   # EIP196
-  @spec has_ec_mult_builtin?(t) :: boolean()
-  def has_ec_mult_builtin?(t)
+  @callback has_ec_mult_builtin?(t) :: boolean()
 
   # EIP197
-  @spec has_ec_pairing_builtin?(t) :: boolean()
-  def has_ec_pairing_builtin?(t)
+  @callback has_ec_pairing_builtin?(t) :: boolean()
 
   # EIP198
-  @spec has_mod_exp_builtin?(t) :: boolean()
-  def has_mod_exp_builtin?(t)
+  @callback has_mod_exp_builtin?(t) :: boolean()
 
   # EIP145
-  @spec has_shift_operations?(t) :: boolean()
-  def has_shift_operations?(t)
+  @callback has_shift_operations?(t) :: boolean()
 
   # EIP1052
-  @spec has_extcodehash?(t) :: boolean()
-  def has_extcodehash?(t)
+  @callback has_extcodehash?(t) :: boolean()
 
   # EIP1014
-  @spec has_create2?(t) :: boolean()
-  def has_create2?(t)
+  @callback has_create2?(t) :: boolean()
 
   # EIP1283
-  @spec eip1283_sstore_gas_cost_changed?(t) :: boolean()
-  def eip1283_sstore_gas_cost_changed?(t)
+  @callback eip1283_sstore_gas_cost_changed?(t) :: boolean()
+
+  @spec for(t) :: module()
+  def for(config) do
+    config.__struct__
+  end
+
+  @spec hardfork_config(String.t()) :: t()
+  def hardfork_config(hardfork) do
+    case hardfork do
+      "Frontier" ->
+        EVM.Configuration.Frontier.new()
+
+      "Homestead" ->
+        EVM.Configuration.Homestead.new()
+
+      "EIP150" ->
+        EVM.Configuration.EIP150.new()
+
+      "EIP158" ->
+        EVM.Configuration.EIP158.new()
+
+      "Byzantium" ->
+        EVM.Configuration.Byzantium.new()
+
+      "Constantinople" ->
+        EVM.Configuration.Constantinople.new()
+
+      _ ->
+        nil
+    end
+  end
 end

--- a/apps/evm/lib/evm/configuration/byzantium.ex
+++ b/apps/evm/lib/evm/configuration/byzantium.ex
@@ -1,5 +1,9 @@
 defmodule EVM.Configuration.Byzantium do
-  defstruct fallback_config: EVM.Configuration.EIP158.new(),
+  @behaviour EVM.Configuration
+
+  alias EVM.Configuration.EIP158
+
+  defstruct fallback_config: EIP158.new(),
             has_revert: true,
             has_static_call: true,
             support_variable_length_return_value: true,
@@ -8,103 +12,112 @@ defmodule EVM.Configuration.Byzantium do
             has_ec_mult_builtin: true,
             has_ec_pairing_builtin: true
 
+  @type t :: %__MODULE__{}
+
   def new do
     %__MODULE__{}
   end
-end
 
-defimpl EVM.Configuration, for: EVM.Configuration.Byzantium do
-  alias EVM.Configuration
+  @impl true
+  def contract_creation_cost(config) do
+    EIP158.contract_creation_cost(config.fallback_config)
+  end
 
-  @spec contract_creation_cost(Configuration.t()) :: integer()
-  def contract_creation_cost(config),
-    do: Configuration.contract_creation_cost(config.fallback_config)
+  @impl true
+  def has_delegate_call?(config), do: EIP158.has_delegate_call?(config.fallback_config)
 
-  @spec has_delegate_call?(Configuration.t()) :: boolean()
-  def has_delegate_call?(config), do: Configuration.has_delegate_call?(config.fallback_config)
+  @impl true
+  def max_signature_s(config), do: EIP158.max_signature_s(config.fallback_config)
 
-  @spec max_signature_s(Configuration.t()) :: atom()
-  def max_signature_s(config), do: Configuration.max_signature_s(config.fallback_config)
+  @impl true
+  def fail_contract_creation_lack_of_gas?(config) do
+    EIP158.fail_contract_creation_lack_of_gas?(config.fallback_config)
+  end
 
-  @spec fail_contract_creation_lack_of_gas?(Configuration.t()) :: boolean()
-  def fail_contract_creation_lack_of_gas?(config),
-    do: Configuration.fail_contract_creation_lack_of_gas?(config.fallback_config)
+  @impl true
+  def extcodesize_cost(config), do: EIP158.extcodesize_cost(config.fallback_config)
 
-  @spec extcodesize_cost(Configuration.t()) :: integer()
-  def extcodesize_cost(config), do: Configuration.extcodesize_cost(config.fallback_config)
+  @impl true
+  def extcodecopy_cost(config), do: EIP158.extcodecopy_cost(config.fallback_config)
 
-  @spec extcodecopy_cost(Configuration.t()) :: integer()
-  def extcodecopy_cost(config), do: Configuration.extcodecopy_cost(config.fallback_config)
+  @impl true
+  def balance_cost(config), do: EIP158.balance_cost(config.fallback_config)
 
-  @spec balance_cost(Configuration.t()) :: integer()
-  def balance_cost(config), do: Configuration.balance_cost(config.fallback_config)
+  @impl true
+  def sload_cost(config), do: EIP158.sload_cost(config.fallback_config)
 
-  @spec sload_cost(Configuration.t()) :: integer()
-  def sload_cost(config), do: Configuration.sload_cost(config.fallback_config)
+  @impl true
+  def call_cost(config), do: EIP158.call_cost(config.fallback_config)
 
-  @spec call_cost(Configuration.t()) :: integer()
-  def call_cost(config), do: Configuration.call_cost(config.fallback_config)
+  @impl true
+  def selfdestruct_cost(config, params) do
+    EIP158.selfdestruct_cost(config.fallback_config, params)
+  end
 
-  @spec selfdestruct_cost(Configuration.t(), keyword()) :: integer()
-  def selfdestruct_cost(config, params),
-    do: Configuration.selfdestruct_cost(config.fallback_config, params)
+  @impl true
+  def fail_nested_operation_lack_of_gas?(config) do
+    EIP158.fail_nested_operation_lack_of_gas?(config.fallback_config)
+  end
 
-  @spec fail_nested_operation_lack_of_gas?(Configuration.t()) :: boolean()
-  def fail_nested_operation_lack_of_gas?(config),
-    do: Configuration.fail_nested_operation_lack_of_gas?(config.fallback_config)
+  @impl true
+  def exp_byte_cost(config), do: EIP158.exp_byte_cost(config.fallback_config)
 
-  @spec exp_byte_cost(Configuration.t()) :: integer()
-  def exp_byte_cost(config), do: Configuration.exp_byte_cost(config.fallback_config)
+  @impl true
+  def limit_contract_code_size?(config, size) do
+    EIP158.limit_contract_code_size?(config.fallback_config, size)
+  end
 
-  @spec limit_contract_code_size?(Configuration.t(), integer()) :: boolean()
-  def limit_contract_code_size?(config, size),
-    do: Configuration.limit_contract_code_size?(config.fallback_config, size)
+  @impl true
+  def increment_nonce_on_create?(config) do
+    EIP158.increment_nonce_on_create?(config.fallback_config)
+  end
 
-  @spec increment_nonce_on_create?(Configuration.t()) :: boolean()
-  def increment_nonce_on_create?(config),
-    do: Configuration.increment_nonce_on_create?(config.fallback_config)
+  @impl true
+  def empty_account_value_transfer?(config) do
+    EIP158.empty_account_value_transfer?(config.fallback_config)
+  end
 
-  @spec empty_account_value_transfer?(Configuration.t()) :: boolean()
-  def empty_account_value_transfer?(config),
-    do: Configuration.empty_account_value_transfer?(config.fallback_config)
+  @impl true
+  def clean_touched_accounts?(config) do
+    EIP158.clean_touched_accounts?(config.fallback_config)
+  end
 
-  @spec clean_touched_accounts?(Configuration.t()) :: boolean()
-  def clean_touched_accounts?(config),
-    do: Configuration.clean_touched_accounts?(config.fallback_config)
-
-  @spec has_revert?(Configuration.t()) :: boolean()
+  @impl true
   def has_revert?(config), do: config.has_revert
 
-  @spec has_static_call?(Configuration.t()) :: boolean()
+  @impl true
   def has_static_call?(config), do: config.has_static_call
 
-  @spec support_variable_length_return_value?(Configuration.t()) :: boolean()
-  def support_variable_length_return_value?(config),
-    do: config.support_variable_length_return_value
+  @impl true
+  def support_variable_length_return_value?(config) do
+    config.support_variable_length_return_value
+  end
 
-  @spec has_mod_exp_builtin?(Configuration.t()) :: boolean()
+  @impl true
   def has_mod_exp_builtin?(config), do: config.has_mod_exp_builtin
 
-  @spec has_ec_add_builtin?(Configuration.t()) :: boolean()
+  @impl true
   def has_ec_add_builtin?(config), do: config.has_ec_add_builtin
 
-  @spec has_ec_mult_builtin?(Configuration.t()) :: boolean()
+  @impl true
   def has_ec_mult_builtin?(config), do: config.has_ec_mult_builtin
 
-  @spec has_ec_pairing_builtin?(Configuration.t()) :: boolean()
+  @impl true
   def has_ec_pairing_builtin?(config), do: config.has_ec_pairing_builtin
 
-  @spec has_shift_operations?(Configuration.t()) :: boolean()
-  def has_shift_operations?(config),
-    do: Configuration.has_shift_operations?(config.fallback_config)
+  @impl true
+  def has_shift_operations?(config) do
+    EIP158.has_shift_operations?(config.fallback_config)
+  end
 
-  @spec has_extcodehash?(Configuration.t()) :: boolean()
-  def has_extcodehash?(config), do: Configuration.has_extcodehash?(config.fallback_config)
+  @impl true
+  def has_extcodehash?(config), do: EIP158.has_extcodehash?(config.fallback_config)
 
-  @spec has_create2?(Configuration.t()) :: boolean()
-  def has_create2?(config), do: Configuration.has_create2?(config.fallback_config)
+  @impl true
+  def has_create2?(config), do: EIP158.has_create2?(config.fallback_config)
 
-  @spec eip1283_sstore_gas_cost_changed?(Configuration.t()) :: boolean()
-  def eip1283_sstore_gas_cost_changed?(config),
-    do: Configuration.eip1283_sstore_gas_cost_changed?(config.fallback_config)
+  @impl true
+  def eip1283_sstore_gas_cost_changed?(config) do
+    EIP158.eip1283_sstore_gas_cost_changed?(config.fallback_config)
+  end
 end

--- a/apps/evm/lib/evm/configuration/constantinople.ex
+++ b/apps/evm/lib/evm/configuration/constantinople.ex
@@ -1,109 +1,123 @@
 defmodule EVM.Configuration.Constantinople do
-  defstruct fallback_config: EVM.Configuration.Byzantium.new(),
+  @behaviour EVM.Configuration
+
+  alias EVM.Configuration.Byzantium
+
+  defstruct fallback_config: Byzantium.new(),
             has_shift_operations: true,
             has_extcodehash: true,
             has_create2: true,
             # temporarily disabled (no common tests yet) https://github.com/ethereum/tests/issues/483
             eip1283_sstore_gas_cost_changed: false
 
+  @type t :: %__MODULE__{}
+
   def new do
     %__MODULE__{}
   end
-end
 
-defimpl EVM.Configuration, for: EVM.Configuration.Constantinople do
-  alias EVM.Configuration
+  @impl true
+  def contract_creation_cost(config) do
+    Byzantium.contract_creation_cost(config.fallback_config)
+  end
 
-  @spec contract_creation_cost(Configuration.t()) :: integer()
-  def contract_creation_cost(config),
-    do: Configuration.contract_creation_cost(config.fallback_config)
+  @impl true
+  def has_delegate_call?(config), do: Byzantium.has_delegate_call?(config.fallback_config)
 
-  @spec has_delegate_call?(Configuration.t()) :: boolean()
-  def has_delegate_call?(config), do: Configuration.has_delegate_call?(config.fallback_config)
+  @impl true
+  def max_signature_s(config), do: Byzantium.max_signature_s(config.fallback_config)
 
-  @spec max_signature_s(Configuration.t()) :: atom()
-  def max_signature_s(config), do: Configuration.max_signature_s(config.fallback_config)
+  @impl true
+  def fail_contract_creation_lack_of_gas?(config) do
+    Byzantium.fail_contract_creation_lack_of_gas?(config.fallback_config)
+  end
 
-  @spec fail_contract_creation_lack_of_gas?(Configuration.t()) :: boolean()
-  def fail_contract_creation_lack_of_gas?(config),
-    do: Configuration.fail_contract_creation_lack_of_gas?(config.fallback_config)
+  @impl true
+  def extcodesize_cost(config), do: Byzantium.extcodesize_cost(config.fallback_config)
 
-  @spec extcodesize_cost(Configuration.t()) :: integer()
-  def extcodesize_cost(config), do: Configuration.extcodesize_cost(config.fallback_config)
+  @impl true
+  def extcodecopy_cost(config), do: Byzantium.extcodecopy_cost(config.fallback_config)
 
-  @spec extcodecopy_cost(Configuration.t()) :: integer()
-  def extcodecopy_cost(config), do: Configuration.extcodecopy_cost(config.fallback_config)
+  @impl true
+  def balance_cost(config), do: Byzantium.balance_cost(config.fallback_config)
 
-  @spec balance_cost(Configuration.t()) :: integer()
-  def balance_cost(config), do: Configuration.balance_cost(config.fallback_config)
+  @impl true
+  def sload_cost(config), do: Byzantium.sload_cost(config.fallback_config)
 
-  @spec sload_cost(Configuration.t()) :: integer()
-  def sload_cost(config), do: Configuration.sload_cost(config.fallback_config)
+  @impl true
+  def call_cost(config), do: Byzantium.call_cost(config.fallback_config)
 
-  @spec call_cost(Configuration.t()) :: integer()
-  def call_cost(config), do: Configuration.call_cost(config.fallback_config)
+  @impl true
+  def selfdestruct_cost(config, params) do
+    Byzantium.selfdestruct_cost(config.fallback_config, params)
+  end
 
-  @spec selfdestruct_cost(Configuration.t(), keyword()) :: integer()
-  def selfdestruct_cost(config, params),
-    do: Configuration.selfdestruct_cost(config.fallback_config, params)
+  @impl true
+  def fail_nested_operation_lack_of_gas?(config) do
+    Byzantium.fail_nested_operation_lack_of_gas?(config.fallback_config)
+  end
 
-  @spec fail_nested_operation_lack_of_gas?(Configuration.t()) :: boolean()
-  def fail_nested_operation_lack_of_gas?(config),
-    do: Configuration.fail_nested_operation_lack_of_gas?(config.fallback_config)
+  @impl true
+  def exp_byte_cost(config), do: Byzantium.exp_byte_cost(config.fallback_config)
 
-  @spec exp_byte_cost(Configuration.t()) :: integer()
-  def exp_byte_cost(config), do: Configuration.exp_byte_cost(config.fallback_config)
+  @impl true
+  def limit_contract_code_size?(config, size) do
+    Byzantium.limit_contract_code_size?(config.fallback_config, size)
+  end
 
-  @spec limit_contract_code_size?(Configuration.t(), integer()) :: boolean()
-  def limit_contract_code_size?(config, size),
-    do: Configuration.limit_contract_code_size?(config.fallback_config, size)
+  @impl true
+  def increment_nonce_on_create?(config) do
+    Byzantium.increment_nonce_on_create?(config.fallback_config)
+  end
 
-  @spec increment_nonce_on_create?(Configuration.t()) :: boolean()
-  def increment_nonce_on_create?(config),
-    do: Configuration.increment_nonce_on_create?(config.fallback_config)
+  @impl true
+  def empty_account_value_transfer?(config) do
+    Byzantium.empty_account_value_transfer?(config.fallback_config)
+  end
 
-  @spec empty_account_value_transfer?(Configuration.t()) :: boolean()
-  def empty_account_value_transfer?(config),
-    do: Configuration.empty_account_value_transfer?(config.fallback_config)
+  @impl true
+  def clean_touched_accounts?(config) do
+    Byzantium.clean_touched_accounts?(config.fallback_config)
+  end
 
-  @spec clean_touched_accounts?(Configuration.t()) :: boolean()
-  def clean_touched_accounts?(config),
-    do: Configuration.clean_touched_accounts?(config.fallback_config)
+  @impl true
+  def has_revert?(config), do: Byzantium.has_revert?(config.fallback_config)
 
-  @spec has_revert?(Configuration.t()) :: boolean()
-  def has_revert?(config), do: Configuration.has_revert?(config.fallback_config)
+  @impl true
+  def has_static_call?(config), do: Byzantium.has_static_call?(config.fallback_config)
 
-  @spec has_static_call?(Configuration.t()) :: boolean()
-  def has_static_call?(config), do: Configuration.has_static_call?(config.fallback_config)
+  @impl true
+  def support_variable_length_return_value?(config) do
+    Byzantium.support_variable_length_return_value?(config.fallback_config)
+  end
 
-  @spec support_variable_length_return_value?(Configuration.t()) :: boolean()
-  def support_variable_length_return_value?(config),
-    do: Configuration.support_variable_length_return_value?(config.fallback_config)
+  @impl true
+  def has_mod_exp_builtin?(config), do: Byzantium.has_mod_exp_builtin?(config.fallback_config)
 
-  @spec has_mod_exp_builtin?(Configuration.t()) :: boolean()
-  def has_mod_exp_builtin?(config), do: Configuration.has_mod_exp_builtin?(config.fallback_config)
+  @impl true
+  def has_ec_add_builtin?(config), do: Byzantium.has_ec_add_builtin?(config.fallback_config)
 
-  @spec has_ec_add_builtin?(Configuration.t()) :: boolean()
-  def has_ec_add_builtin?(config), do: Configuration.has_ec_add_builtin?(config.fallback_config)
+  @impl true
+  def has_ec_mult_builtin?(config), do: Byzantium.has_ec_mult_builtin?(config.fallback_config)
 
-  @spec has_ec_mult_builtin?(Configuration.t()) :: boolean()
-  def has_ec_mult_builtin?(config), do: Configuration.has_ec_mult_builtin?(config.fallback_config)
+  @impl true
+  def has_ec_pairing_builtin?(config) do
+    Byzantium.has_ec_pairing_builtin?(config.fallback_config)
+  end
 
-  @spec has_ec_pairing_builtin?(Configuration.t()) :: boolean()
-  def has_ec_pairing_builtin?(config),
-    do: Configuration.has_ec_pairing_builtin?(config.fallback_config)
+  @impl true
+  def has_shift_operations?(config) do
+    config.has_shift_operations
+  end
 
-  @spec has_shift_operations?(Configuration.t()) :: boolean()
-  def has_shift_operations?(config),
-    do: config.has_shift_operations
-
-  @spec has_extcodehash?(Configuration.t()) :: boolean()
+  @impl true
   def has_extcodehash?(config), do: config.has_extcodehash
 
-  @spec has_create2?(Configuration.t()) :: boolean()
+  @impl true
   def has_create2?(config), do: config.has_create2
 
-  @spec eip1283_sstore_gas_cost_changed?(Configuration.t()) :: boolean()
-  def eip1283_sstore_gas_cost_changed?(config),
-    do: config.eip1283_sstore_gas_cost_changed
+  @impl true
+  def eip1283_sstore_gas_cost_changed?(config) do
+    config.eip1283_sstore_gas_cost_changed
+  end
 end

--- a/apps/evm/lib/evm/configuration/eip150.ex
+++ b/apps/evm/lib/evm/configuration/eip150.ex
@@ -1,4 +1,8 @@
 defmodule EVM.Configuration.EIP150 do
+  @behaviour EVM.Configuration
+
+  alias EVM.Configuration.Homestead
+
   defstruct extcodesize_cost: 700,
             extcodecopy_cost: 700,
             balance_cost: 400,
@@ -7,107 +11,114 @@ defmodule EVM.Configuration.EIP150 do
             selfdestruct_cost: 5_000,
             new_account_destruction_cost: 25_000,
             fail_nested_operation: false,
-            fallback_config: EVM.Configuration.Homestead.new()
+            fallback_config: Homestead.new()
+
+  @type t :: %__MODULE__{}
 
   def new do
     %__MODULE__{}
   end
-end
 
-defimpl EVM.Configuration, for: EVM.Configuration.EIP150 do
-  alias EVM.Configuration
-
-  @spec contract_creation_cost(Configuration.t()) :: integer()
+  @impl true
   def contract_creation_cost(config), do: config.fallback_config.contract_creation_cost
 
-  @spec has_delegate_call?(Configuration.t()) :: boolean()
+  @impl true
   def has_delegate_call?(config), do: config.fallback_config.has_delegate_call
 
-  @spec max_signature_s(Configuration.t()) :: atom()
-  def max_signature_s(config), do: Configuration.max_signature_s(config.fallback_config)
+  @impl true
+  def max_signature_s(config), do: Homestead.max_signature_s(config.fallback_config)
 
-  @spec fail_contract_creation_lack_of_gas?(Configuration.t()) :: boolean()
-  def fail_contract_creation_lack_of_gas?(config),
-    do: config.fallback_config.fail_contract_creation
+  @impl true
+  def fail_contract_creation_lack_of_gas?(config) do
+    config.fallback_config.fail_contract_creation
+  end
 
-  @spec extcodesize_cost(Configuration.t()) :: integer()
+  @impl true
   def extcodesize_cost(config), do: config.extcodesize_cost
 
-  @spec extcodecopy_cost(Configuration.t()) :: integer()
+  @impl true
   def extcodecopy_cost(config), do: config.extcodecopy_cost
 
-  @spec balance_cost(Configuration.t()) :: integer()
+  @impl true
   def balance_cost(config), do: config.balance_cost
 
-  @spec sload_cost(Configuration.t()) :: integer()
+  @impl true
   def sload_cost(config), do: config.sload_cost
 
-  @spec call_cost(Configuration.t()) :: integer()
+  @impl true
   def call_cost(config), do: config.call_cost
 
-  @spec selfdestruct_cost(Configuration.t(), keyword()) :: integer()
+  @impl true
   def selfdestruct_cost(config, new_account: false), do: config.selfdestruct_cost
 
   def selfdestruct_cost(config, new_account: true) do
     config.selfdestruct_cost + config.new_account_destruction_cost
   end
 
-  @spec fail_nested_operation_lack_of_gas?(Configuration.t()) :: boolean()
+  @impl true
   def fail_nested_operation_lack_of_gas?(config), do: config.fail_nested_operation
 
-  @spec exp_byte_cost(Configuration.t()) :: integer()
-  def exp_byte_cost(config), do: Configuration.exp_byte_cost(config.fallback_config)
+  @impl true
+  def exp_byte_cost(config), do: Homestead.exp_byte_cost(config.fallback_config)
 
-  @spec limit_contract_code_size?(Configuration.t(), integer()) :: boolean()
-  def limit_contract_code_size?(config, _),
-    do: Configuration.limit_contract_code_size?(config.fallback_config)
+  @impl true
+  def limit_contract_code_size?(config, size) do
+    Homestead.limit_contract_code_size?(config.fallback_config, size)
+  end
 
-  @spec increment_nonce_on_create?(Configuration.t()) :: boolean()
-  def increment_nonce_on_create?(config),
-    do: Configuration.increment_nonce_on_create?(config.fallback_config)
+  @impl true
+  def increment_nonce_on_create?(config) do
+    Homestead.increment_nonce_on_create?(config.fallback_config)
+  end
 
-  @spec empty_account_value_transfer?(Configuration.t()) :: boolean()
-  def empty_account_value_transfer?(config),
-    do: Configuration.empty_account_value_transfer?(config.fallback_config)
+  @impl true
+  def empty_account_value_transfer?(config) do
+    Homestead.empty_account_value_transfer?(config.fallback_config)
+  end
 
-  @spec clean_touched_accounts?(Configuration.t()) :: boolean()
-  def clean_touched_accounts?(config),
-    do: Configuration.clean_touched_accounts?(config.fallback_config)
+  @impl true
+  def clean_touched_accounts?(config) do
+    Homestead.clean_touched_accounts?(config.fallback_config)
+  end
 
-  @spec has_revert?(Configuration.t()) :: boolean()
-  def has_revert?(config), do: Configuration.has_revert?(config.fallback_config)
+  @impl true
+  def has_revert?(config), do: Homestead.has_revert?(config.fallback_config)
 
-  @spec has_static_call?(Configuration.t()) :: boolean()
-  def has_static_call?(config), do: Configuration.has_static_call?(config.fallback_config)
+  @impl true
+  def has_static_call?(config), do: Homestead.has_static_call?(config.fallback_config)
 
-  @spec support_variable_length_return_value?(Configuration.t()) :: boolean()
-  def support_variable_length_return_value?(config),
-    do: Configuration.support_variable_length_return_value?(config.fallback_config)
+  @impl true
+  def support_variable_length_return_value?(config) do
+    Homestead.support_variable_length_return_value?(config.fallback_config)
+  end
 
-  @spec has_mod_exp_builtin?(Configuration.t()) :: boolean()
-  def has_mod_exp_builtin?(config), do: Configuration.has_mod_exp_builtin?(config.fallback_config)
+  @impl true
+  def has_mod_exp_builtin?(config), do: Homestead.has_mod_exp_builtin?(config.fallback_config)
 
-  @spec has_ec_add_builtin?(Configuration.t()) :: boolean()
-  def has_ec_add_builtin?(config), do: Configuration.has_ec_add_builtin?(config.fallback_config)
+  @impl true
+  def has_ec_add_builtin?(config), do: Homestead.has_ec_add_builtin?(config.fallback_config)
 
-  @spec has_ec_mult_builtin?(Configuration.t()) :: boolean()
-  def has_ec_mult_builtin?(config), do: Configuration.has_ec_mult_builtin?(config.fallback_config)
+  @impl true
+  def has_ec_mult_builtin?(config), do: Homestead.has_ec_mult_builtin?(config.fallback_config)
 
-  @spec has_ec_pairing_builtin?(Configuration.t()) :: boolean()
-  def has_ec_pairing_builtin?(config),
-    do: Configuration.has_ec_pairing_builtin?(config.fallback_config)
+  @impl true
+  def has_ec_pairing_builtin?(config) do
+    Homestead.has_ec_pairing_builtin?(config.fallback_config)
+  end
 
-  @spec has_shift_operations?(Configuration.t()) :: boolean()
-  def has_shift_operations?(config),
-    do: Configuration.has_shift_operations?(config.fallback_config)
+  @impl true
+  def has_shift_operations?(config) do
+    Homestead.has_shift_operations?(config.fallback_config)
+  end
 
-  @spec has_extcodehash?(Configuration.t()) :: boolean()
-  def has_extcodehash?(config), do: Configuration.has_extcodehash?(config.fallback_config)
+  @impl true
+  def has_extcodehash?(config), do: Homestead.has_extcodehash?(config.fallback_config)
 
-  @spec has_create2?(Configuration.t()) :: boolean()
-  def has_create2?(config), do: Configuration.has_create2?(config.fallback_config)
+  @impl true
+  def has_create2?(config), do: Homestead.has_create2?(config.fallback_config)
 
-  @spec eip1283_sstore_gas_cost_changed?(Configuration.t()) :: boolean()
-  def eip1283_sstore_gas_cost_changed?(config),
-    do: Configuration.eip1283_sstore_gas_cost_changed?(config.fallback_config)
+  @impl true
+  def eip1283_sstore_gas_cost_changed?(config) do
+    Homestead.eip1283_sstore_gas_cost_changed?(config.fallback_config)
+  end
 end

--- a/apps/evm/lib/evm/configuration/eip158.ex
+++ b/apps/evm/lib/evm/configuration/eip158.ex
@@ -1,105 +1,115 @@
 defmodule EVM.Configuration.EIP158 do
-  defstruct fallback_config: EVM.Configuration.EIP150.new(),
+  @behaviour EVM.Configuration
+
+  alias EVM.Configuration.EIP150
+
+  defstruct fallback_config: EIP150.new(),
             exp_byte_cost: 50,
             code_size_limit: 24_577,
             increment_nonce_on_create: true,
             empty_account_value_transfer: true,
             clean_touched_accounts: true
 
+  @type t :: %__MODULE__{}
+
   def new do
     %__MODULE__{}
   end
-end
 
-defimpl EVM.Configuration, for: EVM.Configuration.EIP158 do
-  alias EVM.Configuration
+  @impl true
+  def contract_creation_cost(config) do
+    EIP150.contract_creation_cost(config.fallback_config)
+  end
 
-  @spec contract_creation_cost(Configuration.t()) :: integer()
-  def contract_creation_cost(config),
-    do: Configuration.contract_creation_cost(config.fallback_config)
+  @impl true
+  def has_delegate_call?(config), do: EIP150.has_delegate_call?(config.fallback_config)
 
-  @spec has_delegate_call?(Configuration.t()) :: boolean()
-  def has_delegate_call?(config), do: Configuration.has_delegate_call?(config.fallback_config)
+  @impl true
+  def max_signature_s(config), do: EIP150.max_signature_s(config.fallback_config)
 
-  @spec max_signature_s(Configuration.t()) :: atom()
-  def max_signature_s(config), do: Configuration.max_signature_s(config.fallback_config)
+  @impl true
+  def fail_contract_creation_lack_of_gas?(config) do
+    EIP150.fail_contract_creation_lack_of_gas?(config.fallback_config)
+  end
 
-  @spec fail_contract_creation_lack_of_gas?(Configuration.t()) :: boolean()
-  def fail_contract_creation_lack_of_gas?(config),
-    do: Configuration.fail_contract_creation_lack_of_gas?(config.fallback_config)
+  @impl true
+  def extcodesize_cost(config), do: EIP150.extcodesize_cost(config.fallback_config)
 
-  @spec extcodesize_cost(Configuration.t()) :: integer()
-  def extcodesize_cost(config), do: Configuration.extcodesize_cost(config.fallback_config)
+  @impl true
+  def extcodecopy_cost(config), do: EIP150.extcodecopy_cost(config.fallback_config)
 
-  @spec extcodecopy_cost(Configuration.t()) :: integer()
-  def extcodecopy_cost(config), do: Configuration.extcodecopy_cost(config.fallback_config)
+  @impl true
+  def balance_cost(config), do: EIP150.balance_cost(config.fallback_config)
 
-  @spec balance_cost(Configuration.t()) :: integer()
-  def balance_cost(config), do: Configuration.balance_cost(config.fallback_config)
+  @impl true
+  def sload_cost(config), do: EIP150.sload_cost(config.fallback_config)
 
-  @spec sload_cost(Configuration.t()) :: integer()
-  def sload_cost(config), do: Configuration.sload_cost(config.fallback_config)
+  @impl true
+  def call_cost(config), do: EIP150.call_cost(config.fallback_config)
 
-  @spec call_cost(Configuration.t()) :: integer()
-  def call_cost(config), do: Configuration.call_cost(config.fallback_config)
+  @impl true
+  def selfdestruct_cost(config, params) do
+    EIP150.selfdestruct_cost(config.fallback_config, params)
+  end
 
-  @spec selfdestruct_cost(Configuration.t(), keyword()) :: integer()
-  def selfdestruct_cost(config, params),
-    do: Configuration.selfdestruct_cost(config.fallback_config, params)
+  @impl true
+  def fail_nested_operation_lack_of_gas?(config) do
+    EIP150.fail_nested_operation_lack_of_gas?(config.fallback_config)
+  end
 
-  @spec fail_nested_operation_lack_of_gas?(Configuration.t()) :: boolean()
-  def fail_nested_operation_lack_of_gas?(config),
-    do: Configuration.fail_nested_operation_lack_of_gas?(config.fallback_config)
-
-  @spec exp_byte_cost(Configuration.t()) :: integer()
+  @impl true
   def exp_byte_cost(config), do: config.exp_byte_cost
 
-  @spec limit_contract_code_size?(Configuration.t(), integer()) :: boolean()
+  @impl true
   def limit_contract_code_size?(config, size), do: size >= config.code_size_limit
 
-  @spec increment_nonce_on_create?(Configuration.t()) :: boolean()
+  @impl true
   def increment_nonce_on_create?(config), do: config.increment_nonce_on_create
 
-  @spec empty_account_value_transfer?(Configuration.t()) :: boolean()
+  @impl true
   def empty_account_value_transfer?(config), do: config.empty_account_value_transfer
 
-  @spec clean_touched_accounts?(Configuration.t()) :: boolean()
+  @impl true
   def clean_touched_accounts?(config), do: config.clean_touched_accounts
 
-  @spec has_revert?(Configuration.t()) :: boolean()
-  def has_revert?(config), do: Configuration.has_revert?(config.fallback_config)
+  @impl true
+  def has_revert?(config), do: EIP150.has_revert?(config.fallback_config)
 
-  @spec has_static_call?(Configuration.t()) :: boolean()
-  def has_static_call?(config), do: Configuration.has_static_call?(config.fallback_config)
+  @impl true
+  def has_static_call?(config), do: EIP150.has_static_call?(config.fallback_config)
 
-  @spec support_variable_length_return_value?(Configuration.t()) :: boolean()
-  def support_variable_length_return_value?(config),
-    do: Configuration.support_variable_length_return_value?(config.fallback_config)
+  @impl true
+  def support_variable_length_return_value?(config) do
+    EIP150.support_variable_length_return_value?(config.fallback_config)
+  end
 
-  @spec has_mod_exp_builtin?(Configuration.t()) :: boolean()
-  def has_mod_exp_builtin?(config), do: Configuration.has_mod_exp_builtin?(config.fallback_config)
+  @impl true
+  def has_mod_exp_builtin?(config), do: EIP150.has_mod_exp_builtin?(config.fallback_config)
 
-  @spec has_ec_add_builtin?(Configuration.t()) :: boolean()
-  def has_ec_add_builtin?(config), do: Configuration.has_ec_add_builtin?(config.fallback_config)
+  @impl true
+  def has_ec_add_builtin?(config), do: EIP150.has_ec_add_builtin?(config.fallback_config)
 
-  @spec has_ec_mult_builtin?(Configuration.t()) :: boolean()
-  def has_ec_mult_builtin?(config), do: Configuration.has_ec_mult_builtin?(config.fallback_config)
+  @impl true
+  def has_ec_mult_builtin?(config), do: EIP150.has_ec_mult_builtin?(config.fallback_config)
 
-  @spec has_ec_pairing_builtin?(Configuration.t()) :: boolean()
-  def has_ec_pairing_builtin?(config),
-    do: Configuration.has_ec_pairing_builtin?(config.fallback_config)
+  @impl true
+  def has_ec_pairing_builtin?(config) do
+    EIP150.has_ec_pairing_builtin?(config.fallback_config)
+  end
 
-  @spec has_shift_operations?(Configuration.t()) :: boolean()
-  def has_shift_operations?(config),
-    do: Configuration.has_shift_operations?(config.fallback_config)
+  @impl true
+  def has_shift_operations?(config) do
+    EIP150.has_shift_operations?(config.fallback_config)
+  end
 
-  @spec has_extcodehash?(Configuration.t()) :: boolean()
-  def has_extcodehash?(config), do: Configuration.has_extcodehash?(config.fallback_config)
+  @impl true
+  def has_extcodehash?(config), do: EIP150.has_extcodehash?(config.fallback_config)
 
-  @spec has_create2?(Configuration.t()) :: boolean()
-  def has_create2?(config), do: Configuration.has_create2?(config.fallback_config)
+  @impl true
+  def has_create2?(config), do: EIP150.has_create2?(config.fallback_config)
 
-  @spec eip1283_sstore_gas_cost_changed?(Configuration.t()) :: boolean()
-  def eip1283_sstore_gas_cost_changed?(config),
-    do: Configuration.eip1283_sstore_gas_cost_changed?(config.fallback_config)
+  @impl true
+  def eip1283_sstore_gas_cost_changed?(config) do
+    EIP150.eip1283_sstore_gas_cost_changed?(config.fallback_config)
+  end
 end

--- a/apps/evm/lib/evm/configuration/frontier.ex
+++ b/apps/evm/lib/evm/configuration/frontier.ex
@@ -1,4 +1,6 @@
 defmodule EVM.Configuration.Frontier do
+  @behaviour EVM.Configuration
+
   defstruct contract_creation_cost: 21_000,
             has_delegate_call: false,
             fail_contract_creation: false,
@@ -27,93 +29,91 @@ defmodule EVM.Configuration.Frontier do
             has_create2: false,
             eip1283_sstore_gas_cost_changed: false
 
+  @type t :: %__MODULE__{}
+
   def new do
     %__MODULE__{}
   end
-end
 
-defimpl EVM.Configuration, for: EVM.Configuration.Frontier do
-  alias EVM.Configuration
-
-  @spec contract_creation_cost(Configuration.t()) :: integer()
+  @impl true
   def contract_creation_cost(config), do: config.contract_creation_cost
 
-  @spec has_delegate_call?(Configuration.t()) :: boolean()
+  @impl true
   def has_delegate_call?(config), do: config.has_delegate_call
 
-  @spec max_signature_s(Configuration.t()) :: atom()
+  @impl true
   def max_signature_s(config), do: config.max_signature_s
 
-  @spec fail_contract_creation_lack_of_gas?(Configuration.t()) :: boolean()
+  @impl true
   def fail_contract_creation_lack_of_gas?(config), do: config.fail_contract_creation
 
-  @spec extcodesize_cost(Configuration.t()) :: integer()
+  @impl true
   def extcodesize_cost(config), do: config.extcodesize_cost
 
-  @spec extcodecopy_cost(Configuration.t()) :: integer()
+  @impl true
   def extcodecopy_cost(config), do: config.extcodecopy_cost
 
-  @spec balance_cost(Configuration.t()) :: integer()
+  @impl true
   def balance_cost(config), do: config.balance_cost
 
-  @spec sload_cost(Configuration.t()) :: integer()
+  @impl true
   def sload_cost(config), do: config.sload_cost
 
-  @spec call_cost(Configuration.t()) :: integer()
+  @impl true
   def call_cost(config), do: config.call_cost
 
-  @spec selfdestruct_cost(Configuration.t(), keyword()) :: integer()
+  @impl true
   def selfdestruct_cost(config, _params), do: config.selfdestruct_cost
 
-  @spec fail_nested_operation_lack_of_gas?(Configuration.t()) :: boolean()
+  @impl true
   def fail_nested_operation_lack_of_gas?(config), do: config.fail_nested_operation
 
-  @spec exp_byte_cost(Configuration.t()) :: integer()
+  @impl true
   def exp_byte_cost(config), do: config.exp_byte_cost
 
-  @spec limit_contract_code_size?(Configuration.t(), integer()) :: boolean()
+  @impl true
   def limit_contract_code_size?(config, _), do: config.limit_contract_code_size
 
-  @spec increment_nonce_on_create?(Configuration.t()) :: boolean()
+  @impl true
   def increment_nonce_on_create?(config), do: config.increment_nonce_on_create
 
-  @spec empty_account_value_transfer?(Configuration.t()) :: boolean()
+  @impl true
   def empty_account_value_transfer?(config), do: config.empty_account_value_transfer
 
-  @spec clean_touched_accounts?(Configuration.t()) :: boolean()
+  @impl true
   def clean_touched_accounts?(config), do: config.clean_touched_accounts
 
-  @spec has_revert?(Configuration.t()) :: boolean()
+  @impl true
   def has_revert?(config), do: config.has_revert
 
-  @spec has_static_call?(Configuration.t()) :: boolean()
+  @impl true
   def has_static_call?(config), do: config.has_static_call
 
-  @spec support_variable_length_return_value?(Configuration.t()) :: boolean()
+  @impl true
   def support_variable_length_return_value?(config),
     do: config.support_variable_length_return_value
 
-  @spec has_mod_exp_builtin?(Configuration.t()) :: boolean()
+  @impl true
   def has_mod_exp_builtin?(config), do: config.has_mod_exp_builtin
 
-  @spec has_ec_add_builtin?(Configuration.t()) :: boolean()
+  @impl true
   def has_ec_add_builtin?(config), do: config.has_ec_add_builtin
 
-  @spec has_ec_mult_builtin?(Configuration.t()) :: boolean()
+  @impl true
   def has_ec_mult_builtin?(config), do: config.has_ec_mult_builtin
 
-  @spec has_ec_pairing_builtin?(Configuration.t()) :: boolean()
+  @impl true
   def has_ec_pairing_builtin?(config), do: config.has_ec_pairing_builtin
 
-  @spec has_shift_operations?(Configuration.t()) :: boolean()
+  @impl true
   def has_shift_operations?(config), do: config.has_shift_operations
 
-  @spec has_extcodehash?(Configuration.t()) :: boolean()
+  @impl true
   def has_extcodehash?(config), do: config.has_extcodehash
 
-  @spec has_create2?(Configuration.t()) :: boolean()
+  @impl true
   def has_create2?(config), do: config.has_create2
 
-  @spec eip1283_sstore_gas_cost_changed?(Configuration.t()) :: boolean()
+  @impl true
   def eip1283_sstore_gas_cost_changed?(config), do: config.eip1283_sstore_gas_cost_changed
 end

--- a/apps/evm/lib/evm/configuration/homestead.ex
+++ b/apps/evm/lib/evm/configuration/homestead.ex
@@ -1,106 +1,118 @@
 defmodule EVM.Configuration.Homestead do
+  @behaviour EVM.Configuration
+
+  alias EVM.Configuration.Frontier
+
   defstruct contract_creation_cost: 53_000,
             has_delegate_call: true,
             max_signature_s: :secp256k1n_2,
             fail_contract_creation: true,
-            fallback_config: EVM.Configuration.Frontier.new()
+            fallback_config: Frontier.new()
+
+  @type t :: %__MODULE__{}
 
   def new do
     %__MODULE__{}
   end
-end
 
-defimpl EVM.Configuration, for: EVM.Configuration.Homestead do
-  alias EVM.Configuration
-
-  @spec contract_creation_cost(Configuration.t()) :: integer()
+  @impl true
   def contract_creation_cost(config), do: config.contract_creation_cost
 
-  @spec has_delegate_call?(Configuration.t()) :: boolean()
+  @impl true
   def has_delegate_call?(config), do: config.has_delegate_call
 
-  @spec max_signature_s(Configuration.t()) :: atom()
+  @impl true
   def max_signature_s(config), do: config.max_signature_s
 
-  @spec fail_contract_creation_lack_of_gas?(Configuration.t()) :: boolean()
+  @impl true
   def fail_contract_creation_lack_of_gas?(config), do: config.fail_contract_creation
 
-  @spec extcodesize_cost(Configuration.t()) :: integer()
-  def extcodesize_cost(config), do: Configuration.extcodesize_cost(config.fallback_config)
+  @impl true
+  def extcodesize_cost(config), do: Frontier.extcodesize_cost(config.fallback_config)
 
-  @spec extcodecopy_cost(Configuration.t()) :: integer()
-  def extcodecopy_cost(config), do: Configuration.extcodecopy_cost(config.fallback_config)
+  @impl true
+  def extcodecopy_cost(config), do: Frontier.extcodecopy_cost(config.fallback_config)
 
-  @spec balance_cost(Configuration.t()) :: integer()
-  def balance_cost(config), do: Configuration.balance_cost(config.fallback_config)
+  @impl true
+  def balance_cost(config), do: Frontier.balance_cost(config.fallback_config)
 
-  @spec sload_cost(Configuration.t()) :: integer()
-  def sload_cost(config), do: Configuration.sload_cost(config.fallback_config)
+  @impl true
+  def sload_cost(config), do: Frontier.sload_cost(config.fallback_config)
 
-  @spec call_cost(Configuration.t()) :: integer()
-  def call_cost(config), do: Configuration.call_cost(config.fallback_config)
+  @impl true
+  def call_cost(config), do: Frontier.call_cost(config.fallback_config)
 
-  @spec selfdestruct_cost(Configuration.t(), keyword()) :: integer()
-  def selfdestruct_cost(config, _params),
-    do: Configuration.selfdestruct_cost(config.fallback_config)
+  @impl true
+  def selfdestruct_cost(config, params) do
+    Frontier.selfdestruct_cost(config.fallback_config, params)
+  end
 
-  @spec fail_nested_operation_lack_of_gas?(Configuration.t()) :: boolean()
-  def fail_nested_operation_lack_of_gas?(config),
-    do: Configuration.fail_nested_operation_lack_of_gas?(config.fallback_config)
+  @impl true
+  def fail_nested_operation_lack_of_gas?(config) do
+    Frontier.fail_nested_operation_lack_of_gas?(config.fallback_config)
+  end
 
-  @spec exp_byte_cost(Configuration.t()) :: integer()
-  def exp_byte_cost(config), do: Configuration.exp_byte_cost(config.fallback_config)
+  @impl true
+  def exp_byte_cost(config), do: Frontier.exp_byte_cost(config.fallback_config)
 
-  @spec limit_contract_code_size?(Configuration.t(), integer()) :: boolean()
-  def limit_contract_code_size?(config, _),
-    do: Configuration.limit_contract_code_size?(config.fallback_config)
+  @impl true
+  def limit_contract_code_size?(config, size) do
+    Frontier.limit_contract_code_size?(config.fallback_config, size)
+  end
 
-  @spec increment_nonce_on_create?(Configuration.t()) :: boolean()
-  def increment_nonce_on_create?(config),
-    do: Configuration.increment_nonce_on_create?(config.fallback_config)
+  @impl true
+  def increment_nonce_on_create?(config) do
+    Frontier.increment_nonce_on_create?(config.fallback_config)
+  end
 
-  @spec empty_account_value_transfer?(Configuration.t()) :: boolean()
-  def empty_account_value_transfer?(config),
-    do: Configuration.empty_account_value_transfer?(config.fallback_config)
+  @impl true
+  def empty_account_value_transfer?(config) do
+    Frontier.empty_account_value_transfer?(config.fallback_config)
+  end
 
-  @spec clean_touched_accounts?(Configuration.t()) :: boolean()
-  def clean_touched_accounts?(config),
-    do: Configuration.clean_touched_accounts?(config.fallback_config)
+  @impl true
+  def clean_touched_accounts?(config) do
+    Frontier.clean_touched_accounts?(config.fallback_config)
+  end
 
-  @spec has_revert?(Configuration.t()) :: boolean()
-  def has_revert?(config), do: Configuration.has_revert?(config.fallback_config)
+  @impl true
+  def has_revert?(config), do: Frontier.has_revert?(config.fallback_config)
 
-  @spec has_static_call?(Configuration.t()) :: boolean()
-  def has_static_call?(config), do: Configuration.has_static_call?(config.fallback_config)
+  @impl true
+  def has_static_call?(config), do: Frontier.has_static_call?(config.fallback_config)
 
-  @spec support_variable_length_return_value?(Configuration.t()) :: boolean()
-  def support_variable_length_return_value?(config),
-    do: Configuration.support_variable_length_return_value?(config.fallback_config)
+  @impl true
+  def support_variable_length_return_value?(config) do
+    Frontier.support_variable_length_return_value?(config.fallback_config)
+  end
 
-  @spec has_mod_exp_builtin?(Configuration.t()) :: boolean()
-  def has_mod_exp_builtin?(config), do: Configuration.has_mod_exp_builtin?(config.fallback_config)
+  @impl true
+  def has_mod_exp_builtin?(config), do: Frontier.has_mod_exp_builtin?(config.fallback_config)
 
-  @spec has_ec_add_builtin?(Configuration.t()) :: boolean()
-  def has_ec_add_builtin?(config), do: Configuration.has_ec_add_builtin?(config.fallback_config)
+  @impl true
+  def has_ec_add_builtin?(config), do: Frontier.has_ec_add_builtin?(config.fallback_config)
 
-  @spec has_ec_mult_builtin?(Configuration.t()) :: boolean()
-  def has_ec_mult_builtin?(config), do: Configuration.has_ec_mult_builtin?(config.fallback_config)
+  @impl true
+  def has_ec_mult_builtin?(config), do: Frontier.has_ec_mult_builtin?(config.fallback_config)
 
-  @spec has_ec_pairing_builtin?(Configuration.t()) :: boolean()
-  def has_ec_pairing_builtin?(config),
-    do: Configuration.has_ec_pairing_builtin?(config.fallback_config)
+  @impl true
+  def has_ec_pairing_builtin?(config) do
+    Frontier.has_ec_pairing_builtin?(config.fallback_config)
+  end
 
-  @spec has_shift_operations?(Configuration.t()) :: boolean()
-  def has_shift_operations?(config),
-    do: Configuration.has_shift_operations?(config.fallback_config)
+  @impl true
+  def has_shift_operations?(config) do
+    Frontier.has_shift_operations?(config.fallback_config)
+  end
 
-  @spec has_extcodehash?(Configuration.t()) :: boolean()
-  def has_extcodehash?(config), do: Configuration.has_extcodehash?(config.fallback_config)
+  @impl true
+  def has_extcodehash?(config), do: Frontier.has_extcodehash?(config.fallback_config)
 
-  @spec has_create2?(Configuration.t()) :: boolean()
-  def has_create2?(config), do: Configuration.has_create2?(config.fallback_config)
+  @impl true
+  def has_create2?(config), do: Frontier.has_create2?(config.fallback_config)
 
-  @spec eip1283_sstore_gas_cost_changed?(Configuration.t()) :: boolean()
-  def eip1283_sstore_gas_cost_changed?(config),
-    do: Configuration.eip1283_sstore_gas_cost_changed?(config.fallback_config)
+  @impl true
+  def eip1283_sstore_gas_cost_changed?(config) do
+    Frontier.eip1283_sstore_gas_cost_changed?(config.fallback_config)
+  end
 end

--- a/apps/evm/lib/evm/functions.ex
+++ b/apps/evm/lib/evm/functions.ex
@@ -149,36 +149,36 @@ defmodule EVM.Functions do
 
       case operation_metadata.sym do
         :delegatecall ->
-          if Configuration.has_delegate_call?(config), do: operation_metadata
+          if Configuration.for(config).has_delegate_call?(config), do: operation_metadata
 
         :revert ->
-          if Configuration.has_revert?(config), do: operation_metadata
+          if Configuration.for(config).has_revert?(config), do: operation_metadata
 
         :staticcall ->
-          if Configuration.has_static_call?(config), do: operation_metadata
+          if Configuration.for(config).has_static_call?(config), do: operation_metadata
 
         :returndatasize ->
-          if Configuration.support_variable_length_return_value?(config),
+          if Configuration.for(config).support_variable_length_return_value?(config),
             do: operation_metadata
 
         :returndatacopy ->
-          if Configuration.support_variable_length_return_value?(config),
+          if Configuration.for(config).support_variable_length_return_value?(config),
             do: operation_metadata
 
         :shl ->
-          if Configuration.has_shift_operations?(config), do: operation_metadata
+          if Configuration.for(config).has_shift_operations?(config), do: operation_metadata
 
         :shr ->
-          if Configuration.has_shift_operations?(config), do: operation_metadata
+          if Configuration.for(config).has_shift_operations?(config), do: operation_metadata
 
         :sar ->
-          if Configuration.has_shift_operations?(config), do: operation_metadata
+          if Configuration.for(config).has_shift_operations?(config), do: operation_metadata
 
         :extcodehash ->
-          if Configuration.has_extcodehash?(config), do: operation_metadata
+          if Configuration.for(config).has_extcodehash?(config), do: operation_metadata
 
         :create2 ->
-          if Configuration.has_create2?(config), do: operation_metadata
+          if Configuration.for(config).has_create2?(config), do: operation_metadata
 
         _ ->
           operation_metadata

--- a/apps/evm/lib/evm/message_call.ex
+++ b/apps/evm/lib/evm/message_call.ex
@@ -269,15 +269,32 @@ defmodule EVM.MessageCall do
     address = :binary.decode_unsigned(code_owner)
 
     cond do
-      address == 1 -> &Builtin.run_ecrec/2
-      address == 2 -> &Builtin.run_sha256/2
-      address == 3 -> &Builtin.run_rip160/2
-      address == 4 -> &Builtin.run_id/2
-      address == 5 && EVM.Configuration.has_mod_exp_builtin?(config) -> &Builtin.mod_exp/2
-      address == 6 && EVM.Configuration.has_ec_add_builtin?(config) -> &Builtin.ec_add/2
-      address == 7 && EVM.Configuration.has_ec_mult_builtin?(config) -> &Builtin.ec_mult/2
-      address == 8 && EVM.Configuration.has_ec_pairing_builtin?(config) -> &Builtin.ec_pairing/2
-      true -> &VM.run/2
+      address == 1 ->
+        &Builtin.run_ecrec/2
+
+      address == 2 ->
+        &Builtin.run_sha256/2
+
+      address == 3 ->
+        &Builtin.run_rip160/2
+
+      address == 4 ->
+        &Builtin.run_id/2
+
+      address == 5 && EVM.Configuration.for(config).has_mod_exp_builtin?(config) ->
+        &Builtin.mod_exp/2
+
+      address == 6 && EVM.Configuration.for(config).has_ec_add_builtin?(config) ->
+        &Builtin.ec_add/2
+
+      address == 7 && EVM.Configuration.for(config).has_ec_mult_builtin?(config) ->
+        &Builtin.ec_mult/2
+
+      address == 8 && EVM.Configuration.for(config).has_ec_pairing_builtin?(config) ->
+        &Builtin.ec_pairing/2
+
+      true ->
+        &VM.run/2
     end
   end
 

--- a/apps/evm/lib/evm/operation/system.ex
+++ b/apps/evm/lib/evm/operation/system.ex
@@ -268,7 +268,7 @@ defmodule EVM.Operation.System do
       value <= account_balance and exec_env.stack_depth < EVM.Functions.max_stack_depth()
 
     available_gas =
-      if Configuration.fail_nested_operation_lack_of_gas?(exec_env.config) do
+      if Configuration.for(exec_env.config).fail_nested_operation_lack_of_gas?(exec_env.config) do
         machine_state.gas
       else
         EVM.Helpers.all_but_one_64th(machine_state.gas)

--- a/apps/evm/lib/evm/refunds/sstore.ex
+++ b/apps/evm/lib/evm/refunds/sstore.ex
@@ -6,7 +6,7 @@ defmodule EVM.Refunds.Sstore do
 
   @spec refund({integer(), integer()}, ExecEnv.t()) :: integer()
   def refund({key, new_value}, exec_env) do
-    if Configuration.eip1283_sstore_gas_cost_changed?(exec_env.config) do
+    if Configuration.for(exec_env.config).eip1283_sstore_gas_cost_changed?(exec_env.config) do
       eip1283_sstore_refund({key, new_value}, exec_env)
     else
       basic_sstore_refund({key, new_value}, exec_env)

--- a/apps/ex_wire/lib/ex_wire/config.ex
+++ b/apps/ex_wire/lib/ex_wire/config.ex
@@ -101,7 +101,10 @@ defmodule ExWire.Config do
 
   @spec chain() :: Chain.t()
   def chain do
-    get_env!(:chain) |> Chain.load_chain()
+    case get_env!(:chain) do
+      chain when is_atom(chain) -> Chain.load_chain(chain)
+      _ -> raise "Chain config should be an atom"
+    end
   end
 
   @spec commitment_count() :: integer()


### PR DESCRIPTION
What?
=====

We turn `EVM.Configuration` into a Behaviour instead of a protocol.

Why?
=====

Behaviours and Protocols are two ways to implement polymorphism in
Elixir. When we want a module to behave the same way as other modules,
we want it to satisfy a behaviour (e.g. `GenServer`). When we want to
create a somewhat generic set of operations on different types, we use
protocols (e.g. `Enumerable` working on lists, ranges, etc).

Since the `EVM.Configuration` lands on the first camp, we should use a
`Behaviour` for it. This has the side-effect of cleaning up some
dialyzer errors that made no sense previously, such as an `Atom` not
having the `EVM.Configuration` protocol implemented.