### PR TITLE
Ag yp equation updates

### DIFF
--- a/apps/blockchain/lib/bit_helper.ex
+++ b/apps/blockchain/lib/bit_helper.ex
@@ -108,9 +108,8 @@ defmodule BitHelper do
 
   @doc """
   Similar to `:binary.encode_unsigned/1`, except we encode `0` as
-  `<<>>`, the empty string. This is because the specification says that
-  we cannot have any leading zeros, and so having <<0>> by itself is
-  leading with a zero and prohibited.
+  `<<>>`, the empty string. The specification does not allow leading zeros; 
+  <<0>> by itself is leading with a zero and prohibited.
 
   ## Examples
 

--- a/apps/blockchain/lib/blockchain.ex
+++ b/apps/blockchain/lib/blockchain.ex
@@ -1,6 +1,8 @@
 defmodule Blockchain do
   @moduledoc """
-  The Blockchain application is responsible for Ethereum blockchain processes and capabilities as defined in the [Ethereum yellow paper](https://ethereum.github.io/yellowpaper/paper.pdf)
+  The Blockchain application is responsible for Ethereum blockchain processes
+  and capabilities as defined in the 
+  [Ethereum yellow paper](https://ethereum.github.io/yellowpaper/paper.pdf). Equation references are based on the Yellow Paper - Byzantium Version e94ebda.
 
   Application functionality includes:
   * Block encoding

--- a/apps/blockchain/lib/blockchain/account.ex
+++ b/apps/blockchain/lib/blockchain/account.ex
@@ -1,7 +1,7 @@
 defmodule Blockchain.Account do
   @moduledoc """
   Represents the account state,
-  as defined in Section 4.1 of the Yellow Paper.
+  as defined in Section 4.1 of the Yellow Paper
   """
 
   alias ExthCrypto.Hash.Keccak
@@ -14,7 +14,7 @@ defmodule Blockchain.Account do
   # State defined in Section 4.1 of the Yellow Paper:
   # nonce: σ_n
   # balance: σ_b
-  # storate_root: σ_s
+  # storage_root: σ_s
   # code_hash: σ_c
   defstruct nonce: 0,
             balance: 0,
@@ -29,8 +29,10 @@ defmodule Blockchain.Account do
         }
 
   @doc """
-  Checks whether or not an account is a non-contract account.
-  This is defined in the latter part of Section 4.1 of the Yellow Paper.
+  Checks whether or not an account is a non-contract account. 
+  If the codeHash field is the Keccak-256 hash of the empty string, then the 
+  node represents a simple account, sometimes referred to as a “non-contract” 
+  account. This is defined in the latter part of Section 4.1 of the Yellow Paper.
 
   ## Examples
 
@@ -105,7 +107,8 @@ defmodule Blockchain.Account do
   end
 
   @doc """
-  Loads an account from an address, as defined in Eq.(9), Eq.(10), and Eq.(12) of the Yellow Paper.
+  Loads an account from an address, as defined in Eq.(9), Eq.(10), and Eq.(12) 
+  of the Yellow Paper.
 
   ## Examples
 
@@ -139,12 +142,12 @@ defmodule Blockchain.Account do
   end
 
   @doc """
-  Checks for an empty code hash and a zero nonce. This is the equivalent of
-  any empty account check regardless of whether the account has a balance.
-  This check is needed when an account hides money in one of it's contract
-  addresses and later creates a contract to get the money out. This technique
-  is documented as `Quirk #1 - hiding in plain sight` in the [Ethereum quirks and vulns](http://swende.se/blog/Ethereum_quirks_and_vulns.html)
-  blog post.
+  Checks for an empty code hash and a zero nonce. This is the equivalent of any
+  empty account check regardless of whether the account has a balance. This
+  check is needed when an account hides money in one of it's contract addresses
+  and later creates a contract to get the money out. This technique is
+  documented as `Quirk #1 - hiding in plain sight` in the [Ethereum quirks and
+  vulns](http://swende.se/blog/Ethereum_quirks_and_vulns.html) blog post.
   """
   @spec uninitialized_contract?(t()) :: boolean()
   def uninitialized_contract?(account) do
@@ -300,9 +303,9 @@ defmodule Blockchain.Account do
   end
 
   @doc """
-  Simple helper function to adjust wei in an account. Wei may be
-  positive (to add wei) or negative (to remove it). This function
-  will raise if we attempt to reduce wei in an account to less than zero.
+  Simple helper function to adjust wei in an account. Wei may be positive (to
+  add wei) or negative (to remove it). This function will raise if we attempt to
+  reduce wei in an account to less than zero.
 
   ## Examples
 
@@ -339,9 +342,9 @@ defmodule Blockchain.Account do
   end
 
   @doc """
-  Even simpler helper function to adjust wei in an account negatively. Wei
-  may be positive (to subtract wei) or negative (to add it). This function
-  will raise if we attempt to reduce wei in an account to less than zero.
+  Even simpler helper function to adjust wei in an account negatively. Wei may
+  be positive (to subtract wei) or negative (to add it). This function will
+  raise if we attempt to reduce wei in an account to less than zero.
 
   ## Examples
 
@@ -374,14 +377,14 @@ defmodule Blockchain.Account do
   This handles the fact that a new account may be shadow-created if
   it receives eth. See Section 8, Eq.(100-104) of the Yellow Paper.
 
-  The Yellow Paper assumes this function will always succeed
-  (as the checks occur before this function is called),
-  but we'll check just in case this function is not properly called.
-  The only case will be if the sending account is nil or has an insufficient balance,
-  but we add a few extra checks just in case.
+  The Yellow Paper assumes this function will always succeed (as the checks
+  occur before this function is called), but we'll check just in case this
+  function is not properly called. The only case will be if the sending account
+  is nil or has an insufficient balance, but we add a few extra checks just in
+  case.
 
-  Note: transferring value to an empty account still adds value to said account,
-        even though it's effectively a zombie.
+  **Note**: transferring value to an empty account still adds value to said 
+  account, even though it's effectively a zombie.
 
   ## Examples
 
@@ -453,11 +456,10 @@ defmodule Blockchain.Account do
 
   @doc """
   Puts code into a given account.
-  Note, this will handle the aspect that we need to store the
-  `code_hash` outside of the contract itself and
-  only store the KEC of the code_hash.
 
-  This is defined in Section 4.1 under `codeHash` in the Yellow Paper.
+  **Note**: we need to store the `code_hash` outside of the contract itself and
+  only store the KEC of the code_hash. See Section 4.1 under `codeHash` in the 
+  Yellow Paper.
 
   All such code fragments are contained in the
   state database under their corresponding hashes for later retrieval.
@@ -485,19 +487,18 @@ defmodule Blockchain.Account do
   end
 
   @doc """
-  Returns the machine code associated with the account at the given
-  address. This will return nil if the contract has
-  no associated code (i.e. it is a simple account).
+  Returns the machine code associated with the account at the given address.
+  This will return nil if the contract has no associated code (i.e. it is a
+  simple account).
 
-  We may return `:not_found`, indicating that we were not able to
-  find the given code hash in the state trie.
+  We may return `:not_found`, indicating that we were not able to find the given
+  code hash in the state trie.
 
-  Alternatively, we will return `{:ok, machine_code}` where `machine_code`
-  may be the empty string `<<>>`.
+  Alternatively, we will return `{:ok, machine_code}` where `machine_code` may
+  be the empty string `<<>>`.
 
-  Note from Yellow Paper:
-    > "it is assumed that the client will have stored the pair (KEC(I_b), I_b)
-       at some point prior in order to make the determinatio of Ib feasible"
+  **Note**: "it is assumed that the client will have stored the pair  (KEC(I_b),
+  I_b) at some point prior in order to make the determination of Ib feasible"
 
   ## Examples
 

