### PR TITLE
fix modexp output

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ Ethereum common tests are created for all clients to test against. We plan to pr
   - [BlockchainTests](https://github.com/ethereum/tests/tree/develop/BlockchainTests) (Includes GeneralStateTests) 1233/1233 = 100% passing
   - [GeneralStateTests](https://github.com/ethereum/tests/tree/develop/GeneralStateTests) 1181/1181 = 100% passing
 - [x] Byzantium
-  - [BlockchainTests](https://github.com/ethereum/tests/tree/develop/BlockchainTests) (Includes GeneralStateTests) 4987/4992 = 99.9% passing
-  - [GeneralStateTests](https://github.com/ethereum/tests/tree/develop/GeneralStateTests) 4782/4784 = 99.9% passing
+  - [BlockchainTests](https://github.com/ethereum/tests/tree/develop/BlockchainTests) (Includes GeneralStateTests) 4991/4992 = 99.9% passing
+  - [GeneralStateTests](https://github.com/ethereum/tests/tree/develop/GeneralStateTests) 4783/4784 = 99.9% passing
 - [ ] Constantinople: View the community [Constantinople Project Tracker](https://github.com/ethereum/pm/issues/53).
 
 ## Updating the Common test

--- a/apps/blockchain/test/blockchain/state_test.exs
+++ b/apps/blockchain/test/blockchain/state_test.exs
@@ -7,10 +7,7 @@ defmodule Blockchain.StateTest do
   use ExUnit.Case, async: true
 
   @failing_tests %{
-    "Byzantium" => [
-      "stReturnDataTest/modexp_modsize0_returndatasize",
-      "stRevertTest/RevertInCreateInInit"
-    ],
+    "Byzantium" => ["stRevertTest/RevertInCreateInInit"],
     "Constantinople" => [
       "stCreate2/CREATE2_ContractSuicideDuringInit_ThenStoreThenReturn",
       "stCreate2/CREATE2_Suicide",

--- a/apps/blockchain/test/blockchain_test.exs
+++ b/apps/blockchain/test/blockchain_test.exs
@@ -18,10 +18,6 @@ defmodule BlockchainTest do
     "TangerineWhistle" => [],
     "SpuriousDragon" => [],
     "Byzantium" => [
-      "GeneralStateTests/stReturnDataTest/modexp_modsize0_returndatasize_d0g0v0.json",
-      "GeneralStateTests/stReturnDataTest/modexp_modsize0_returndatasize_d0g1v0.json",
-      "GeneralStateTests/stReturnDataTest/modexp_modsize0_returndatasize_d0g2v0.json",
-      "GeneralStateTests/stReturnDataTest/modexp_modsize0_returndatasize_d0g3v0.json",
       "GeneralStateTests/stRevertTest/RevertInCreateInInit_d0g0v0.json"
     ],
     "Constantinople" => String.split(@failing_constantinople_tests, "\n"),

--- a/apps/evm/lib/evm/builtin/mod_exp.ex
+++ b/apps/evm/lib/evm/builtin/mod_exp.ex
@@ -61,6 +61,7 @@ defmodule EVM.Builtin.ModExp do
     if required_gas <= gas do
       result =
         cond do
+          modulus_length == 0 -> <<>>
           modulus <= 1 -> <<0>>
           exponent == 0 -> <<1>>
           base == 0 -> <<0>>


### PR DESCRIPTION
We should return empty binary if mod_size is equal to zero

fixes https://github.com/poanetwork/mana/issues/524