### PR TITLE
EIP-155 signature schema

### DIFF
--- a/apps/blockchain/lib/blockchain/block.ex
+++ b/apps/blockchain/lib/blockchain/block.ex
@@ -723,7 +723,7 @@ defmodule Blockchain.Block do
     state = Trie.new(db, header.state_root)
 
     {new_account_interface, gas_used, receipt} =
-      Transaction.execute_with_validation(state, trx, header, chain.evm_config)
+      Transaction.execute_with_validation(state, trx, header, chain)
 
     new_state = AccountInterface.commit(new_account_interface).state
 

--- a/apps/blockchain/lib/blockchain/transaction.ex
+++ b/apps/blockchain/lib/blockchain/transaction.ex
@@ -5,7 +5,7 @@ defmodule Blockchain.Transaction do
   We are focused on implementing 𝛶, as defined in Eq.(1).
   """
 
-  alias Blockchain.{Account, Contract, Transaction, MathHelper}
+  alias Blockchain.{Account, Chain, Contract, Transaction, MathHelper}
   alias Blockchain.Transaction.{Validity, Receipt, AccountCleaner}
   alias Block.Header
   alias EVM.{Gas, Configuration, SubState}
@@ -166,18 +166,18 @@ defmodule Blockchain.Transaction do
   @doc """
   Validates the validity of a transaction and then executes it if transaction is valid.
   """
-  @spec execute_with_validation(EVM.state(), t, Header.t(), EVM.Configuration.t()) ::
+  @spec execute_with_validation(EVM.state(), t, Header.t(), Chain.t()) ::
           {AccountInterface.t(), Gas.t(), Receipt.t()}
   def execute_with_validation(
         state,
         tx,
         block_header,
-        config \\ EVM.Configuration.Frontier.new()
+        chain
       ) do
-    validation_result = Validity.validate(state, tx, block_header, config)
+    validation_result = Validity.validate(state, tx, block_header, chain)
 
     case validation_result do
-      :valid -> execute(state, tx, block_header, config)
+      :valid -> execute(state, tx, block_header, chain)
       {:invalid, _} -> {AccountInterface.new(state), 0, %Receipt{}}
     end
   end
@@ -196,17 +196,17 @@ defmodule Blockchain.Transaction do
   and the status code of this transaction. These are referred to as {σ', Υ^g,
   Υ^l, Y^z} in the Transaction Execution section of the Yellow Paper.
   """
-  @spec execute(EVM.state(), t, Header.t(), EVM.Configuration.t()) ::
+  @spec execute(EVM.state(), t, Header.t(), Chain.t()) ::
           {AccountInterface.t(), Gas.t(), Receipt.t()}
-  def execute(state, tx, block_header, config \\ EVM.Configuration.Frontier.new()) do
-    {:ok, sender} = Transaction.Signature.sender(tx)
+  def execute(state, tx, block_header, chain) do
+    {:ok, sender} = Transaction.Signature.sender(tx, chain.params.network_id)
 
     initial_account_interface = AccountInterface.new(state)
 
     {updated_account_interface, remaining_gas, sub_state, status} =
       initial_account_interface
       |> begin_transaction(sender, tx)
-      |> apply_transaction(tx, block_header, sender, config)
+      |> apply_transaction(tx, block_header, sender, chain.evm_config)
 
     {expended_gas, refund} = calculate_gas_usage(tx, remaining_gas, sub_state)
 
@@ -214,7 +214,7 @@ defmodule Blockchain.Transaction do
       updated_account_interface
       |> pay_and_refund_gas(sender, tx, refund, block_header)
       |> clean_up_accounts_marked_for_destruction(sub_state, block_header)
