### PR TITLE
set last_return_data to empty binary on message call failure

### DIFF
--- a/apps/blockchain/test/blockchain/state_test.exs
+++ b/apps/blockchain/test/blockchain/state_test.exs
@@ -10,7 +10,6 @@ defmodule Blockchain.StateTest do
   @failing_tests %{
     "Byzantium" => [
       "stReturnDataTest/call_outsize_then_create_successful_then_returndatasize",
-      "stReturnDataTest/call_then_call_value_fail_then_returndatasize",
       "stReturnDataTest/call_then_create_successful_then_returndatasize",
       "stReturnDataTest/modexp_modsize0_returndatasize",
       "stReturnDataTest/returndatacopy_afterFailing_create",

--- a/apps/evm/lib/evm/message_call.ex
+++ b/apps/evm/lib/evm/message_call.ex
@@ -338,6 +338,8 @@ defmodule EVM.MessageCall do
       |> push_failure_on_stack()
       |> MachineState.refund_gas(remaining_gas)
 
+    updated_machine_state = %{updated_machine_state | last_return_data: <<>>}
+
     %{machine_state: updated_machine_state}
   end
 

--- a/apps/evm/test/evm/message_call_test.exs
+++ b/apps/evm/test/evm/message_call_test.exs
@@ -120,6 +120,22 @@ defmodule EVM.MessageCallTest do
     assert has_failure_on_stack?(machine_state.stack)
   end
 
+  test "sets last last_return_data to empty binary on failure" do
+    pre_machine_state = build(:machine_state, last_return_data: <<1, 2, 3, 4, 5>>)
+
+    message_call =
+      build(:message_call,
+        current_machine_state: pre_machine_state,
+        value: 9000,
+        execution_value: 100
+      )
+
+    %{machine_state: machine_state} = MessageCall.call(message_call)
+
+    assert has_failure_on_stack?(machine_state.stack)
+    assert machine_state.last_return_data == <<>>
+  end
+
   test "sets machine_state.active_words" do
     pre_machine_state = build(:machine_state)
 


### PR DESCRIPTION
We should set `last_return_data` to empty binary on message call failure because there is no return data.