### PR TITLE
fix substate deduplication

### DIFF
--- a/apps/evm/test/evm/refunds_test.exs
+++ b/apps/evm/test/evm/refunds_test.exs
@@ -38,7 +38,7 @@ defmodule EVM.RefundsTest do
     expected_exec_env = Map.put(exec_env, :account_repo, expected_account_repo)
 
     assert result ==
-             {0, %EVM.SubState{logs: [], refund: 15_000, selfdestruct_list: []},
+             {0, %EVM.SubState{logs: [], refund: 15_000, selfdestruct_list: MapSet.new()},
               expected_exec_env, ""}
   end
 end

--- a/apps/evm/test/evm/sub_state_test.exs
+++ b/apps/evm/test/evm/sub_state_test.exs
@@ -13,7 +13,7 @@ defmodule EVM.SubStateTest do
           }
         ],
         refund: 0,
-        selfdestruct_list: []
+        selfdestruct_list: MapSet.new()
       }
 
       new_substate = EVM.SubState.add_log(sub_state, 1, [5], "zxcz")

--- a/apps/evm/test/evm/vm_test.exs
+++ b/apps/evm/test/evm/vm_test.exs
@@ -30,7 +30,7 @@ defmodule EVM.VMTest do
     exec_env = %ExecEnv{machine_code: MachineCode.compile(instructions)}
     result = VM.run(24, exec_env)
 
-    expected_sub_state = %SubState{logs: [], refund: 0, selfdestruct_list: []}
+    expected_sub_state = %SubState{}
     expected = {0, expected_sub_state, exec_env, <<0x08::256>>}
 
     assert result == expected
@@ -67,7 +67,7 @@ defmodule EVM.VMTest do
 
     expected_account_repo = MockAccountRepo.new(expected_account_state)
     expected_exec_env = Map.put(exec_env, :account_repo, expected_account_repo)
-    expected_sub_state = %SubState{logs: [], refund: 0, selfdestruct_list: []}
+    expected_sub_state = %SubState{}
 
     expected = {0, expected_sub_state, expected_exec_env, ""}
     assert result == expected


### PR DESCRIPTION
While working on https://github.com/poanetwork/mana/issues/506 it was discovered that substate deduplication works wrong

We used `Enum.dedup` for `selfdestruct_list` and `touched_accounts`
deduplication. It's wrong because it deduplicates only consecutive
values. MapSet has required functionality for deduplication