### PR TITLE
Correct EVM.state() to Trie.t()

### DIFF
--- a/.dialyzer.ignore-warnings
+++ b/.dialyzer.ignore-warnings
@@ -86,8 +86,6 @@ tate_root':=_, _=>_}, _=>_}
 # using erlang 21 while we are using erlang 20. But we cannot yet update to
 # erlang 21 because we need rox to update
 apps/blockchain/lib/blockchain/block.ex:739: Function create_receipt/6 will never be called
-apps/blockchain/lib/blockchain/account/repo.ex:47: Function commit/1 has no local return
-apps/blockchain/lib/blockchain/account/repo.ex:50: The call 'Elixir.Blockchain.Account.Repo':new(#{<<_:160>>=>#{'balance':=integer(), 'code':=binary(), 'nonce':=integer(), 'storage':=#{'__struct__':='Elixir.MerklePatriciaTree.Trie', 'db':={atom(),_}, 'root_hash':=binary()}}}) will never return since it differs in the 1st argument from the success typing arguments: (#{'__struct__':='Elixir.MerklePatriciaTree.Trie', 'db':={atom(),_}, 'root_hash':=binary()})
 
 -------------------------------
 # blockchain/genesis.ex

--- a/apps/blockchain/lib/blockchain/account/repo/cache.ex
+++ b/apps/blockchain/lib/blockchain/account/repo/cache.ex
@@ -1,6 +1,7 @@
 defmodule Blockchain.Account.Repo.Cache do
   alias Blockchain.Account
   alias Blockchain.Account.Address
+  alias MerklePatriciaTree.Trie
 
   defstruct storage_cache: %{}, accounts_cache: %{}
 
@@ -74,21 +75,21 @@ defmodule Blockchain.Account.Repo.Cache do
     %{cache_struct | accounts_cache: updated_accounts_cache}
   end
 
-  @spec commit(t(), EVM.state()) :: EVM.state()
+  @spec commit(t(), Trie.t()) :: Trie.t()
   def commit(cache_struct, state) do
     committed_accounts = commit_accounts(cache_struct, state)
 
     commit_storage(cache_struct, committed_accounts)
   end
 
-  @spec commit_storage(t(), EVM.state()) :: EVM.state()
+  @spec commit_storage(t(), Trie.t()) :: Trie.t()
   def commit_storage(cache_struct, state) do
     cache_struct
     |> storage_to_list()
     |> Enum.reduce(state, &commit_account_storage_cache/2)
   end
 
-  @spec commit_accounts(t(), EVM.state()) :: EVM.state()
+  @spec commit_accounts(t(), Trie.t()) :: Trie.t()
   def commit_accounts(cache_struct, state) do
     cache_struct
     |> accounts_to_list()

--- a/apps/blockchain/lib/blockchain/block.ex
+++ b/apps/blockchain/lib/blockchain/block.ex
@@ -755,7 +755,7 @@ defmodule Blockchain.Block do
   end
 
   # Updates a block to have a new state root given a state object
-  @spec put_state(t, EVM.state() | EVM.trie_root()) :: t
+  @spec put_state(t, Trie.t()) :: t
   def put_state(block = %__MODULE__{header: header = %Header{}}, new_state) do
     %{block | header: %{header | state_root: new_state.root_hash}}
   end

--- a/apps/blockchain/lib/blockchain/transaction.ex
+++ b/apps/blockchain/lib/blockchain/transaction.ex
@@ -10,6 +10,7 @@ defmodule Blockchain.Transaction do
   alias Block.Header
   alias EVM.{Gas, Configuration, SubState}
   alias Blockchain.Account.Repo
+  alias MerklePatriciaTree.Trie
 
   # nonce: T_n
   # gas_price: T_p
@@ -166,7 +167,7 @@ defmodule Blockchain.Transaction do
   @doc """
   Validates the validity of a transaction and then executes it if transaction is valid.
   """
-  @spec execute_with_validation(EVM.state(), t, Header.t(), Chain.t()) ::
+  @spec execute_with_validation(Trie.t(), t, Header.t(), Chain.t()) ::
           {Repo.t(), Gas.t(), Receipt.t()}
   def execute_with_validation(
         state,
@@ -196,7 +197,7 @@ defmodule Blockchain.Transaction do
   and the status code of this transaction. These are referred to as {σ', Υ^g,
   Υ^l, Y^z} in the Transaction Execution section of the Yellow Paper.
   """
-  @spec execute(EVM.state(), t, Header.t(), Chain.t()) :: {Repo.t(), Gas.t(), Receipt.t()}
+  @spec execute(Trie.t(), t, Header.t(), Chain.t()) :: {Repo.t(), Gas.t(), Receipt.t()}
   def execute(state, tx, block_header, chain) do
     {:ok, sender} = Transaction.Signature.sender(tx, chain.params.network_id)
 

--- a/apps/blockchain/test/blockchain/account/repo_test.exs
+++ b/apps/blockchain/test/blockchain/account/repo_test.exs
@@ -15,6 +15,30 @@ defmodule Blockchain.Account.RepoTest do
     {:ok, %{state: state}}
   end
 
+  describe "commit/1" do
+    test "persists cached state into storage", %{state: state} do
+      account = %Account{
+        nonce: 5,
+        balance: 10,
+        storage_root: <<0x00, 0x01>>,
+        code_hash: <<0x01, 0x02>>
+      }
+
+      address = <<1::160>>
+      code = <<5>>
+
+      cache = %Cache{accounts_cache: %{address => {account, code}}}
+
+      account_repo =
+        state
+        |> Repo.new(cache)
+        |> Repo.commit()
+
+      assert account_repo.cache == %Cache{}
+      assert account_repo.state.root_hash != state.root_hash
+    end
+  end
+
   describe "reset_cache/1" do
     test "resets cache", %{state: state} do
       account = %Account{


### PR DESCRIPTION
This fixes the last dialyzer warnings introduced in https://github.com/poanetwork/mana/pull/494

Description
===========

Several typespec definitions claimed they accepted or returned a `EVM.state()` type. But that is not accurate. The all take a `MerklePatriciaTree.Trie.t()`.

Dialyzer was throwing warnings in `blockchain/account/repo.ex` because it thought the `commit` function was passing `EVM.state()` into the `new` function, and that it would fail in that function call.

Here is the full error. Note that `EVM.state()` is defined as a `%{account_address => account}` mapping, which is why we see that being passed as the first argument into `Account.Repo.new`

```elixir
apps/blockchain/lib/blockchain/account/repo.ex:50: The call
'Elixir.Blockchain.Account.Repo':new(#{<<_:160>> => #{
  'balance':=integer(),
  'code':=binary(),
  'nonce':=integer(),
  'storage':=#{
    '__struct__':='Elixir.MerklePatriciaTree.Trie',
    'db':={atom(), _ },
    'root_hash':=binary()
  }
}})

will never return since it differs in the 1st argument from the success
typing arguments:

(#{'__struct__':='Elixir.MerklePatriciaTree.Trie', 'db':={atom(),_}, 'root_hash':=binary()})
```