### PR TITLE
fix extcodecopy

### DIFF
--- a/apps/evm/lib/evm/mock/mock_account_repo.ex
+++ b/apps/evm/lib/evm/mock/mock_account_repo.ex
@@ -43,8 +43,6 @@ defmodule EVM.Mock.MockAccountRepo do
 
     if account do
       account.balance
-    else
-      nil
     end
   end
 

--- a/apps/evm/lib/evm/operation/environmental_information.ex
+++ b/apps/evm/lib/evm/operation/environmental_information.ex
@@ -298,7 +298,7 @@ defmodule EVM.Operation.EnvironmentalInformation do
       )
 
     if size == 0 || size + mem_offset > EVM.max_int() || (code_offset == 0 && account_code == "") do
-      0
+      %{machine_state: machine_state}
     else
       data = Memory.read_zeroed_memory(account_code, code_offset, size)
       machine_state = Memory.write(machine_state, mem_offset, data)

--- a/apps/evm/test/evm/operation/environmental_information_test.exs
+++ b/apps/evm/test/evm/operation/environmental_information_test.exs
@@ -35,4 +35,24 @@ defmodule EVM.Operation.EnvironmentalInformationTest do
       assert result == %{machine_state: machine_state}
     end
   end
+
+  describe "extcodecopy" do
+    test "returns unmodified machine state if size is zero" do
+      address = <<1>>
+      mem_offset = code_offset = size = 0
+
+      params = [address, mem_offset, code_offset, size]
+
+      exec_env = %EVM.ExecEnv{
+        account_repo: %EVM.Mock.MockAccountRepo{account_map: %{<<1>> => %{code: <<11>>}}}
+      }
+
+      machine_state = %EVM.MachineState{}
+      vm_map = %{exec_env: exec_env, machine_state: machine_state}
+
+      result = EVM.Operation.EnvironmentalInformation.extcodecopy(params, vm_map)
+
+      assert result == %{machine_state: machine_state}
+    end
+  end
 end


### PR DESCRIPTION
fixes https://github.com/poanetwork/mana/issues/500

We're pushing zero to stack if invalid params for `extcodecopy` are provided. We should return unmodified machine state