### PR TITLE
Use EIP161 chain config for EIP158

### DIFF
--- a/apps/blockchain/lib/blockchain/chain.ex
+++ b/apps/blockchain/lib/blockchain/chain.ex
@@ -148,7 +148,7 @@ defmodule Blockchain.Chain do
         load_chain(:eip150_test, config)
 
       "EIP158" ->
-        load_chain(:eip150_test, config)
+        load_chain(:eip161_test, config)
 
       "Byzantium" ->
         load_chain(:byzantium_test, config)

--- a/chains/eip161_test.json
+++ b/chains/eip161_test.json
@@ -1,0 +1,50 @@
+{
+	"name": "Homestead (Test)",
+	"engine": {
+		"Ethash": {
+			"params": {
+				"minimumDifficulty": "0x020000",
+				"difficultyBoundDivisor": "0x0800",
+				"durationLimit": "0x0d",
+				"blockReward": "0x4563918244F40000",
+				"homesteadTransition": "0x0"
+			}
+		}
+	},
+	"params": {
+		"gasLimitBoundDivisor": "0x0400",
+		"registrar" : "0xc6d9d2cd449a754c494264e1809c50e34d64562b",
+		"accountStartNonce": "0x00",
+		"maximumExtraDataSize": "0x20",
+		"minGasLimit": "0x1388",
+		"networkID" : "0x1",
+		"eip150Transition": "0x0",
+		"eip160Transition": "0x0",
+		"eip161abcTransition": "0x0",
+		"eip161dTransition": "0x0",
+		"eip98Transition": "0x7fffffffffffffff",
+		"eip155Transition": "0x0",
+		"maxCodeSize": 24576,
+		"maxCodeSizeTransition": "0x0"
+	},
+	"genesis": {
+		"seal": {
+			"ethereum": {
+				"nonce": "0x0000000000000042",
+				"mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000"
+			}
+		},
+		"difficulty": "0x400000000",
+		"author": "0x0000000000000000000000000000000000000000",
+		"timestamp": "0x00",
+		"parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+		"extraData": "0x11bbe8db4e347b4e8c937c1c8370e4b5ed33adb3db69cbdb7a38e1e50b1b82fa",
+		"gasLimit": "0x1388"
+	},
+	"accounts": {
+		"0000000000000000000000000000000000000001": { "balance": "1", "builtin": { "name": "ecrecover", "pricing": { "linear": { "base": 3000, "word": 0 } } } },
+		"0000000000000000000000000000000000000002": { "balance": "1", "builtin": { "name": "sha256", "pricing": { "linear": { "base": 60, "word": 12 } } } },
+		"0000000000000000000000000000000000000003": { "balance": "1", "builtin": { "name": "ripemd160", "pricing": { "linear": { "base": 600, "word": 120 } } } },
+		"0000000000000000000000000000000000000004": { "balance": "1", "builtin": { "name": "identity", "pricing": { "linear": { "base": 15, "word": 3 } } } }
+	}
+}


### PR DESCRIPTION
It turns out we have been using `EIP150`'s chain configuration for `EIP158` (during tests). A more accurate chain to use would be `EIP161` since `EIP161` is what superseded `EIP158`. We should also consider renaming EIP150 -> TangerineWhistle and EIP58 (EIP161) -> SpuriousDragon, but we leave that for future work.

This change does not have an effect in number of tests passed since most of the values that differ between EIP150 and EIP158 are being sourced via the `EVM.Configuration.EIP158` and not via the chain struct.