### PR TITLE
Fix dialyzer warnings for AccountRepo implementations

### DIFF
--- a/.dialyzer.ignore-warnings
+++ b/.dialyzer.ignore-warnings
@@ -16,7 +16,7 @@ apps/evm/lib/evm/builtin.ex:255: Guard test __@3::'true' =:= 'false' can never s
 apps/evm/lib/evm/builtin.ex:255: Guard test __@1::'true' =:= 'false' can never succeed
 
 -------------------------------
-# TODO: rewrite mocked protocol typespecs
+# Machine code
 -------------------------------
 lib/evm/machine_code
 
@@ -86,6 +86,8 @@ tate_root':=_, _=>_}, _=>_}
 # using erlang 21 while we are using erlang 20. But we cannot yet update to
 # erlang 21 because we need rox to update
 apps/blockchain/lib/blockchain/block.ex:739: Function create_receipt/6 will never be called
+apps/blockchain/lib/blockchain/account/repo.ex:47: Function commit/1 has no local return
+apps/blockchain/lib/blockchain/account/repo.ex:50: The call 'Elixir.Blockchain.Account.Repo':new(#{<<_:160>>=>#{'balance':=integer(), 'code':=binary(), 'nonce':=integer(), 'storage':=#{'__struct__':='Elixir.MerklePatriciaTree.Trie', 'db':={atom(),_}, 'root_hash':=binary()}}}) will never return since it differs in the 1st argument from the success typing arguments: (#{'__struct__':='Elixir.MerklePatriciaTree.Trie', 'db':={atom(),_}, 'root_hash':=binary()})
 
 -------------------------------
 # blockchain/genesis.ex
@@ -117,17 +119,11 @@ apps/blockchain/lib/blockchain/application.ex:14: The call 'Elixir.EVM.Debugger'
 -------------------------------
 apps/blockchain/lib/mix/tasks/sync/from_file.ex
 -------------------------------
-# Ignores the whole contract and account_interface file
+# Ignores the whole contract
 -------------------------------
 apps/blockchain/lib/blockchain/contract.ex
 apps/blockchain/lib/blockchain/contract/create_contract.ex
 apps/blockchain/lib/blockchain/contract/message_call.ex
-
--------------------------------
-# Ignores AccountRepo implementations because we were ignoring the account interface
--------------------------------
-apps/blockchain/lib/blockchain/account/repo.ex
-apps/evm/lib/evm/mock/mock_account_repo
 
 -------------------------------
 # Ignores state test generation script

--- a/apps/blockchain/lib/blockchain/account/repo/cache.ex
+++ b/apps/blockchain/lib/blockchain/account/repo/cache.ex
@@ -67,11 +67,7 @@ defmodule Blockchain.Account.Repo.Cache do
     Map.get(cache_struct.accounts_cache, address)
   end
 
-  @spec update_account(
-          t(),
-          Address.t(),
-          cached_account_info()
-        ) :: t()
+  @spec update_account(t(), Address.t(), cached_account_info()) :: t()
   def update_account(cache_struct, address, account) do
     updated_accounts_cache = Map.put(cache_struct.accounts_cache, address, account)
 

--- a/apps/evm/lib/evm/account_repo.ex
+++ b/apps/evm/lib/evm/account_repo.ex
@@ -13,9 +13,7 @@ defmodule EVM.AccountRepo do
 
   @callback get_account_balance(t, EVM.address()) :: nil | EVM.Wei.t()
 
-  @callback add_wei(t, EVM.address(), integer()) :: nil | EVM.Wei.t()
-
-  @callback transfer(t, EVM.address(), EVM.address(), integer()) :: nil | EVM.Wei.t()
+  @callback transfer(t, EVM.address(), EVM.address(), integer()) :: t
 
   @callback get_account_code(t, EVM.address()) :: nil | binary()
 
@@ -37,21 +35,6 @@ defmodule EVM.AccountRepo do
 
   @callback dump_storage(t) :: %{EVM.address() => EVM.val()}
 
-  @callback message_call(
-              t,
-              EVM.address(),
-              EVM.address(),
-              EVM.address(),
-              EVM.address(),
-              EVM.Gas.t(),
-              EVM.Gas.gas_price(),
-              EVM.Wei.t(),
-              EVM.Wei.t(),
-              binary(),
-              integer(),
-              Header.t()
-            ) :: {t, EVM.Gas.t(), EVM.SubState.t(), EVM.VM.output()}
-
   @callback create_contract(
               t,
               EVM.address(),
@@ -65,8 +48,6 @@ defmodule EVM.AccountRepo do
               EVM.address() | nil,
               EVM.Configuration.t()
             ) :: {:ok | :error, {t, EVM.Gas.t(), EVM.SubState.t()}}
-
-  @callback new_contract_address(t, EVM.address(), integer()) :: EVM.address()
 
   @doc "Sets the balance of the account at the given address to zero"
   @callback clear_balance(t, EVM.address()) :: t

--- a/apps/evm/lib/evm/mock/mock_account_repo.ex
+++ b/apps/evm/lib/evm/mock/mock_account_repo.ex
@@ -49,17 +49,16 @@ defmodule EVM.Mock.MockAccountRepo do
   end
 
   @impl true
-  def add_wei(mock_account_repo, address, value) do
-    account = get_account(mock_account_repo, address) || new_account()
-
-    put_account(mock_account_repo, address, %{account | balance: account.balance + value})
-  end
-
-  @impl true
   def transfer(mock_account_repo, from, to, value) do
     mock_account_repo
     |> add_wei(from, -value)
     |> add_wei(to, value)
+  end
+
+  defp add_wei(mock_account_repo, address, value) do
+    account = get_account(mock_account_repo, address) || new_account()
+
+    put_account(mock_account_repo, address, %{account | balance: account.balance + value})
   end
 
   @impl true
@@ -182,29 +181,6 @@ defmodule EVM.Mock.MockAccountRepo do
   end
 
   @impl true
-  def message_call(
-        mock_account_repo,
-        _sender,
-        _originator,
-        _recipient,
-        _contract,
-        _available_gas,
-        _gas_price,
-        _value,
-        _apparent_value,
-        _data,
-        _stack_depth,
-        _block_header
-      ) do
-    {
-      mock_account_repo,
-      mock_account_repo.contract_result[:gas],
-      mock_account_repo.contract_result[:sub_state],
-      mock_account_repo.contract_result[:output]
-    }
-  end
-
-  @impl true
   def create_contract(
         mock_account_repo,
         _sender,
@@ -224,11 +200,6 @@ defmodule EVM.Mock.MockAccountRepo do
        mock_account_repo.contract_result[:gas],
        mock_account_repo.contract_result[:sub_state] || EVM.SubState.empty()
      }}