-      |> clean_touched_accounts(sub_state, config)
+      |> clean_touched_accounts(sub_state, chain.evm_config)
 
     receipt =
       create_receipt(

--- a/apps/blockchain/lib/blockchain/transaction/signature.ex
+++ b/apps/blockchain/lib/blockchain/transaction/signature.ex
@@ -156,44 +156,46 @@ defmodule Blockchain.Transaction.Signature do
 
   ## Examples
 
-    iex> Blockchain.Transaction.Signature.is_signature_valid?(1, 1, 27, max_s: :secp256k1n)
+    iex> Blockchain.Transaction.Signature.is_signature_valid?(1, 1, 27, 1, max_s: :secp256k1n)
     true
 
-    iex> Blockchain.Transaction.Signature.is_signature_valid?(1, 1, 20, max_s: :secp256k1n) # invalid v
+    iex> Blockchain.Transaction.Signature.is_signature_valid?(1, 1, 20, 1, max_s: :secp256k1n) # invalid v
     false
 
     iex> secp256k1n = 115792089237316195423570985008687907852837564279074904382605163141518161494337
-    iex> Blockchain.Transaction.Signature.is_signature_valid?(secp256k1n - 1, 1, 28, max_s: :secp256k1n) # r okay
+    iex> Blockchain.Transaction.Signature.is_signature_valid?(secp256k1n - 1, 1, 28, 1, max_s: :secp256k1n) # r okay
     true
 
     iex> secp256k1n = 115792089237316195423570985008687907852837564279074904382605163141518161494337
-    iex> Blockchain.Transaction.Signature.is_signature_valid?(secp256k1n + 1, 1, 28, max_s: :secp256k1n) # r too high
+    iex> Blockchain.Transaction.Signature.is_signature_valid?(secp256k1n + 1, 1, 28, 1, max_s: :secp256k1n) # r too high
     false
 
     iex> secp256k1n = 115792089237316195423570985008687907852837564279074904382605163141518161494337
-    iex> Blockchain.Transaction.Signature.is_signature_valid?(1, secp256k1n + 1, 28, max_s: :secp256k1n) # s too high for non-homestead
+    iex> Blockchain.Transaction.Signature.is_signature_valid?(1, secp256k1n + 1, 28, 1, max_s: :secp256k1n) # s too high for non-homestead
     false
 
     iex> secp256k1n = 115792089237316195423570985008687907852837564279074904382605163141518161494337
-    iex> Blockchain.Transaction.Signature.is_signature_valid?(1, secp256k1n - 1, 28, max_s: :secp256k1n) # s okay for non-homestead
+    iex> Blockchain.Transaction.Signature.is_signature_valid?(1, secp256k1n - 1, 28, 1, max_s: :secp256k1n) # s okay for non-homestead
     true
 
     iex> secp256k1n = 115792089237316195423570985008687907852837564279074904382605163141518161494337
-    iex> Blockchain.Transaction.Signature.is_signature_valid?(1, secp256k1n - 1, 28, max_s: :secp256k1n_2) # s too high for homestead
+    iex> Blockchain.Transaction.Signature.is_signature_valid?(1, secp256k1n - 1, 28, 1, max_s: :secp256k1n_2) # s too high for homestead
     false
 
     iex> secp256k1n = 115792089237316195423570985008687907852837564279074904382605163141518161494337
     iex> secp256k1n_2 = round(:math.floor(secp256k1n / 2))
-    iex> Blockchain.Transaction.Signature.is_signature_valid?(secp256k1n_2 - 1, 1, 28, max_s: :secp256k1n_2) # s okay for homestead
+    iex> Blockchain.Transaction.Signature.is_signature_valid?(secp256k1n_2 - 1, 1, 28, 1, max_s: :secp256k1n_2) # s okay for homestead
     true
   """
-  @spec is_signature_valid?(integer(), integer(), integer(), max_s: atom()) :: boolean()
-  def is_signature_valid?(r, s, v, max_s: :secp256k1n) do
+  @spec is_signature_valid?(integer(), integer(), integer(), integer(), max_s: atom()) ::
+          boolean()
+  def is_signature_valid?(r, s, v, _, max_s: :secp256k1n) do
     r > 0 and r < @secp256k1n and s > 0 and s < @secp256k1n and (v == 27 || v == 28)
   end
 
-  def is_signature_valid?(r, s, v, max_s: :secp256k1n_2) do
-    r > 0 and r < @secp256k1n and s > 0 and s <= @secp256k1n_2 and (v == 27 || v == 28)
+  def is_signature_valid?(r, s, v, chain_id, max_s: :secp256k1n_2) do
+    r > 0 and r < @secp256k1n and s > 0 and s <= @secp256k1n_2 and
+      (v == 27 || v == 28 || v == chain_id * 2 + 35 || v == chain_id * 2 + 36)
   end
 
   @doc """

--- a/apps/blockchain/lib/eth_common_test/state_test_runner.ex
+++ b/apps/blockchain/lib/eth_common_test/state_test_runner.ex
@@ -1,6 +1,6 @@
 defmodule EthCommonTest.StateTestRunner do
   alias MerklePatriciaTree.Trie
-  alias Blockchain.{Account, Transaction}
+  alias Blockchain.{Account, Chain, Transaction}
   alias Blockchain.Interface.AccountInterface
   alias Blockchain.Account.Storage
   alias ExthCrypto.Hash.Keccak
@@ -27,7 +27,7 @@ defmodule EthCommonTest.StateTestRunner do
   end
 
   def run_test({test_name, test}, hardfork) do
-    hardfork_configuration = EVM.Configuration.hardfork_config(hardfork)
+    chain = Chain.test_config(hardfork)
 
     test["post"][hardfork]
     |> Enum.with_index()
@@ -65,13 +65,13 @@ defmodule EthCommonTest.StateTestRunner do
             gas_limit: load_integer(test["env"]["currentGasLimit"]),
             parent_hash: maybe_hex(test["env"]["previousHash"])
           },
