### PR TITLE
fix fork configuration resolving

### DIFF
--- a/apps/blockchain/lib/eth_common_test/helpers.ex
+++ b/apps/blockchain/lib/eth_common_test/helpers.ex
@@ -97,6 +97,14 @@ defmodule EthCommonTest.Helpers do
     end
   end
 
+  def test_suite_fork_name(fork) do
+    case fork do
+      "TangerineWhistle" -> "EIP150"
+      "SpuriousDragon" -> "EIP158"
+      fork -> fork
+    end
+  end
+
   @spec ethereum_common_tests_path :: String.t()
   def ethereum_common_tests_path do
     Path.join(System.cwd(), "/../../ethereum_common_tests")

--- a/apps/blockchain/lib/eth_common_test/state_test_runner.ex
+++ b/apps/blockchain/lib/eth_common_test/state_test_runner.ex
@@ -20,14 +20,18 @@ defmodule EthCommonTest.StateTestRunner do
   end
 
   defp fork_test?({_test_name, test_data}, fork) do
-    case Map.fetch(test_data["post"], fork) do
+    tests_suite_fork = test_suite_fork_name(fork)
+
+    case Map.fetch(test_data["post"], tests_suite_fork) do
       {:ok, _test_data} -> true
       _ -> false
     end
   end
 
   def run_test({test_name, test}, hardfork) do
-    chain = Chain.test_config(hardfork)
+    hardfork = test_suite_fork_name(hardfork)
+    human_readable_hardfork = human_readable_fork_name(hardfork)
+    chain = Chain.test_config(human_readable_hardfork)
 
     test["post"][hardfork]
     |> Enum.with_index()
@@ -85,7 +89,7 @@ defmodule EthCommonTest.StateTestRunner do
       logs_hash = logs_hash(receipt.logs)
 
       %{
-        hardfork: hardfork,
+        hardfork: human_readable_hardfork,
         test_name: test_name,
         test_source: test["_info"]["source"],
         state_root_mismatch: state.root_hash != expected_hash,

--- a/apps/blockchain/scripts/generate_state_tests.ex
+++ b/apps/blockchain/scripts/generate_state_tests.ex
@@ -4,6 +4,7 @@ defmodule GenerateStateTests do
   alias Blockchain.Interface.AccountInterface
   alias Blockchain.Account.Storage
   alias EthCommonTest.StateTestRunner
+  alias EthCommonTest.Helpers
 
   use EthCommonTest.Harness
 
@@ -105,7 +106,10 @@ defmodule GenerateStateTests do
     completed_tests =
       test["post"]
       |> Enum.reduce(completed_tests, fn {hardfork, _test_data}, completed_tests ->
-        hardfork_configuration = EVM.Configuration.hardfork_config(hardfork)
+        hardfork_configuration =
+          hardfork
+          |> Helpers.human_readable_fork_name()
+          |> EVM.Configuration.hardfork_config()
 
         if hardfork_configuration do
           run_transaction(
@@ -130,13 +134,23 @@ defmodule GenerateStateTests do
          test,
          hardfork
        ) do
+    human_readable = Helpers.human_readable_fork_name(hardfork)
+
     {test_name, test}
     |> StateTestRunner.run_test(hardfork)
     |> Enum.reduce(completed_tests, fn result, completed_tests ->
       if result.state_root_mismatch || result.logs_hash_mismatch do
-        update_in(completed_tests, [:failing, hardfork], &["#{test_group}/#{test_name}" | &1])
+        update_in(
+          completed_tests,
+          [:failing, human_readable],
+          &["#{test_group}/#{test_name}" | &1]
+        )
       else
-        update_in(completed_tests, [:passing, hardfork], &["#{test_group}/#{test_name}" | &1])
+        update_in(
+          completed_tests,
+          [:passing, human_readable],
+          &["#{test_group}/#{test_name}" | &1]
+        )
       end
     end)
   end

--- a/apps/blockchain/test/blockchain/state_test.exs
+++ b/apps/blockchain/test/blockchain/state_test.exs
@@ -2,6 +2,7 @@ defmodule Blockchain.StateTest do
   alias MerklePatriciaTree.Trie
   alias Blockchain.Account
   alias EthCommonTest.StateTestRunner
+  alias EthCommonTest.Helpers
 
   use EthCommonTest.Harness
   use ExUnit.Case, async: true
@@ -60,13 +61,13 @@ defmodule Blockchain.StateTest do
       "stCreate2/returndatasize_following_successful_create",
       "stRevertTest/RevertOpcodeMultipleSubCalls"
     ],
-    "TangerineWhistle" => ["stRevertTest/RevertOpcodeMultipleSubCalls"],
+    "Frontier" => [],
+    "Homestead" => ["stRevertTest/RevertOpcodeMultipleSubCalls"],
     "SpuriousDragon" => [
       "stRevertTest/RevertOpcodeMultipleSubCalls",
       "stSpecialTest/failed_tx_xcf416c53"
     ],
-    "Frontier" => [],
-    "Homestead" => ["stRevertTest/RevertOpcodeMultipleSubCalls"]
+    "TangerineWhistle" => ["stRevertTest/RevertOpcodeMultipleSubCalls"]
   }
 
   @fifteen_minutes 1000 * 60 * 15
@@ -110,6 +111,7 @@ defmodule Blockchain.StateTest do
 
   defp fork_without_implementation?(fork) do
     fork
+    |> Helpers.human_readable_fork_name()
     |> EVM.Configuration.hardfork_config()
     |> is_nil()
   end


### PR DESCRIPTION
In in the previous pull requests (https://github.com/poanetwork/mana/pull/462, https://github.com/poanetwork/mana/commit/bfe50d73432450da18a98de12c6bbcd8265cea85), `EIP158` was renamed to `SpuriousDragon` and `EIP150` was renamed to `TangerineWhistle`

- We didn't run `EIP158` and `EIP150` hard fork tests
- State tests generation script did not run `EIP158` and `EIP150` hard fork tests