### PR TITLE
Touch RIPEMD account on failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,8 @@ Ethereum common tests are created for all clients to test against. We plan to pr
   - [BlockchainTests](https://github.com/ethereum/tests/tree/develop/BlockchainTests) (Includes GeneralStateTests) 1275/1275 = 100% passing
   - [GeneralStateTests](https://github.com/ethereum/tests/tree/develop/GeneralStateTests) 1113/1113 = 100.0% passing
 - [x] EIP158
-  - [BlockchainTests](https://github.com/ethereum/tests/tree/develop/BlockchainTests) (Includes GeneralStateTests) 1232/1233 = 99.9% passing
-  - [GeneralStateTests](https://github.com/ethereum/tests/tree/develop/GeneralStateTests) 1180/1181 = 99.9% passing
+  - [BlockchainTests](https://github.com/ethereum/tests/tree/develop/BlockchainTests) (Includes GeneralStateTests) 1233/1233 = 100% passing
+  - [GeneralStateTests](https://github.com/ethereum/tests/tree/develop/GeneralStateTests) 1181/1181 = 100% passing
 - [x] Byzantium
   - [BlockchainTests](https://github.com/ethereum/tests/tree/develop/BlockchainTests) (Includes GeneralStateTests) 4915/4959 = 99.1% passing
   - [GeneralStateTests](https://github.com/ethereum/tests/tree/develop/GeneralStateTests) 4758/4784 = 99.5% passing

--- a/apps/blockchain/test/blockchain/state_test.exs
+++ b/apps/blockchain/test/blockchain/state_test.exs
@@ -24,8 +24,7 @@ defmodule Blockchain.StateTest do
       "stRevertTest/RevertInCallCode",
       "stRevertTest/RevertInCreateInInit",
       "stRevertTest/RevertInDelegateCall",
-      "stRevertTest/RevertOpcodeInCreateReturns",
-      "stSpecialTest/failed_tx_xcf416c53"
+      "stRevertTest/RevertOpcodeInCreateReturns"
     ],
     "Constantinople" => [
       "stCreate2/CREATE2_ContractSuicideDuringInit_ThenStoreThenReturn",
@@ -59,7 +58,7 @@ defmodule Blockchain.StateTest do
     ],
     "Frontier" => [],
     "Homestead" => [],
-    "SpuriousDragon" => ["stSpecialTest/failed_tx_xcf416c53"],
+    "SpuriousDragon" => [],
     "TangerineWhistle" => []
   }
 

--- a/apps/blockchain/test/blockchain_test.exs
+++ b/apps/blockchain/test/blockchain_test.exs
@@ -17,9 +17,7 @@ defmodule BlockchainTest do
     "Frontier" => [],
     "Homestead" => [],
     "TangerineWhistle" => [],
-    "SpuriousDragon" => [
-      "GeneralStateTests/stSpecialTest/failed_tx_xcf416c53_d0g0v0.json"
-    ],
+    "SpuriousDragon" => [],
     "Byzantium" => String.split(@failing_byzantium_tests, "\n"),
     "Constantinople" => String.split(@failing_constantinople_tests, "\n"),
     # the rest are not implemented yet

--- a/apps/evm/lib/evm/builtin/rip160.ex
+++ b/apps/evm/lib/evm/builtin/rip160.ex
@@ -1,6 +1,7 @@
 defmodule EVM.Builtin.Rip160 do
   @g_rip160_base 600
   @g_rip160_byte 120
+  @contract_address <<3::160>>
 
   @doc """
   Runs RIPEMD160 hashing
@@ -24,5 +25,9 @@ defmodule EVM.Builtin.Rip160 do
     else
       {0, %EVM.SubState{}, exec_env, :failed}
     end
+  end
+
+  def contract_address do
+    @contract_address
   end
 end

--- a/apps/evm/lib/evm/message_call.ex
+++ b/apps/evm/lib/evm/message_call.ex
@@ -161,7 +161,7 @@ defmodule EVM.MessageCall do
        ) do
     result = failed_call(message_call)
 
-    if message_call_to_rip_md?(message_call) do
+    if message_call_to_rip_emd?(message_call) do
       sub_state =
         message_call.current_sub_state
         |> SubState.add_touched_account(message_call.recipient)
@@ -172,8 +172,8 @@ defmodule EVM.MessageCall do
     end
   end
 
-  defp message_call_to_rip_md?(message_call) do
-    message_call.recipient == <<3::160>>
+  defp message_call_to_rip_emd?(message_call) do
+    message_call.recipient == EVM.Builtin.Rip160.contract_address()
   end
 
   defp finalize_reverted_message_call(

--- a/apps/evm/lib/evm/message_call.ex
+++ b/apps/evm/lib/evm/message_call.ex
@@ -2,7 +2,7 @@ defmodule EVM.MessageCall do
   alias EVM.{AccountRepo, ExecEnv, Memory, Builtin, VM, Functions, MachineState, SubState}
 
   @moduledoc """
-  Describes a message call function that used for all call operations (call, delegatecall, callcode, staticcall).
+  Describes a message call function that is used for all call operations (call, delegatecall, callcode, staticcall).
   """
   defstruct [
     :current_exec_env,
@@ -145,7 +145,7 @@ defmodule EVM.MessageCall do
       ) do
     case output do
       :failed ->
-        failed_call(message_call)
+        finalize_failed_message_call(exec_result, message_call)
 
       {:revert, _output} ->
         finalize_reverted_message_call(exec_result, message_call)
@@ -153,6 +153,27 @@ defmodule EVM.MessageCall do
       _ ->
         finalize_successful_message_call(exec_result, message_call)
     end
+  end
+
+  defp finalize_failed_message_call(
+         {_remaining_gas, _n_sub_state, _exec_env, :failed},
+         message_call
+       ) do
+    result = failed_call(message_call)
+
+    if message_call_to_rip_md?(message_call) do
+      sub_state =
+        message_call.current_sub_state
+        |> SubState.add_touched_account(message_call.recipient)
+
+      Map.put(result, :sub_state, sub_state)
+    else
+      result
+    end
+  end
+
+  defp message_call_to_rip_md?(message_call) do
+    message_call.recipient == <<3::160>>
   end
 
   defp finalize_reverted_message_call(

--- a/apps/evm/test/evm/message_call_test.exs
+++ b/apps/evm/test/evm/message_call_test.exs
@@ -184,7 +184,7 @@ defmodule EVM.MessageCallTest do
   describe "when recipient address is precompiled contract 3" do
     test "fails if it runs out of gas" do
       pre_machine_state = build(:machine_state)
-      precompiled_contract = <<3::160>>
+      precompiled_contract = EVM.Builtin.Rip160.contract_address()
 
       message_call =
         build(:message_call,
@@ -201,7 +201,7 @@ defmodule EVM.MessageCallTest do
 
     test "includes the address in the substate's touched accounts" do
       pre_machine_state = build(:machine_state)
-      precompiled_contract = <<3::160>>
+      precompiled_contract = EVM.Builtin.Rip160.contract_address()
 
       message_call =
         build(:message_call,

--- a/apps/evm/test/evm/message_call_test.exs
+++ b/apps/evm/test/evm/message_call_test.exs
@@ -49,7 +49,7 @@ defmodule EVM.MessageCallTest do
     assert machine_state.memory == <<0x4::256>>
     assert machine_state.gas == message_call.execution_value - 24
     assert machine_state.active_words == 8
-    assert machine_state.stack == pre_machine_state.stack ++ [1]
+    assert has_success_on_stack?(machine_state.stack)
   end
 
   test "transfers value from current account to recipient" do
@@ -102,7 +102,7 @@ defmodule EVM.MessageCallTest do
 
     assert %{machine_state: machine_state} = MessageCall.call(message_call)
     assert machine_state.gas == pre_machine_state.gas + message_call.execution_value
-    assert machine_state.stack == pre_machine_state.stack ++ [0]
+    assert has_failure_on_stack?(machine_state.stack)
   end
 
   test "fails if there aren't enough funds to perform call" do
@@ -117,7 +117,7 @@ defmodule EVM.MessageCallTest do
 
     assert %{machine_state: machine_state} = MessageCall.call(message_call)
     assert machine_state.gas == pre_machine_state.gas + message_call.execution_value
-    assert machine_state.stack == pre_machine_state.stack ++ [0]
+    assert has_failure_on_stack?(machine_state.stack)
   end
 
   test "sets machine_state.active_words" do
@@ -179,5 +179,50 @@ defmodule EVM.MessageCallTest do
 
     assert machine_state.memory == <<0, 0>>
     assert machine_state.active_words == 1
+  end
+
+  describe "when recipient address is precompiled contract 3" do
+    test "fails if it runs out of gas" do
+      pre_machine_state = build(:machine_state)
+      precompiled_contract = <<3::160>>
+
+      message_call =
+        build(:message_call,
+          current_machine_state: pre_machine_state,
+          value: 0,
+          code_owner: precompiled_contract,
+          recipient: precompiled_contract
+        )
+
+      assert %{machine_state: machine_state} = MessageCall.call(message_call)
+      assert machine_state.gas == 0
+      assert has_failure_on_stack?(machine_state.stack)
+    end
+
+    test "includes the address in the substate's touched accounts" do
+      pre_machine_state = build(:machine_state)
+      precompiled_contract = <<3::160>>
+
+      message_call =
+        build(:message_call,
+          current_machine_state: pre_machine_state,
+          value: 0,
+          code_owner: precompiled_contract,
+          recipient: precompiled_contract
+        )
+
+      assert %{sub_state: sub_state} = MessageCall.call(message_call)
+      assert Enum.member?(sub_state.touched_accounts, precompiled_contract)
+    end
+  end
+
+  defp has_failure_on_stack?(stack) do
+    {value, _rest} = EVM.Stack.pop(stack)
+    value == 0
+  end
+
+  defp has_success_on_stack?(stack) do
+    {value, _rest} = EVM.Stack.pop(stack)
+    value == 1
   end
 end


### PR DESCRIPTION
Relates to https://github.com/poanetwork/mana/issues/370

This fixes GeneralStateTests/stSpecialTest/failed_tx_xcf416c53 in state tests for SpuriousDragon and Byzantium, and it fixes it in blockchain tests for SpuriousDragon. Strangely, it does not solve it for Byzantium. I will continue working on a Byzantium fix, but I think this can be committed now as a unit of work.

Description
===========

During the empty account cleanup that ensued after the Spurious Dragon hardfork, a consensus issue arose. Geth was not reverting removed empty accounts (un-deleting them as it where) when a call was OOG. Parity was reverting the removal.

During cleanup, it was discovered that there was one more idiosyncrasy: both Geth and Parity had failed to revert the clean up of an empty account when an inner call was out-of gas. The account in question was account 3, the precompiled contract RIPEMD.

Since both Geth and Parity had removed the account and had not reverted that, it was deemed that it should remain that way. So the `failed_tx_xcf416c53` test is testing that very thing. It's testing transaction [0xcf416c536ec1a19ed1fb89e4ec7ffb3cf73aa413b3aa9b77d60e4fd81a4296ba](https://etherscan.io/tx/0xcf416c536ec1a19ed1fb89e4ec7ffb3cf73aa413b3aa9b77d60e4fd81a4296ba#internal)

What's our fix?
==============

Since we implicitly revert on a call failure by simply not returning a new sub state or exec env, we modify the call failure to return a new sub state with the account touched if it is the RIPEMD contract. It is an ugly fix for this, but I am unsure as to how else to handle it without changing the logic of how we revert state on a call failure.

More details
============

If more details are needed, please see:

- The announcement of the consensus bug: https://blog.ethereum.org/2016/11/25/security-alert-11242016-consensus-bug-geth-v1-4-19-v1-5-2/

In there you can see,

> Details: Geth was failing to revert empty account deletions when the
transaction causing the deletions of empty accounts ended with an out-of-gas
exception. An additional issue was found in Parity, where the Parity client
incorrectly failed to revert empty account deletions in a more limited set of
contexts involving out-of-gas calls to precompiled contracts; the new Geth
behavior matches Parity’s, and empty accounts will cease to be a source of
concern in general in about one week once the state clearing process finishes.

- This helpful comment by Holiman in EIP 716: https://github.com/ethereum/EIPs/issues/716#issuecomment-330824096

- Geth introducing fix: https://github.com/ethereum/go-ethereum/commit/12d654a6fc4580f9194a931032ebf0e1b1927279#diff-2433aa143ee4772026454b8abd76b9ddR93

- Aleth implementation of fix: https://github.com/ethereum/aleth/blob/8daa6e1c56e874e88e894d96f89f1ff8c9412a63/libethereum/Executive.cpp#L314