--- a/apps/blockchain/lib/blockchain/account/address.ex
+++ b/apps/blockchain/lib/blockchain/account/address.ex
@@ -1,6 +1,8 @@
 defmodule Blockchain.Account.Address do
   @moduledoc """
-  Represents an account's address
+  Represents an account's address. The address of the new account is defined as
+  being the rightmost 160 bits of the Keccak hash of the RLP encoding of the 
+  structure containing only the sender and the account nonce. 
   """
 
   alias ExthCrypto.Hash.Keccak
@@ -11,11 +13,10 @@ defmodule Blockchain.Account.Address do
 
   @doc """
   Determines the address of a new contract
-  based on the sender and the sender's current nonce.
+  based on the sender and the sender's current nonce. See Eq.(77) in the Yellow 
+  Paper.
 
-  This is defined as Eq.(77) in the Yellow Paper.
-
-  Note: Nonce should be already pre-incremented when calling this function.
+  **Note**: Nonce should be already pre-incremented when calling this function.
 
   ## Examples
 

--- a/apps/blockchain/lib/blockchain/account/storage.ex
+++ b/apps/blockchain/lib/blockchain/account/storage.ex
@@ -2,6 +2,10 @@ defmodule Blockchain.Account.Storage do
   @moduledoc """
   Represents the account storage,
   as defined in Section 4.1 of the Yellow Paper.
+
+  A mapping between addresses and account states is stored in a modified Merkle 
+  Patricia tree.  The trie requires a simple database backend 
+  (the state database) that maintains a mapping of bytearrays to bytearrays.
   """
 
   alias ExthCrypto.Hash.Keccak

--- a/apps/blockchain/lib/blockchain/block/holistic_validity.ex
+++ b/apps/blockchain/lib/blockchain/block/holistic_validity.ex
@@ -1,7 +1,7 @@
 defmodule Blockchain.Block.HolisticValidity do
   @moduledoc """
-  This module is responsible for holistic validity check,
-  as defined in Eq.(29) of the Yellow Paper.
+  This module is responsible for holistic validity check, as defined in Eq.(31),
+  section 4.3.2, of the Yellow Paper - Byzantium Version e94ebda.
   """
 
   alias Blockchain.{Block, Genesis, Chain}
@@ -11,9 +11,8 @@ defmodule Blockchain.Block.HolisticValidity do
   Determines whether or not a block is valid. This is
   defined in Eq.(29) of the Yellow Paper.
 
-  Note, this is a serious intensive operation, and not
-  faint of heart (since we need to run all transaction
-  in the block to validate the block).
+  This is an intensive operation because we must run all transactions in the 
+  block to validate it
 
   ## Examples
 
@@ -133,3 +132,4 @@ defmodule Blockchain.Block.HolisticValidity do
     end
   end
 end
+

--- a/apps/blockchain/lib/blockchain/block/holistic_validity.ex
+++ b/apps/blockchain/lib/blockchain/block/holistic_validity.ex
@@ -132,4 +132,3 @@ defmodule Blockchain.Block.HolisticValidity do
     end
   end
 end
-


### PR DESCRIPTION
### What Changed

- Minor documentation updates to fix formatting, clarify text and check Yellow Paper references.

### Notes

- It may be useful to add a small amount of documentation to Blockchain.Account.Storage functions.
- I would like to create a better shorthand for referring to the Yellow Paper. Is there room for a glossary or table with common reference points? If so, where would be the best place for this in the current documentation context? 