### PR TITLE
fix extcodehash opcode parameter

### DIFF
--- a/apps/evm/lib/evm/memory.ex
+++ b/apps/evm/lib/evm/memory.ex
@@ -71,7 +71,7 @@ defmodule EVM.Memory do
           MachineState.t()
   def write(machine_state, offset_bytes, original_data, size \\ nil)
 
-  def write(machine_state, offset_bytes, data, size) when size == 0,
+  def write(machine_state, _offset_bytes, _data, size) when size == 0,
     do: machine_state
 
   def write(machine_state, offset_bytes, data, size) when is_integer(data),

--- a/apps/evm/lib/evm/operation/environmental_information.ex
+++ b/apps/evm/lib/evm/operation/environmental_information.ex
@@ -1,5 +1,5 @@
 defmodule EVM.Operation.EnvironmentalInformation do
-  alias EVM.{AccountRepo, Helpers, Memory, Operation, Stack}
+  alias EVM.{AccountRepo, Address, Helpers, Memory, Operation, Stack}
 
   @doc """
   Get address of currently executing account.
@@ -313,7 +313,7 @@ defmodule EVM.Operation.EnvironmentalInformation do
 
   @spec extcodehash(Operation.stack_args(), Operation.vm_map()) :: Operation.op_result()
   def extcodehash([address], %{exec_env: exec_env}) do
-    wrapped_address = Helpers.wrap_address(address)
+    wrapped_address = Address.new(address)
 
     hash =
       AccountRepo.repo(exec_env.account_repo).get_account_code_hash(


### PR DESCRIPTION
`extcodehash` was failing because we were trying to calculate sha3 hash
from integer instead of binary

```
12:26:51.523 [error] Task #PID<0.909.0> started from #PID<0.74.0> terminating
** (ArgumentError) argument error
    :keccakf1600.sha3_256(1)
```

We should convert integer address from stack to binary