### PR TITLE
increase `CREATE2` memory cost

### DIFF
--- a/apps/evm/lib/evm/gas.ex
+++ b/apps/evm/lib/evm/gas.ex
@@ -219,7 +219,8 @@ defmodule EVM.Gas do
   end
 
   def memory_cost(:create2, [_value, in_offset, in_length, _salt], machine_state) do
-    memory_expansion_cost(machine_state, in_offset, in_length)
+    memory_expansion_cost(machine_state, in_offset, in_length) +
+      @g_sha3word * MathHelper.bits_to_words(in_length)
   end
 
   def memory_cost(:return, [offset, length], machine_state) do


### PR DESCRIPTION
This PR implements changes to [EIP1014](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1014.md#gas-cost)
`The CREATE2 has the same gas schema as CREATE, but also an extra hashcost of GSHA3WORD * ceil(len(init_code) / 32), to account for the hashing that must be performed.`