-          hardfork_configuration
+          chain
         )
 
       account_interface =
         account_interface
         |> simulate_miner_reward(test)
-        |> simulate_account_cleaning(test, hardfork_configuration)
+        |> simulate_account_cleaning(test, chain.evm_config)
 
       state = AccountInterface.commit(account_interface).state
 

--- a/apps/blockchain/scripts/sync_with_infura.ex
+++ b/apps/blockchain/scripts/sync_with_infura.ex
@@ -104,8 +104,8 @@ defmodule SyncWithInfura do
       end
 
     Blockchain.Block.add_ommers(block, ommers)
-  catch
-    :exit, error ->
+  rescue
+    error ->
       Logger.info("error:  #{inspect(error)}")
       Logger.info("Retrying")
       get_block(n)

--- a/apps/blockchain/test/blockchain/transaction/validity_test.exs
+++ b/apps/blockchain/test/blockchain/transaction/validity_test.exs
@@ -1,7 +1,7 @@
 defmodule Blockchain.Transaction.ValidityTest do
   use ExUnit.Case, async: true
   alias Blockchain.Transaction.Validity
-  alias Blockchain.{Transaction, Account}
+  alias Blockchain.{Account, Chain, Transaction}
 
   describe "validate/3" do
     test "invalidates transaction when signature's s-value is too high (after homestead fork)" do
@@ -24,7 +24,7 @@ defmodule Blockchain.Transaction.ValidityTest do
         |> Validity.validate(
           trx,
           %Block.Header{},
-          EVM.Configuration.Homestead.new()
+          Chain.test_config("Homestead")
         )
 
       assert result == {:invalid, :invalid_sender}
@@ -47,7 +47,7 @@ defmodule Blockchain.Transaction.ValidityTest do
       result =
         MerklePatriciaTree.Test.random_ets_db()
         |> MerklePatriciaTree.Trie.new()
-        |> Validity.validate(trx, %Block.Header{}, EVM.Configuration.Frontier.new())
+        |> Validity.validate(trx, %Block.Header{}, Chain.load_chain(:frontier_test))
 
       assert result == {:invalid, :invalid_sender}
     end
@@ -74,7 +74,7 @@ defmodule Blockchain.Transaction.ValidityTest do
         MerklePatriciaTree.Test.random_ets_db()
         |> MerklePatriciaTree.Trie.new()
         |> Account.put_account(sender, %Account{balance: 1000, nonce: 5})
-        |> Validity.validate(trx, %Block.Header{}, EVM.Configuration.Frontier.new())
+        |> Validity.validate(trx, %Block.Header{}, Chain.load_chain(:frontier_test))
 
       assert Enum.member?(errors, :nonce_mismatch)
     end
@@ -101,7 +101,7 @@ defmodule Blockchain.Transaction.ValidityTest do
         MerklePatriciaTree.Test.random_ets_db()
         |> MerklePatriciaTree.Trie.new()
         |> Account.put_account(sender, %Account{balance: 1000, nonce: 5})
-        |> Validity.validate(trx, %Block.Header{}, EVM.Configuration.Frontier.new())
+        |> Validity.validate(trx, %Block.Header{}, Chain.load_chain(:frontier_test))
 
       assert result ==
                {:invalid, [:over_gas_limit, :insufficient_balance, :insufficient_intrinsic_gas]}
@@ -129,7 +129,7 @@ defmodule Blockchain.Transaction.ValidityTest do
         MerklePatriciaTree.Test.random_ets_db()
         |> MerklePatriciaTree.Trie.new()
         |> Account.put_account(sender, %Account{balance: 1000, nonce: 5})
-        |> Validity.validate(trx, %Block.Header{}, EVM.Configuration.Frontier.new())
+        |> Validity.validate(trx, %Block.Header{}, Chain.load_chain(:frontier_test))
 
       assert result == {:invalid, [:over_gas_limit, :insufficient_balance]}
     end
@@ -159,7 +159,7 @@ defmodule Blockchain.Transaction.ValidityTest do
         |> Validity.validate(
           trx,
           %Block.Header{gas_limit: 50_000, gas_used: 49_999},
-          EVM.Configuration.Frontier.new()
+          Chain.load_chain(:frontier_test)
         )
 
       assert result == {:invalid, [:over_gas_limit]}
@@ -190,7 +190,7 @@ defmodule Blockchain.Transaction.ValidityTest do
         |> Validity.validate(
           trx,
           %Block.Header{gas_limit: 500_000, gas_used: 49_999},
-          EVM.Configuration.Frontier.new()
+          Chain.load_chain(:frontier_test)
         )
 
       assert result == :valid

