### PR TITLE
check if recipient is currrent account in message call

### DIFF
--- a/apps/evm/lib/evm/message_call.ex
+++ b/apps/evm/lib/evm/message_call.ex
@@ -88,7 +88,7 @@ defmodule EVM.MessageCall do
         message_call.sender
       )
 
-    sender_balance >= message_call.value
+    sender_balance >= message_call.value || recipient_is_current_account?(message_call)
   end
 
   defp valid_stack_depth?(message_call) do


### PR DESCRIPTION
We were failing on 158253 block in ropsten because we shouldn't validate if an account has enough funds for delegate call (account is the same)