### PR TITLE
fix writing to memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,13 +129,13 @@ Ethereum common tests are created for all clients to test against. We plan to pr
   - [GeneralStateTests](https://github.com/ethereum/tests/tree/develop/GeneralStateTests) 1026/1026 = 100% passing
 - [x] Homestead
   - [BlockchainTests](https://github.com/ethereum/tests/tree/develop/BlockchainTests) (Includes GeneralStateTests) 2231/2231 = 100% passing
-  - [GeneralStateTests](https://github.com/ethereum/tests/tree/develop/GeneralStateTests) 2059/2061 = 99.9% passing
+  - [GeneralStateTests](https://github.com/ethereum/tests/tree/develop/GeneralStateTests) 2061/2061 = 100.0% passing
 - [x] EIP150
   - [BlockchainTests](https://github.com/ethereum/tests/tree/develop/BlockchainTests) (Includes GeneralStateTests) 1275/1275 = 100% passing
-  - [GeneralStateTests](https://github.com/ethereum/tests/tree/develop/GeneralStateTests) 1109/1113 = 99.6% passing
+  - [GeneralStateTests](https://github.com/ethereum/tests/tree/develop/GeneralStateTests) 1113/1113 = 100.0% passing
 - [x] EIP158
   - [BlockchainTests](https://github.com/ethereum/tests/tree/develop/BlockchainTests) (Includes GeneralStateTests) 1232/1233 = 99.9% passing
-  - [GeneralStateTests](https://github.com/ethereum/tests/tree/develop/GeneralStateTests) 1176/1181 = 99.6% passing
+  - [GeneralStateTests](https://github.com/ethereum/tests/tree/develop/GeneralStateTests) 1180/1181 = 99.9% passing
 - [x] Byzantium
   - [BlockchainTests](https://github.com/ethereum/tests/tree/develop/BlockchainTests) (Includes GeneralStateTests) 4915/4959 = 99.1% passing
   - [GeneralStateTests](https://github.com/ethereum/tests/tree/develop/GeneralStateTests) 4758/4784 = 99.5% passing

--- a/apps/blockchain/test/blockchain/state_test.exs
+++ b/apps/blockchain/test/blockchain/state_test.exs
@@ -21,14 +21,11 @@ defmodule Blockchain.StateTest do
       "stReturnDataTest/returndatacopy_following_call",
       "stReturnDataTest/returndatacopy_following_revert",
       "stReturnDataTest/returndatacopy_following_revert_in_create",
-      "stRevertTest/PythonRevertTestTue201814-1430",
       "stRevertTest/RevertInCallCode",
       "stRevertTest/RevertInCreateInInit",
       "stRevertTest/RevertInDelegateCall",
       "stRevertTest/RevertOpcodeInCreateReturns",
-      "stRevertTest/RevertOpcodeMultipleSubCalls",
-      "stSpecialTest/failed_tx_xcf416c53",
-      "stStaticCall/static_Call1024PreCalls2"
+      "stSpecialTest/failed_tx_xcf416c53"
     ],
     "Constantinople" => [
       "stCreate2/CREATE2_ContractSuicideDuringInit_ThenStoreThenReturn",
@@ -58,16 +55,12 @@ defmodule Blockchain.StateTest do
       "stCreate2/returndatacopy_0_0_following_successful_create",
       "stCreate2/returndatacopy_afterFailing_create",
       "stCreate2/returndatacopy_following_revert_in_create",
-      "stCreate2/returndatasize_following_successful_create",
-      "stRevertTest/RevertOpcodeMultipleSubCalls"
+      "stCreate2/returndatasize_following_successful_create"
     ],
     "Frontier" => [],
-    "Homestead" => ["stRevertTest/RevertOpcodeMultipleSubCalls"],
-    "SpuriousDragon" => [
-      "stRevertTest/RevertOpcodeMultipleSubCalls",
-      "stSpecialTest/failed_tx_xcf416c53"
-    ],
-    "TangerineWhistle" => ["stRevertTest/RevertOpcodeMultipleSubCalls"]
+    "Homestead" => [],
+    "SpuriousDragon" => ["stSpecialTest/failed_tx_xcf416c53"],
+    "TangerineWhistle" => []
   }
 
   @fifteen_minutes 1000 * 60 * 15

--- a/apps/evm/lib/evm/memory.ex
+++ b/apps/evm/lib/evm/memory.ex
@@ -79,13 +79,17 @@ defmodule EVM.Memory do
 
   def write(machine_state = %MachineState{}, offset_bytes, original_data, size) do
     data =
-      if size do
-        original_data
-        |> :binary.decode_unsigned()
-        |> rem(size * EVM.word_size())
-        |> :binary.encode_unsigned()
-      else
-        original_data
+      cond do
+        is_nil(size) ->
+          original_data
+
+        size > byte_size(original_data) ->
+          original_data
+
+        true ->
+          <<data::binary-size(size), _tail::bitstring>> = original_data
+
+          data
       end
 
     memory_size = byte_size(machine_state.memory)

--- a/apps/evm/lib/evm/message_call.ex
+++ b/apps/evm/lib/evm/message_call.ex
@@ -200,7 +200,7 @@ defmodule EVM.MessageCall do
           %{machine_state | last_return_data: output}
 
         true ->
-          machine_state = Memory.write(machine_state, out_offset, output)
+          machine_state = Memory.write(machine_state, out_offset, output, out_size)
 
           %{machine_state | last_return_data: output}
       end

--- a/apps/evm/lib/evm/operation/stack_memory_storage_and_flow.ex
+++ b/apps/evm/lib/evm/operation/stack_memory_storage_and_flow.ex
@@ -65,7 +65,12 @@ defmodule EVM.Operation.StackMemoryStorageAndFlow do
   """
   @spec mstore8(Operation.stack_args(), Operation.vm_map()) :: Operation.op_result()
   def mstore8([offset, value], %{machine_state: machine_state}) do
-    machine_state = Memory.write(machine_state, offset, value, EVM.byte_size())
+    byte_value =
+      value
+      |> rem(8 * EVM.word_size())
+      |> :binary.encode_unsigned()
+
+    machine_state = Memory.write(machine_state, offset, byte_value)
 
     %{machine_state: machine_state}
   end

--- a/apps/evm/test/evm/memory_test.exs
+++ b/apps/evm/test/evm/memory_test.exs
@@ -3,9 +3,31 @@ defmodule EVM.MemoryTest do
   use ExUnit.Case, async: true
   doctest EVM.Memory
 
-  test "returns the machine_state unchanged if data size is zero" do
-    machine_state = %MachineState{}
-    updated_machine_state = Memory.write(machine_state, 256, <<>>, 0)
-    assert machine_state == updated_machine_state
+  describe "write/4" do
+    test "returns the machine_state unchanged if data size is zero" do
+      machine_state = %MachineState{}
+      updated_machine_state = Memory.write(machine_state, 256, <<>>, 0)
+      assert machine_state == updated_machine_state
+    end
+
+    test "truncates input if the size parameter is smaller than input's size" do
+      machine_state = %MachineState{}
+      input = Enum.reduce(1..60, <<>>, fn i, acc -> <<i>> <> acc end)
+
+      updated_machine_state = Memory.write(machine_state, 0, input, 2)
+
+      assert updated_machine_state.memory == <<60, 59>>
+      assert updated_machine_state.active_words == 1
+    end
+
+    test "does not truncate input if the size parameter is bigger than input's size" do
+      machine_state = %MachineState{}
+      input = Enum.reduce(1..60, <<>>, fn i, acc -> <<i>> <> acc end)
+
+      updated_machine_state = Memory.write(machine_state, 0, input, 61)
+
+      assert updated_machine_state.memory == input
+      assert updated_machine_state.active_words == 2
+    end
   end
 end

--- a/apps/evm/test/evm/message_call_test.exs
+++ b/apps/evm/test/evm/message_call_test.exs
@@ -153,13 +153,13 @@ defmodule EVM.MessageCallTest do
 
     recipient = %{address: <<0x9::160>>, code: code}
 
-    account_interface =
-      build(:mock_account_interface)
-      |> MockAccountInterface.add_account(recipient.address, %{balance: 10, code: recipient.code})
+    account_repo =
+      build(:mock_account_repo)
+      |> MockAccountRepo.add_account(recipient.address, %{balance: 10, code: recipient.code})
 
     pre_exec_env =
       build(:exec_env,
-        account_interface: account_interface
+        account_repo: account_repo
       )
 
     pre_machine_state = build(:machine_state)

--- a/apps/evm/test/evm/message_call_test.exs
+++ b/apps/evm/test/evm/message_call_test.exs
@@ -38,7 +38,8 @@ defmodule EVM.MessageCallTest do
         current_machine_state: pre_machine_state,
         recipient: recipient.address,
         code_owner: recipient.address,
-        execution_value: 100
+        execution_value: 100,
+        output_params: {0, 256}
       )
 
     %{machine_state: machine_state, exec_env: _exec_env, sub_state: _sub_state} =
@@ -47,7 +48,7 @@ defmodule EVM.MessageCallTest do
     # Code was to add 1 + 3 = 4 and store in memory.
     assert machine_state.memory == <<0x4::256>>
     assert machine_state.gas == message_call.execution_value - 24
-    assert machine_state.active_words == pre_machine_state.active_words + 1
+    assert machine_state.active_words == 8
     assert machine_state.stack == pre_machine_state.stack ++ [1]
   end
 
@@ -145,5 +146,38 @@ defmodule EVM.MessageCallTest do
     %{machine_state: %{active_words: active_words}} = MessageCall.call(message_call)
 
     assert active_words == 0
+  end
+
+  test "truncates message call's output if output's byte size is bigger than output_params" do
+    code = build(:machine_code, operations: [:push1, 1, :push1, 3, :add, :push1, 0x00, :mstore])
+
+    recipient = %{address: <<0x9::160>>, code: code}
+
+    account_interface =
+      build(:mock_account_interface)
+      |> MockAccountInterface.add_account(recipient.address, %{balance: 10, code: recipient.code})
+
+    pre_exec_env =
+      build(:exec_env,
+        account_interface: account_interface
+      )
+
+    pre_machine_state = build(:machine_state)
+
+    message_call =
+      build(:message_call,
+        current_exec_env: pre_exec_env,
+        current_machine_state: pre_machine_state,
+        recipient: recipient.address,
+        code_owner: recipient.address,
+        execution_value: 100,
+        output_params: {0, 2}
+      )
+
+    %{machine_state: machine_state, exec_env: _exec_env, sub_state: _sub_state} =
+      MessageCall.call(message_call)
+
+    assert machine_state.memory == <<0, 0>>
+    assert machine_state.active_words == 1
   end
 end


### PR DESCRIPTION
fixes https://github.com/poanetwork/mana/issues/491

Changes:
- We weren't considering `out_size` parameter when we were writing to the memory after message call. If it is smaller than output's size than we should truncate output
- Truncating logic in `Memory` module was wrong