### PR TITLE
Improve EVM.Logger output

### DIFF
--- a/apps/evm/README.md
+++ b/apps/evm/README.md
@@ -45,11 +45,11 @@ The following example is from [Ethereum Virtual Machine in Elixir](https://www.b
       operation = MachineCode.current_operation(machine_state, exec_env)
       inputs = Operation.inputs(operation, machine_state)
 
-      # more code
-
-      final_machine_state
+      machine_state
       |> EVM.Logger.log_stack()
       |> EVM.Logger.log_state(operation)
+
+      # more code
 
       {final_machine_state, n_sub_state, n_exec_env}
       ```

--- a/apps/evm/lib/evm/machine_state.ex
+++ b/apps/evm/lib/evm/machine_state.ex
@@ -15,7 +15,8 @@ defmodule EVM.MachineState do
             active_words: 0,
             previously_active_words: 0,
             stack: [],
-            last_return_data: <<>>
+            last_return_data: <<>>,
+            step: 0
 
   @type program_counter :: integer()
   @type memory :: binary()
@@ -27,6 +28,10 @@ defmodule EVM.MachineState do
   - m: memory
   - i: active_words
   - s: stack
+
+  Other terms:
+
+  - step: the number of vm cycles the machine state gas gone through
   """
   @type t :: %__MODULE__{
           gas: Gas.t(),
@@ -35,7 +40,8 @@ defmodule EVM.MachineState do
           active_words: integer(),
           previously_active_words: integer(),
           stack: Stack.t(),
-          last_return_data: binary()
+          last_return_data: binary(),
+          step: integer()
         }
 
   @doc """
@@ -138,5 +144,18 @@ defmodule EVM.MachineState do
     next_postion = ProgramCounter.next(machine_state.program_counter, operation_metadata, inputs)
 
     %{machine_state | program_counter: next_postion}
+  end
+
+  @doc """
+  Increments the step (representing another vm cycle)
+
+  ## Examples
+
+      iex> EVM.MachineState.increment_step(%EVM.MachineState{step: 9})
+      %EVM.MachineState{step: 10}
+  """
+  @spec increment_step(MachineState.t()) :: MachineState.t()
+  def increment_step(machine_state) do
+    %{machine_state | step: machine_state.step + 1}
   end
 end


### PR DESCRIPTION
As I work on debugging why we're failing to sync the mainnet, I have found these changes to be helpful. I am unsure whether or not this is something we want to use, since I know the EVM.Logger's original intent was to compare the output with parity. But I have found that most of my debugging is done against Geth's stacktraces in [Etherescan](https://etherscan.io). A sample stack trace can be found [here](https://etherscan.io/vmtrace?txhash=0xec32243bad69039271ae01362ec4916be9fbf546e5356db420b1267ac1a038a3#raw).

Description
===========

A lot of our debugging is happening as we compare stack traces against geth's vm traces found in Etherescan.

To that end, we make the following changes so that debugging is easier:

1. Add a `step` key to `MachineState` so that we know how many cycles the vm has executed. This is very helpful in comparing vm traces line-by-line against geth, since they keep a step count. We increment the step at the end of each `VM.cycle`.

2. Log the program counter as a number. For some reason, we were logging the program counter as hex. Etherscan shows it as a number, and it is much easier to reason about.

3. Log stack as hex. Etherescan shows the stack as hex numbers, not as integers. Comparing the stack against that will be much easier and will no longer require manual translation of values.

4. We update the EVM readme to suggest placing the EVM.Logger calls closer to the beginning of the `cycle` function so that values more closely match Etherscan's values (e.g. gas used would be equivalent to next cycle's gas in Etherscan if it's printed at the end of the cycle).

Comparisons
==========

Before
-------

![screen shot 2018-10-23 at 10 33 48 am](https://user-images.githubusercontent.com/3245976/47368216-3a44ac00-d6af-11e8-8361-75581edfce19.png)


After
------

![screen shot 2018-10-23 at 10 24 42 am](https://user-images.githubusercontent.com/3245976/47368227-3fa1f680-d6af-11e8-88b9-e199ba5101d2.png)
