### PR TITLE
Move test runners out of test/support

### DIFF
--- a/.dialyzer.ignore-warnings
+++ b/.dialyzer.ignore-warnings
@@ -172,5 +172,5 @@ apps/blockchain/scripts/generate_state_tests.ex
 -------------------------------
 # Ignores test runners
 -------------------------------
-apps/blockchain/test/support/blockchain_test_runner.ex
-apps/blockchain/test/support/state_test_runner.ex
+apps/blockchain/lib/eth_common_test/blockchain_test_runner.ex
+apps/blockchain/lib/eth_common_test/state_test_runner.ex

--- a/apps/blockchain/lib/eth_common_test/blockchain_test_runner.ex
+++ b/apps/blockchain/lib/eth_common_test/blockchain_test_runner.ex
@@ -1,4 +1,4 @@
-defmodule BlockchainTestRunner do
+defmodule EthCommonTest.BlockchainTestRunner do
   import EthCommonTest.Helpers
 
   alias Blockchain.{Blocktree, Account, Transaction, Chain}

--- a/apps/blockchain/lib/eth_common_test/state_test_runner.ex
+++ b/apps/blockchain/lib/eth_common_test/state_test_runner.ex
@@ -1,4 +1,4 @@
-defmodule StateTestRunner do
+defmodule EthCommonTest.StateTestRunner do
   alias MerklePatriciaTree.Trie
   alias Blockchain.{Account, Transaction}
   alias Blockchain.Interface.AccountInterface

--- a/apps/blockchain/lib/mix/tasks/common_tests.run.ex
+++ b/apps/blockchain/lib/mix/tasks/common_tests.run.ex
@@ -3,12 +3,14 @@ defmodule Mix.Tasks.CommonTests.Run do
 
   require Logger
 
+  alias EthCommonTest.BlockchainTestRunner
+
   @shortdoc "Runs a single blockchain common test"
 
   @moduledoc """
   Runs a single blockchain common test.
 
-  Note that this must be run with `MIX_ENV=test`.
+  Note that this should be run with `MIX_ENV=test`.
 
   ## Example
 

--- a/apps/blockchain/lib/mix/tasks/state_tests.run.ex
+++ b/apps/blockchain/lib/mix/tasks/state_tests.run.ex
@@ -3,12 +3,14 @@ defmodule Mix.Tasks.StateTests.Run do
 
   require Logger
 
+  alias EthCommonTest.StateTestRunner
+
   @shortdoc "Runs a single state common test"
 
   @moduledoc """
   Runs a single state common test.
 
-  Note that this must be run with `MIX_ENV=test`.
+  Note that this should be run with `MIX_ENV=test`.
 
   ## Example
 

--- a/apps/blockchain/scripts/generate_state_tests.ex
+++ b/apps/blockchain/scripts/generate_state_tests.ex
@@ -4,6 +4,7 @@ defmodule GenerateStateTests do
   alias Blockchain.Interface.AccountInterface
   alias Blockchain.Account.Storage
   alias ExthCrypto.Hash.Keccak
+  alias EthCommonTest.StateTestRunner
 
   use EthCommonTest.Harness
 

--- a/apps/blockchain/test/blockchain/state_test.exs
+++ b/apps/blockchain/test/blockchain/state_test.exs
@@ -1,6 +1,7 @@
 defmodule Blockchain.StateTest do
   alias MerklePatriciaTree.Trie
   alias Blockchain.Account
+  alias EthCommonTest.StateTestRunner
 
   use EthCommonTest.Harness
   use ExUnit.Case, async: true

--- a/apps/blockchain/test/blockchain_test.exs
+++ b/apps/blockchain/test/blockchain_test.exs
@@ -4,6 +4,7 @@ defmodule BlockchainTest do
   import EthCommonTest.Helpers
 
   alias Blockchain.Chain
+  alias EthCommonTest.BlockchainTestRunner
 
   doctest Blockchain
 


### PR DESCRIPTION
Since the `StateTestRunner` and `BlockchainTestRunner` modules are no longer used simply from within the `state_test.exs` and `blockchain_test.exs`, but are also used my mix tasks, we move them out of the `test/support` directory into the `lib/eth_common_test` directory.

Not doing so throws warnings during compilation that state that `StateTestRunner` and `BlockchainTestRunner` are not defined. It also forces us to run the mix tasks by prepending them with `MIX_ENV=test`.