### PR TITLE
Rename common_tests.run task to blockchain_tests.run

### DIFF
--- a/apps/blockchain/lib/mix/tasks/blockchain_tests.run.ex
+++ b/apps/blockchain/lib/mix/tasks/blockchain_tests.run.ex
@@ -1,4 +1,4 @@
-defmodule Mix.Tasks.CommonTests.Run do
+defmodule Mix.Tasks.BlockchainTests.Run do
   use Mix.Task
 
   require Logger
@@ -10,20 +10,17 @@ defmodule Mix.Tasks.CommonTests.Run do
   @moduledoc """
   Runs a single blockchain common test.
 
-  Note that this should be run with `MIX_ENV=test`.
-
   ## Example
 
   From the blockchain app,
 
   ```
-  MIX_ENV=test mix common_tests.run "stSpecialTest/failed_tx" --fork "EIP158"
+  mix blockchain_tests.run "stSpecialTest/failed_tx" --fork "SpuriousDragon"
   ```
 
   ## Command line options
 
-  * `--fork` - the name of the hardfork to run (optional)
-  * `--hardfork` - alias for `--fork`
+  * `--fork`, `-f` - the name of the hardfork to run (optional)
   """
 
   @preferred_cli_env :test

--- a/apps/blockchain/lib/mix/tasks/state_tests.run.ex
+++ b/apps/blockchain/lib/mix/tasks/state_tests.run.ex
@@ -10,20 +10,17 @@ defmodule Mix.Tasks.StateTests.Run do
   @moduledoc """
   Runs a single state common test.
 
-  Note that this should be run with `MIX_ENV=test`.
-
   ## Example
 
   From the blockchain app,
 
   ```
-  MIX_ENV=test mix state_tests.run "stRevertTest/RevertInCallCode" --fork "Byzantium"
+  mix state_tests.run "stRevertTest/RevertInCallCode" --fork "Byzantium"
   ```
 
   ## Command line options
 
-  * `--fork` - the name of the hardfork to run (optional)
-  * `-f` - alias for `--fork`
+  * `--fork`, `-f` - the name of the hardfork to run (optional)
   """
 
   @preferred_cli_env :test


### PR DESCRIPTION
Description
===========

The mix task for running a single blockchain test was created first, and since the task lives in the blockchain app, it was named `common_tests.run`. But now that we also have a `state_tests.run` mix task, the `common_tests.run` task name is confusing. We update it to be `blockchain_tests.run`.