### PR TITLE
Simplify extcodecopy conditional logic

### DIFF
--- a/apps/evm/lib/evm/operation/environmental_information.ex
+++ b/apps/evm/lib/evm/operation/environmental_information.ex
@@ -301,14 +301,10 @@ defmodule EVM.Operation.EnvironmentalInformation do
         wrapped_address
       )
 
-    if size == 0 || size + mem_offset > EVM.max_int() || (code_offset == 0 && account_code == "") do
-      %{machine_state: machine_state}
-    else
-      data = Memory.read_zeroed_memory(account_code, code_offset, size)
-      machine_state = Memory.write(machine_state, mem_offset, data)
+    data = Memory.read_zeroed_memory(account_code, code_offset, size)
+    machine_state = Memory.write(machine_state, mem_offset, data)
 
-      %{machine_state: machine_state}
-    end
+    %{machine_state: machine_state}
   end
 
   @spec extcodehash(Operation.stack_args(), Operation.vm_map()) :: Operation.op_result()

--- a/apps/evm/test/evm/operation/environmental_information_test.exs
+++ b/apps/evm/test/evm/operation/environmental_information_test.exs
@@ -52,6 +52,27 @@ defmodule EVM.Operation.EnvironmentalInformationTest do
   end
 
   describe "extcodecopy" do
+    test "writes empty code to memory if size is positive" do
+      address = <<1::160>>
+      mem_offset = code_offset = 0
+      size = 120
+      bit_size = size * 8
+      code = <<>>
+
+      params = [address, mem_offset, code_offset, size]
+
+      exec_env = %EVM.ExecEnv{
+        account_repo: %EVM.Mock.MockAccountRepo{account_map: %{address => %{code: code}}}
+      }
+
+      vm_map = %{exec_env: exec_env, machine_state: %EVM.MachineState{}}
+
+      result = EVM.Operation.EnvironmentalInformation.extcodecopy(params, vm_map)
+
+      assert %{machine_state: machine_state} = result
+      assert machine_state.memory == <<0::size(bit_size)>>
+    end
+
     test "returns unmodified machine state if size is zero" do
       address = <<1>>
       mem_offset = code_offset = size = 0


### PR DESCRIPTION
Resolves https://github.com/poanetwork/mana/issues/528

Description
============

We were failing to sync past block 2325632 on the mainnet because transaction `0xec32243bad69039271ae01362ec4916be9fbf546e5356db420b1267ac1a038a3` has an `extcodecopy` operation with positive `size` but the code is empty.

In order to fix that, we remove the conditionals on `extcodecopy` that returned an unchanged `machine_state`. That conditional tested three possibilities with logical ORs, meaning any of these three would return an unchanged `machine_state`:

1. size == 0 -> this is already handled by the Memory.write operation, so we remove the condition.

2. size + mem_offset > EVM.max_int() -> reading the yellow paper, it seems that this condition was wrong. Under `excodecopy` in the appendices outlining Environmental Information, it says:

> The additions in μs[2] + i are not subject to the 2^256 modulo.

3. (code_offset == 0 && account_code == "") -> this condition was the one failing the transaction mentioned above because even though the code offset was `0` and the account code was empty, the size was still positive, meaning we actually needed to write into memory. We add a test for this case to prevent future regression of this condition.