### PR TITLE
Clarify Gas.cost/cost_with_status

### DIFF
--- a/.dialyzer.ignore-warnings
+++ b/.dialyzer.ignore-warnings
@@ -33,9 +33,6 @@ apps/evm/lib/evm/gas.ex:310: The call 'Elixir.EVM.Gas':operation_cost(__@1::any(
 apps/evm/lib/evm/gas.ex:310: Function operation_cost/3 has no local return
 apps/evm/lib/evm/gas.ex:310: The call 'Elixir.EVM.Gas':operation_cost(__@1::any(),__@2::any(),__@3::any(),'nil') breaks the contract (atom(),['Elixir.EVM':val()],['Elixir.EVM':val()],'Elixir.EVM.MachineState':t()) -> t() | 'nil'
 apps/evm/lib/evm/gas.ex:577: Function gas_cost_for_nested_operation/2 will never be called
-apps/evm/lib/evm/machine_state.ex:53: Function subtract_gas/2 has no local return
-apps/evm/lib/evm/machine_state.ex:55: The pattern {'changed', _cost@1, _new_call_gas@1} can never match the type number() | {'original',number()}
-apps/evm/lib/evm/machine_state.ex:55: The pattern {'changed', _cost@1, _new_call_gas@1} can never match the type integer() | {'original',integer()}
 apps/evm/lib/evm/operation/environmental_information.ex:114: Function calldataload/2 has no local return
 apps/evm/lib/evm/operation/environmental_information.ex:117: The call 'Elixir.EVM.Helpers':decode_signed(binary()) breaks the contract (integer() | 'nil') -> 'Elixir.EVM':val() | 'nil'
 apps/evm/lib/evm/vm.ex:98: The pattern 'continue' can never match the type {'halt','invalid_instruction' | 'stack_underflow' | 'undefined_instruction'}

--- a/.dialyzer.ignore-warnings
+++ b/.dialyzer.ignore-warnings
@@ -21,18 +21,6 @@ apps/evm/lib/evm/functions.ex:190: Function 'not_enough_gas?'/2 has no local ret
 apps/evm/lib/evm/functions.ex:197: Function 'out_of_memory_bounds?'/3 will never be called
 apps/evm/lib/evm/functions.ex:213: Function 'is_invalid_jump_destination?'/3 will never be called
 apps/evm/lib/evm/functions.ex:223: Function 'static_state_modification?'/2 will never be called
-apps/evm/lib/evm/gas.ex:139: Function cost/2 has no local return
-apps/evm/lib/evm/gas.ex:139: Function cost/3 has no local return
-apps/evm/lib/evm/gas.ex:162: The pattern {_status@2, _value@2, _call_gass@1} can never match the type {'original',integer()}
-apps/evm/lib/evm/gas.ex:310: Function operation_cost/0 has no local return
-apps/evm/lib/evm/gas.ex:310: The call 'Elixir.EVM.Gas':operation_cost('nil','nil','nil','nil') breaks the contract (atom(),['Elixir.EVM':val()],['Elixir.EVM':val()],'Elixir.EVM.MachineState':t()) -> t() | 'nil'
-apps/evm/lib/evm/gas.ex:310: Function operation_cost/1 has no local return
-apps/evm/lib/evm/gas.ex:310: The call 'Elixir.EVM.Gas':operation_cost(__@1::any(),'nil','nil','nil') breaks the contract (atom(),['Elixir.EVM':val()],['Elixir.EVM':val()],'Elixir.EVM.MachineState':t()) -> t() | 'nil'
-apps/evm/lib/evm/gas.ex:310: Function operation_cost/2 has no local return
-apps/evm/lib/evm/gas.ex:310: The call 'Elixir.EVM.Gas':operation_cost(__@1::any(),__@2::any(),'nil','nil') breaks the contract (atom(),['Elixir.EVM':val()],['Elixir.EVM':val()],'Elixir.EVM.MachineState':t()) -> t() | 'nil'
-apps/evm/lib/evm/gas.ex:310: Function operation_cost/3 has no local return
-apps/evm/lib/evm/gas.ex:310: The call 'Elixir.EVM.Gas':operation_cost(__@1::any(),__@2::any(),__@3::any(),'nil') breaks the contract (atom(),['Elixir.EVM':val()],['Elixir.EVM':val()],'Elixir.EVM.MachineState':t()) -> t() | 'nil'
-apps/evm/lib/evm/gas.ex:577: Function gas_cost_for_nested_operation/2 will never be called
 apps/evm/lib/evm/operation/environmental_information.ex:114: Function calldataload/2 has no local return
 apps/evm/lib/evm/operation/environmental_information.ex:117: The call 'Elixir.EVM.Helpers':decode_signed(binary()) breaks the contract (integer() | 'nil') -> 'Elixir.EVM':val() | 'nil'
 apps/evm/lib/evm/vm.ex:98: The pattern 'continue' can never match the type {'halt','invalid_instruction' | 'stack_underflow' | 'undefined_instruction'}

--- a/apps/evm/lib/evm/machine_state.ex
+++ b/apps/evm/lib/evm/machine_state.ex
@@ -51,7 +51,7 @@ defmodule EVM.MachineState do
   """
   @spec subtract_gas(MachineState.t(), ExecEnv.t()) :: MachineState.t()
   def subtract_gas(machine_state, exec_env) do
-    case Gas.cost(machine_state, exec_env, with_status: true) do
+    case Gas.cost_with_status(machine_state, exec_env) do
       {:changed, cost, new_call_gas} ->
         new_stack = Stack.replace(machine_state.stack, 0, new_call_gas)
 

--- a/apps/evm/test/evm/gas_test.exs
+++ b/apps/evm/test/evm/gas_test.exs
@@ -22,8 +22,7 @@ defmodule EVM.GasTest do
         config: config
       }
 
-      assert {:changed, 39_777, 14_071} ==
-               EVM.Gas.cost(machine_state, exec_env, with_status: true)
+      assert {:changed, 39_777, 14_071} == EVM.Gas.cost_with_status(machine_state, exec_env)
     end
   end
 


### PR DESCRIPTION
Description
===========

The function `Gas.cost` was a bit confusing, especially since we had to constantly check whether or not the `with_status` flag had been passed in order to know what values to return. This also tripped up Dialyzer in https://github.com/poanetwork/mana/pull/473#discussion_r222670772, and I wanted to make sure this wasn't a real bug Dialyzer had discovered.

Here we separate `cost` and `cost_with_status` into two functions and clarify the typespecs to more clearly document what the functions return (e.g. :original | :changed instead of atom(), Gas.t instead of number()).