### PR TITLE
Fix memory error at 1417555

### DIFF
--- a/apps/evm/lib/evm/memory.ex
+++ b/apps/evm/lib/evm/memory.ex
@@ -71,6 +71,9 @@ defmodule EVM.Memory do
           MachineState.t()
   def write(machine_state, offset_bytes, original_data, size \\ nil)
 
+  def write(machine_state, offset_bytes, data, size) when size == 0,
+    do: machine_state
+
   def write(machine_state, offset_bytes, data, size) when is_integer(data),
     do: write(machine_state, offset_bytes, :binary.encode_unsigned(data), size)
 

--- a/apps/evm/test/evm/memory_test.exs
+++ b/apps/evm/test/evm/memory_test.exs
@@ -1,4 +1,11 @@
 defmodule EVM.MemoryTest do
+  alias EVM.{MachineState, Memory}
   use ExUnit.Case, async: true
   doctest EVM.Memory
+
+  test "returns the machine_state unchanged if data size is zero" do
+    machine_state = %MachineState{}
+    updated_machine_state = Memory.write(machine_state, 256, <<>>, 0)
+    assert machine_state == updated_machine_state
+  end
 end


### PR DESCRIPTION
[Transaction 0x9d1b51c65d0624985e41447a7966bf7287a08dc9334b85dac9e0a1ab5dd7a9c1](https://etherscan.io/tx/0x9d1b51c65d0624985e41447a7966bf7287a08dc9334b85dac9e0a1ab5dd7a9c1) calls a `CODECOPY` with offset > 0xffffffffe0
causing the memory to overflow. Since the data size zero the write can
be skipped all together.