--- a/apps/blockchain/test/blockchain/transaction_test.exs
+++ b/apps/blockchain/test/blockchain/transaction_test.exs
@@ -5,7 +5,7 @@ defmodule Blockchain.TransactionTest do
   doctest Blockchain.Transaction
 
   alias ExthCrypto.Hash.Keccak
-  alias Blockchain.{Account, Transaction}
+  alias Blockchain.{Account, Chain, Transaction}
   alias Blockchain.Transaction.Signature
   alias Blockchain.Interface.AccountInterface
   alias MerklePatriciaTree.Trie
@@ -173,11 +173,13 @@ defmodule Blockchain.TransactionTest do
 
       tx = Transaction.Signature.sign_transaction(unsigned_tx, private_key)
 
+      chain = Chain.test_config("Frontier")
+
       {account_interface, gas, receipt} =
         MerklePatriciaTree.Test.random_ets_db()
         |> Trie.new()
         |> Account.put_account(sender, %Account{balance: 400_000, nonce: 5})
-        |> Transaction.execute(tx, %Block.Header{beneficiary: beneficiary})
+        |> Transaction.execute(tx, %Block.Header{beneficiary: beneficiary}, chain)
 
       state = AccountInterface.commit(account_interface).state
 
@@ -242,12 +244,14 @@ defmodule Blockchain.TransactionTest do
 
       db = MerklePatriciaTree.Test.random_ets_db()
 
+      chain = Chain.test_config("Frontier")
+
       {account_interface, gas, receipt} =
         db
         |> Trie.new()
         |> Account.put_account(sender, %Account{balance: 400_000, nonce: 5})
         |> Account.put_code(contract_address, machine_code)
-        |> Transaction.execute(tx, %Block.Header{beneficiary: beneficiary})
+        |> Transaction.execute(tx, %Block.Header{beneficiary: beneficiary}, chain)
 
       state = AccountInterface.commit(account_interface).state
 
@@ -295,11 +299,13 @@ defmodule Blockchain.TransactionTest do
         }
         |> Transaction.Signature.sign_transaction(private_key)
 
+      chain = Chain.test_config("Frontier")
+
       {account_interface, gas_used, receipt} =
         MerklePatriciaTree.Test.random_ets_db()
         |> Trie.new()
         |> Account.put_account(sender_address, sender_account)
-        |> Transaction.execute(tx, %Block.Header{beneficiary: beneficiary_address})
+        |> Transaction.execute(tx, %Block.Header{beneficiary: beneficiary_address}, chain)
 
       state = AccountInterface.commit(account_interface).state
 
@@ -318,7 +324,7 @@ defmodule Blockchain.TransactionTest do
 
   describe "execute transaction with revert (Byzantium)" do
     test "reverts message call state except for gas used, increments nonce, and marks tx status as failed (0)" do
-      config = EVM.Configuration.Byzantium.new()
+      chain = Chain.test_config("Byzantium")
       private_key = <<1::256>>
       gas_price = 3
 
@@ -361,7 +367,7 @@ defmodule Blockchain.TransactionTest do
         |> Trie.new()
         |> Account.put_account(sender.address, %Account{balance: 400_000, nonce: sender.nonce})
         |> Account.put_code(contract_address, machine_code)
-        |> Transaction.execute(tx, %Block.Header{beneficiary: beneficiary.address}, config)
+        |> Transaction.execute(tx, %Block.Header{beneficiary: beneficiary.address}, chain)
 
       state = AccountInterface.commit(account_interface).state
 
@@ -382,7 +388,7 @@ defmodule Blockchain.TransactionTest do
     end
 
     test "reverts contract creation state except for gas used, increments nonce, and marks tx status as failed (0)" do
-      config = EVM.Configuration.Byzantium.new()
+      chain = Chain.test_config("Byzantium")
       private_key = <<1::256>>
       gas_price = 3
 
@@ -422,7 +428,7 @@ defmodule Blockchain.TransactionTest do
         MerklePatriciaTree.Test.random_ets_db()
         |> Trie.new()
         |> Account.put_account(sender.address, %Account{balance: 400_000, nonce: sender.nonce})
-        |> Transaction.execute(tx, %Block.Header{beneficiary: beneficiary.address}, config)
+        |> Transaction.execute(tx, %Block.Header{beneficiary: beneficiary.address}, chain)
 
       state = AccountInterface.commit(account_interface).state
 


### PR DESCRIPTION
Why:

We should be validating signatures using v = 27 | 28 | CHAIN_ID * 2 + 35
| CHAIN_ID * 2 + 36 but we are currently only using v = 27 | 28.

This PR:

Adds the additional valid values for v. This means we need to pass
around the chain instead of only evm_config for validating sender
signatures.