### PR TITLE
Simulate coinbase reward/clean-up in state tests

### DIFF
--- a/.dialyzer.ignore-warnings
+++ b/.dialyzer.ignore-warnings
@@ -143,6 +143,11 @@ apps/blockchain/lib/blockchain/account.ex
 apps/blockchain/lib/blockchain/transaction.ex
 
 -------------------------------
+# blockchain/transaction/account_cleaner.ex
+-------------------------------
+apps/blockchain/lib/blockchain/transaction/account_cleaner.ex:11: Guard test __@2::#{'__struct__':='Elixir.Blockchain.Account', 'balance':=integer(), 'code_hash':=binary() | [integer()], 'nonce':=integer(), 'storage_root':=binary()} =:= 'false' can never succeed
+
+-------------------------------
 # blockchain/application.ex
 -------------------------------
 apps/blockchain/lib/blockchain/application.ex:14: The call 'Elixir.EVM.Debugger':break_on([{'address',binary()},...]) will never return since the success typing is (['address']) -> integer() and the contract is (elixir:keyword('Elixir.EVM.Debugger.Breakpoint':conditions())) -> 'Elixir.EVM.Debugger.Breakpoint':id()

--- a/README.md
+++ b/README.md
@@ -120,19 +120,19 @@ Ethereum common tests are created for all clients to test against. We plan to pr
 - [VMTests](https://github.com/ethereum/tests/tree/develop/VMTests/vmTests) = 100% passing
 - [x] Frontier
   - [BlockchainTests](https://github.com/ethereum/tests/tree/develop/BlockchainTests) (Includes GeneralStateTests) 1325/1325 = 100% passing
-  - [GeneralStateTests](https://github.com/ethereum/tests/tree/develop/GeneralStateTests) 1014/1026 = 98.8% passing
+  - [GeneralStateTests](https://github.com/ethereum/tests/tree/develop/GeneralStateTests) 1026/1026 = 100% passing
 - [x] Homestead
   - [BlockchainTests](https://github.com/ethereum/tests/tree/develop/BlockchainTests) (Includes GeneralStateTests) 2231/2231 = 100% passing
-  - [GeneralStateTests](https://github.com/ethereum/tests/tree/develop/GeneralStateTests) 2023/2061 = 98.2% passing
+  - [GeneralStateTests](https://github.com/ethereum/tests/tree/develop/GeneralStateTests) 2059/2061 = 99.9% passing
 - [x] EIP150
   - [BlockchainTests](https://github.com/ethereum/tests/tree/develop/BlockchainTests) (Includes GeneralStateTests) 1275/1275 = 100% passing
-  - [GeneralStateTests](https://github.com/ethereum/tests/tree/develop/GeneralStateTests) 1088/1113 = 97.8% passing
+  - [GeneralStateTests](https://github.com/ethereum/tests/tree/develop/GeneralStateTests) 1109/1113 = 99.6% passing
 - [x] EIP158
   - [BlockchainTests](https://github.com/ethereum/tests/tree/develop/BlockchainTests) (Includes GeneralStateTests) 1232/1233 = 99.9% passing
-  - [GeneralStateTests](https://github.com/ethereum/tests/tree/develop/GeneralStateTests) 1175/1181 = 99.5% passing
+  - [GeneralStateTests](https://github.com/ethereum/tests/tree/develop/GeneralStateTests) 1176/1181 = 99.6% passing
 - [x] Byzantium
   - [BlockchainTests](https://github.com/ethereum/tests/tree/develop/BlockchainTests) (Includes GeneralStateTests) 4915/4959 = 99.1% passing
-  - [GeneralStateTests](https://github.com/ethereum/tests/tree/develop/GeneralStateTests) 4756/4784 = 99.4% passing
+  - [GeneralStateTests](https://github.com/ethereum/tests/tree/develop/GeneralStateTests) 4758/4784 = 99.5% passing
 - [ ] Constantinople: View the community [Constantinople Project Tracker](https://github.com/ethereum/pm/issues/53).
 
 ## Updating the Common test

--- a/apps/blockchain/lib/blockchain/transaction/account_cleaner.ex
+++ b/apps/blockchain/lib/blockchain/transaction/account_cleaner.ex
@@ -1,0 +1,21 @@
+defmodule Blockchain.Transaction.AccountCleaner do
+  alias Blockchain.Account
+  alias Blockchain.Interface.AccountInterface
+  alias EVM.Configuration
+
+  def clean_touched_accounts(account_interface, accounts, config) do
+    if Configuration.for(config).clean_touched_accounts?(config) do
+      Enum.reduce(accounts, account_interface, fn address, new_account_interface ->
+        account = AccountInterface.account(new_account_interface, address)
+
+        if account && Account.empty?(account) do
+          AccountInterface.del_account(new_account_interface, address)
+        else
+          new_account_interface
+        end
+      end)
+    else
+      account_interface
+    end
+  end
+end

--- a/apps/blockchain/test/blockchain/state_test.exs
+++ b/apps/blockchain/test/blockchain/state_test.exs
@@ -26,9 +26,7 @@ defmodule Blockchain.StateTest do
       "stRevertTest/RevertOpcodeInCreateReturns",
       "stRevertTest/RevertOpcodeMultipleSubCalls",
       "stSpecialTest/failed_tx_xcf416c53",
-      "stStaticCall/static_Call1024PreCalls2",
-      "stTransactionTest/EmptyTransaction2",
-      "stZeroKnowledge2/ecmul_0-3_5616_28000_96"
+      "stStaticCall/static_Call1024PreCalls2"
     ],
     "Constantinople" => [
       "stCreate2/RevertDepthCreate2OOG",
@@ -42,88 +40,15 @@ defmodule Blockchain.StateTest do
       "stCreate2/create2SmartInitCode",
       "stCreate2/create2callPrecompiles",
       "stCreate2/create2checkFieldsInInitcode",
-      "stCreate2/create2collisionBalance",
       "stCreate2/create2collisionStorage",
       "stCreate2/returndatacopy_afterFailing_create",
       "stCreate2/returndatacopy_following_revert_in_create",
-      "stRevertTest/RevertOpcodeMultipleSubCalls",
-      "stZeroKnowledge2/ecmul_0-3_5616_28000_96"
+      "stRevertTest/RevertOpcodeMultipleSubCalls"
     ],
-    "EIP150" => [
-      "stInitCodeTest/NotEnoughCashContractCreation",
-      "stInitCodeTest/OutOfGasContractCreation",
-      "stInitCodeTest/OutOfGasPrefundedContractCreation",
-      "stRandom2/201503110226PYTHON_DUP6",
-      "stRevertTest/RevertOpcodeInInit",
-      "stRevertTest/RevertOpcodeMultipleSubCalls",
-      "stRevertTest/RevertOpcodeWithBigOutputInInit",
-      "stTransactionTest/CreateTransactionReverted",
-      "stTransactionTest/EmptyTransaction",
-      "stTransactionTest/OverflowGasRequire",
-      "stTransactionTest/RefundOverflow",
-      "stTransactionTest/RefundOverflow2",
-      "stTransactionTest/TransactionNonceCheck",
-      "stTransactionTest/TransactionNonceCheck2",
-      "stTransactionTest/TransactionToItselfNotEnoughFounds",
-      "stTransactionTest/UserTransactionGasLimitIsTooLowWhenZeroCost",
-      "stTransitionTest/createNameRegistratorPerTxsNotEnoughGasAfter",
-      "stTransitionTest/createNameRegistratorPerTxsNotEnoughGasAt",
-      "stTransitionTest/createNameRegistratorPerTxsNotEnoughGasBefore"
-    ],
-    "EIP158" => [
-      "stRevertTest/RevertOpcodeMultipleSubCalls",
-      "stSpecialTest/failed_tx_xcf416c53",
-      "stTransactionTest/EmptyTransaction2"
-    ],
-    "Frontier" => [
-      "stCallCreateCallCodeTest/createNameRegistratorPerTxsNotEnoughGas",
-      "stInitCodeTest/NotEnoughCashContractCreation",
-      "stRandom2/201503110226PYTHON_DUP6",
-      "stTransactionTest/CreateTransactionReverted",
-      "stTransactionTest/EmptyTransaction",
-      "stTransactionTest/OverflowGasRequire",
-      "stTransactionTest/RefundOverflow",
-      "stTransactionTest/RefundOverflow2",
-      "stTransactionTest/TransactionNonceCheck",
-      "stTransactionTest/TransactionNonceCheck2",
-      "stTransactionTest/TransactionToItselfNotEnoughFounds",
-      "stTransactionTest/UserTransactionGasLimitIsTooLowWhenZeroCost"
-    ],
-    "Homestead" => [
-      "stDelegatecallTestHomestead/callOutput1",
-      "stDelegatecallTestHomestead/callOutput2",
-      "stDelegatecallTestHomestead/callOutput3",
-      "stDelegatecallTestHomestead/callOutput3Fail",
-      "stDelegatecallTestHomestead/callOutput3partial",
-      "stDelegatecallTestHomestead/callOutput3partialFail",
-      "stDelegatecallTestHomestead/callcodeOutput1",
-      "stDelegatecallTestHomestead/callcodeOutput2",
-      "stDelegatecallTestHomestead/callcodeOutput3",
-      "stDelegatecallTestHomestead/callcodeOutput3Fail",
-      "stDelegatecallTestHomestead/callcodeOutput3partial",
-      "stDelegatecallTestHomestead/callcodeOutput3partialFail",
-      "stInitCodeTest/NotEnoughCashContractCreation",
-      "stInitCodeTest/OutOfGasContractCreation",
-      "stInitCodeTest/OutOfGasPrefundedContractCreation",
-      "stRandom/randomStatetest184",
-      "stRandom/randomStatetest347",
-      "stRandom2/201503110226PYTHON_DUP6",
-      "stRevertTest/RevertOpcodeInInit",
-      "stRevertTest/RevertOpcodeMultipleSubCalls",
-      "stRevertTest/RevertOpcodeWithBigOutputInInit",
-      "stTransactionTest/CreateTransactionReverted",
-      "stTransactionTest/EmptyTransaction",
-      "stTransactionTest/OverflowGasRequire",
-      "stTransactionTest/RefundOverflow",
-      "stTransactionTest/RefundOverflow2",
-      "stTransactionTest/TransactionNonceCheck",
-      "stTransactionTest/TransactionNonceCheck2",
-      "stTransactionTest/TransactionToItselfNotEnoughFounds",
-      "stTransactionTest/UserTransactionGasLimitIsTooLowWhenZeroCost",
-      "stTransitionTest/createNameRegistratorPerTxsNotEnoughGasAfter",
-      "stTransitionTest/createNameRegistratorPerTxsNotEnoughGasAt",
-      "stTransitionTest/createNameRegistratorPerTxsNotEnoughGasBefore"
-    ]
+    "EIP150" => ["stRevertTest/RevertOpcodeMultipleSubCalls"],
+    "EIP158" => ["stRevertTest/RevertOpcodeMultipleSubCalls", "stSpecialTest/failed_tx_xcf416c53"],
+    "Frontier" => [],
+    "Homestead" => ["stRevertTest/RevertOpcodeMultipleSubCalls"]
   }
 
   @fifteen_minutes 1000 * 60 * 15
@@ -219,7 +144,7 @@ defmodule Blockchain.StateTest do
 
     """
     State root mismatch for the following tests:
-    #{inspect(state_root_error_messages)}
+    #{state_root_error_messages}
     -----------------
     Total state root failures: #{inspect(total_count)}
     """
@@ -247,23 +172,23 @@ defmodule Blockchain.StateTest do
   defp single_logs_hash_error_message(test_result) do
     %{
       hardfork: hardfork,
-      test_name: test_name,
+      test_source: test_source,
       logs_hash_expected: expected,
       logs_hash_actual: actual
     } = test_result
 
-    "[#{hardfork}] #{test_name}: expected #{inspect(expected)}, but received #{inspect(actual)}"
+    "[#{hardfork}] #{test_source}: expected #{inspect(expected)}, but received #{inspect(actual)}"
   end
 
   defp single_state_root_error_message(test_result) do
     %{
       hardfork: hardfork,
-      test_name: test_name,
+      test_source: test_source,
       state_root_expected: expected,
       state_root_actual: actual
     } = test_result
 
-    "[#{hardfork}] #{test_name}: expected #{inspect(expected)}, but received #{inspect(actual)}"
+    "[#{hardfork}] #{test_source}: expected #{inspect(expected)}, but received #{inspect(actual)}"
   end
 
   def dump_state(state) do


### PR DESCRIPTION
Closes https://github.com/poanetwork/mana/issues/460

What changed?
============

Introduces a step in our state tests to create the miner/beneficiary/coinbase account immediately before setting up accounts in the `pre` state. It also adds a step after the transaction execution to cleanup the miner account if we are past EIP-161 (since that is when we start cleaning up empty accounts).

Why is this needed?
===================

It turns out the state tests are not supposed to be run completely in a vacuum. Other implementations' test runners duplicate some of their blockchain implementation's functionality in order to make the state tests run more like blockchain tests.

We have state tests that are failing because of state root hash mismatches: these tests should be simulating giving a miner reward, and if the environment gives a block number that is past EIP-161, the test runner should clean up that account (if empty) before comparing state root hashes. Currently, we have some of these tests passing coincidentally because we never create a coinbase account, so we generate a state root hash that matches that of those tests that expect the coinbase to be cleaned up.

There is a helpful discussion about it in [this gitter conversation](https://gitter.im/ethereum/tests?at=5b85004aff445156164b685f).

As it turns out, Aleth made these changes [here](https://github.com/ethereum/aleth/pull/5024/files) because it [runs statetests as blockchain tests](https://gitter.im/ethereum/tests?at=5b8505a4d8d36815e59e4e42).

Both [geth](https://github.com/ethereum/go-ethereum/pull/17538/files#diff-f53696be8527ac422b8d4de7c8e945c1R149) and [parity](https://github.com/paritytech/parity-ethereum/pull/9440/files#diff-05e19decbee4a7f9c0d37af47063056eR220) have also implemented these changes.