### PR TITLE
Add Blockchain.Account.Inspector

### DIFF
--- a/apps/blockchain/lib/blockchain/account/inspector.ex
+++ b/apps/blockchain/lib/blockchain/account/inspector.ex
@@ -1,0 +1,41 @@
+defmodule Blockchain.Account.Inspector do
+  @moduledoc """
+  Module to inspect account information
+  """
+
+  alias Blockchain.Account
+
+  @doc """
+  Prints a visual representation of several accounts
+  """
+  def inspect_accounts(state, account_addresses) do
+    Enum.map(account_addresses, &inspect_account(state, &1))
+  end
+
+  @doc """
+  Prints a visual representation of an account
+  """
+  def inspect_account(state, account_address) do
+    address_key = Base.decode16!(account_address, case: :mixed)
+    account = Account.get_account(state, address_key)
+
+    if is_nil(account) do
+      IO.puts("#{account_address} does not exist")
+    else
+      """
+      #{account_address}
+        Balance: #{account.balance}
+        Nonce: #{account.nonce}
+        Storage Root:
+          #{encode(account.storage_root)}
+        Code Hash:
+          #{encode(account.code_hash)}
+      """
+      |> IO.puts()
+    end
+  end
+
+  defp encode(binary) do
+    Base.encode16(binary, case: :lower)
+  end
+end

--- a/apps/blockchain/test/blockchain/account/inspector_test.exs
+++ b/apps/blockchain/test/blockchain/account/inspector_test.exs
@@ -1,0 +1,35 @@
+defmodule Blockchain.Account.InspectorTest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureIO
+
+  alias Blockchain.Account.{Inspector, Repo}
+
+  describe "inspect_account/1" do
+    test "prints a visual representation of an account" do
+      account = %Blockchain.Account{balance: 10, nonce: 3}
+      account_address = <<1::160>>
+      hex_account_address = Base.encode16(account_address, case: :lower)
+
+      state =
+        :random_db
+        |> MerklePatriciaTree.Test.random_ets_db()
+        |> MerklePatriciaTree.Trie.new()
+
+      repo =
+        state
+        |> Repo.new()
+        |> Repo.put_account(account_address, account)
+        |> Repo.commit()
+
+      io_result =
+        capture_io(fn ->
+          Inspector.inspect_account(repo.state, hex_account_address)
+        end)
+
+      assert io_result =~ hex_account_address
+      assert io_result =~ "Balance: #{account.balance}"
+      assert io_result =~ "Nonce: #{account.nonce}"
+    end
+  end
+end


### PR DESCRIPTION
Description
===========

Adds a `Blockchain.Account.Inspector` module to more easily inspect the contents of an account. This is mostly for debugging purposes, and it is not expected that it would be used in production. It takes an account address (hex) and prints out the balance, nonce, storage root, and code hash.