### PR TITLE
fix logs order in receipts

### DIFF
--- a/apps/blockchain/lib/blockchain/block/holistic_validity.ex
+++ b/apps/blockchain/lib/blockchain/block/holistic_validity.ex
@@ -80,9 +80,8 @@ defmodule Blockchain.Block.HolisticValidity do
       |> check_ommers_hash_validity(child_block, block)
       |> check_transactions_root_validity(child_block, block)
       |> check_gas_used(child_block, block)
-
-    # |> check_receipts_root_validity(child_block, block)
-    # |> check_logs_bloom(child_block, block)
+      |> check_receipts_root_validity(child_block, block)
+      |> check_logs_bloom(child_block, block)
 
     if errors == [], do: :valid, else: {:invalid, errors}
   end

--- a/apps/evm/lib/evm/operation/system.ex
+++ b/apps/evm/lib/evm/operation/system.ex
@@ -343,8 +343,8 @@ defmodule EVM.Operation.System do
     exec_env = %{exec_env | account_repo: updated_account_repo}
 
     sub_state =
-      n_sub_state
-      |> SubState.merge(sub_state)
+      sub_state
+      |> SubState.merge(n_sub_state)
       |> SubState.add_touched_account(new_address)
 
     %{


### PR DESCRIPTION
fixes https://github.com/poanetwork/mana/issues/498

We were prepending logs from contract creation to accumulated logs.
This is wrong. Logs order have to be from old to new