### PR TITLE
Fix state_tests.run --fork alias

### DIFF
--- a/apps/blockchain/lib/mix/tasks/state_tests.run.ex
+++ b/apps/blockchain/lib/mix/tasks/state_tests.run.ex
@@ -23,15 +23,16 @@ defmodule Mix.Tasks.StateTests.Run do
   ## Command line options
 
   * `--fork` - the name of the hardfork to run (optional)
-  * `--hardfork` - alias for `--fork`
+  * `-f` - alias for `--fork`
   """
 
   @preferred_cli_env :test
   @switches [test: :string, fork: :string]
-  @aliases [hardfork: :fork]
+  @aliases [f: :fork]
 
   def run(args) do
     {opts, [test_name | _]} = OptionParser.parse!(args, switches: @switches, aliases: @aliases)
+
     hardfork = Keyword.get(opts, :fork, :all)
 
     test_name


### PR DESCRIPTION
OptionParser aliases are not for aliasing two different `--options` but rather for creating a shorthand version of an existing alias.

So this _does not_ create a `hardfork` alias for `fork`:

```elixir
[hardfork: :fork]
```

But this creates an alias for `--fork` that can be used with `-f`

```elixir
[f: :fork]
```