-  end
-
-  @impl true
-  def new_contract_address(_mock_account_repo, address, _nonce) do
-    address
   end
 
   @impl true


### PR DESCRIPTION
This fixes the majority of the ignored dialyzer warnings for `blockchain/account/repo.ex`, `blockchain/account/repo/cache.ex`, `evm/mock/mock_account_repo.ex`, `evm/account_repo.ex`. They were ignored as part of https://github.com/poanetwork/mana/pull/494. 

Description
===========

We start by removing the ignored warnings for `blockchain/account/repo` and `evm/mock/mock_account_repo`. This triggered a cascade of fixes that spanned more modules that just those two. In fact, some warnings led us to understand that some of the functions were not used at all:

Removals
--------

- Remove add_wei from EVM.AccountRepo. It is not called from the evm app and thus does not need to be part of the behaviour. It remains as part of the `Blockchain.Account.Repo`.

- Remove AccountRepo.new_contract_address callback. It is not used.

- Remove unused AccountRepo.message_call callback. It is not used.

Other changes
-------------

- Update correct typespec from EVM.state() to Trie.t() in several places in `Account.Repo`.

- Correct the return type of EVM.AccountRepo.transfer

- We expose better types from `Account.Repo.Cache` to be used by `Account.Repo`.

- We address several incorrect types in `Account.Repo.Cache` that triggered several dialyzer warnings in `Account.Repo`. the Cache's types are fairly inaccurate in their representation of all the `nil` possibilities. Based on how the cache is used from the `Account.Repo` module, we make some updates that more accurately represent reality. For example, a function in `Account.Repo` calls the caching to update updating an account with `{nil, nil}` in order to "delete" the account from cache.

This behavior seems oddly intentional based on a failing test suggesting that we should not retrieve the account which has been deleted from storage since that would ignore the fact that it was deleted (but not yet persisted).

We should find a better way to handle that rather than having to do a manual insert of `{nil, nil}` to signify "this account has been deleted in cache, so do not look for it in storage".