### PR TITLE
turn on eip1283

### DIFF
--- a/apps/blockchain/scripts/generate_state_tests.ex
+++ b/apps/blockchain/scripts/generate_state_tests.ex
@@ -68,7 +68,7 @@ defmodule GenerateStateTests do
       percentage =
         if total_tests == 0, do: 0, else: round(passing_tests / total_tests * 1000) / 10
 
-      IO.puts("Passing #{hardfork} tests #{passing_tests}/#{total_tests}= #{percentage}%")
+      IO.puts("Passing #{hardfork} tests #{passing_tests}/#{total_tests} = #{percentage}%")
     end
   end
 

--- a/apps/blockchain/scripts/generate_state_tests.ex
+++ b/apps/blockchain/scripts/generate_state_tests.ex
@@ -68,7 +68,7 @@ defmodule GenerateStateTests do
       percentage =
         if total_tests == 0, do: 0, else: round(passing_tests / total_tests * 1000) / 10
 
-      IO.puts("Passing #{hardfork} tests tests #{passing_tests}/#{total_tests}= #{percentage}%")
+      IO.puts("Passing #{hardfork} tests #{passing_tests}/#{total_tests}= #{percentage}%")
     end
   end
 

--- a/apps/evm/lib/evm/configuration.ex
+++ b/apps/evm/lib/evm/configuration.ex
@@ -115,8 +115,8 @@ defmodule EVM.Configuration do
       "Byzantium" ->
         EVM.Configuration.Byzantium.new()
 
-      "Constantinople" ->
-        EVM.Configuration.Constantinople.new()
+      # "Constantinople" ->
+      #   EVM.Configuration.Constantinople.new()
 
       _ ->
         nil

--- a/apps/evm/lib/evm/configuration/constantinople.ex
+++ b/apps/evm/lib/evm/configuration/constantinople.ex
@@ -7,8 +7,7 @@ defmodule EVM.Configuration.Constantinople do
             has_shift_operations: true,
             has_extcodehash: true,
             has_create2: true,
-            # temporarily disabled (no common tests yet) https://github.com/ethereum/tests/issues/483
-            eip1283_sstore_gas_cost_changed: false
+            eip1283_sstore_gas_cost_changed: true
 
   @type t :: %__MODULE__{}
 


### PR DESCRIPTION
eip1283 (sstore gas cost changes) was disabled because common tests
weren't ready

Passing Constantinople state tests 5309/5311= 100.0%
Passing Constantinople blockchain tests 5347/5349 = 100.0%
