### PR TITLE
Make EVM.Configuration simpler

### DIFF
--- a/apps/blockchain/lib/blockchain/contract/create_contract.ex
+++ b/apps/blockchain/lib/blockchain/contract/create_contract.ex
@@ -83,7 +83,7 @@ defmodule Blockchain.Contract.CreateContract do
           EVM.address()
         ) :: Repo.t()
   defp increment_nonce_of_touched_account(account_repo, config, address) do
-    if EVM.Configuration.for(config).increment_nonce_on_create?(config) do
+    if config.increment_nonce_on_create do
       Repo.increment_account_nonce(account_repo, address)
     else
       account_repo
@@ -155,8 +155,7 @@ defmodule Blockchain.Contract.CreateContract do
     insufficient_gas = remaining_gas < contract_creation_cost
 
     cond do
-      insufficient_gas &&
-          EVM.Configuration.for(params.config).fail_contract_creation_lack_of_gas?(params.config) ->
+      insufficient_gas && params.config.should_fail_contract_creation_lack_of_gas ->
         {:error, {original_account_repo, 0, SubState.empty(), <<>>}}
 
       EVM.Configuration.for(params.config).limit_contract_code_size?(

--- a/apps/blockchain/lib/blockchain/transaction.ex
+++ b/apps/blockchain/lib/blockchain/transaction.ex
@@ -212,8 +212,7 @@ defmodule Blockchain.Transaction do
     {expended_gas, refund} = calculate_gas_usage(tx, remaining_gas, sub_state)
 
     {account_repo_after_receipt, receipt} =
-      if empty_contract_creation?(tx) &&
-           Configuration.for(evm_config).clean_touched_accounts?(evm_config) do
+      if empty_contract_creation?(tx) && evm_config.clean_touched_accounts do
         account_repo_after_execution = Repo.commit(updated_account_repo)
 
         receipt =
@@ -496,14 +495,14 @@ defmodule Blockchain.Transaction do
 
   defp transaction_cost(tx, config) do
     if contract_creation?(tx) do
-      Configuration.for(config).contract_creation_cost(config)
+      config.contract_creation_cost
     else
       Gas.g_transaction()
     end
   end
 
   defp create_receipt(state_root_hash, gas_used, logs, status_code, evm_config) do
-    if Configuration.for(evm_config).status_in_receipt?(evm_config) do
+    if evm_config.status_in_receipt do
       Receipt.new(status_code, gas_used, logs)
     else
       Receipt.new(state_root_hash, gas_used, logs)

--- a/apps/blockchain/lib/blockchain/transaction/account_cleaner.ex
+++ b/apps/blockchain/lib/blockchain/transaction/account_cleaner.ex
@@ -1,10 +1,9 @@
 defmodule Blockchain.Transaction.AccountCleaner do
   alias Blockchain.Account
   alias Blockchain.Account.Repo
-  alias EVM.Configuration
 
   def clean_touched_accounts(account_repo, accounts, config) do
-    if Configuration.for(config).clean_touched_accounts?(config) do
+    if config.clean_touched_accounts do
       Enum.reduce(accounts, account_repo, fn address, new_account_repo ->
         account = Repo.account(new_account_repo, address)
 

--- a/apps/blockchain/lib/blockchain/transaction/validity.ex
+++ b/apps/blockchain/lib/blockchain/transaction/validity.ex
@@ -43,7 +43,7 @@ defmodule Blockchain.Transaction.Validity do
   end
 
   defp validate_signature(trx, chain, evm_config) do
-    max_s_value = EVM.Configuration.for(evm_config).max_signature_s(evm_config)
+    max_s_value = evm_config.max_signature_s
 
     if Transaction.Signature.is_signature_valid?(trx.r, trx.s, trx.v, chain.params.network_id,
          max_s: max_s_value

--- a/apps/evm/lib/evm/configuration.ex
+++ b/apps/evm/lib/evm/configuration.ex
@@ -3,91 +3,62 @@ defmodule EVM.Configuration do
   Behaviour for hardfork configurations.
   """
 
-  @type t :: struct()
+  defmacro __using__(opts) do
+    fallback_config = Keyword.fetch!(opts, :fallback_config)
+    overrides = Keyword.fetch!(opts, :overrides)
 
-  # EIP2
-  @callback contract_creation_cost(t) :: integer()
+    quote do
+      @behaviour EVM.Configuration
 
-  # EIP2
-  @callback fail_contract_creation_lack_of_gas?(t) :: boolean()
+      defstruct unquote(fallback_config).new()
+                |> Map.from_struct()
+                |> Map.merge(unquote(overrides))
+                |> Enum.into([])
 
-  # EIP2
-  @callback max_signature_s(t) :: atom()
+      @impl true
+      def new, do: %__MODULE__{}
+    end
+  end
 
-  # EIP7
-  @callback has_delegate_call?(t) :: boolean()
+  @type t :: %{
+          :contract_creation_cost => non_neg_integer(),
+          :has_delegate_call => boolean(),
+          :should_fail_contract_creation_lack_of_gas => boolean(),
+          :max_signature_s => :secp256k1n | :secp256k1n_2,
+          :extcodesize_cost => non_neg_integer(),
+          :extcodecopy_cost => non_neg_integer(),
+          :balance_cost => non_neg_integer(),
+          :sload_cost => non_neg_integer(),
+          :call_cost => non_neg_integer(),
+          :selfdestruct_cost => non_neg_integer(),
+          :should_fail_nested_operation_lack_of_gas => boolean(),
+          :exp_byte_cost => non_neg_integer(),
+          :limit_contract_code_size => boolean(),
+          :increment_nonce_on_create => boolean(),
+          :empty_account_value_transfer => boolean(),
+          :clean_touched_accounts => boolean(),
+          :has_revert => boolean(),
+          :has_static_call => boolean(),
+          :support_variable_length_return_value => boolean(),
+          :has_mod_exp_builtin => boolean(),
+          :status_in_receipt => boolean(),
+          :has_ec_add_builtin => boolean(),
+          :has_ec_mult_builtin => boolean(),
+          :has_ec_pairing_builtin => boolean(),
+          :has_shift_operations => boolean(),
+          :has_extcodehash => boolean(),
+          :has_create2 => boolean(),
+          :eip1283_sstore_gas_cost_changed => boolean(),
+          optional(atom) => any()
+        }
 
-  # EIP150
-  @callback extcodesize_cost(t) :: integer()
-
-  # EIP150
-  @callback extcodecopy_cost(t) :: integer()
-
-  # EIP150
-  @callback balance_cost(t) :: integer()
-
-  # EIP150
-  @callback sload_cost(t) :: integer()
-
-  # EIP150
-  @callback call_cost(t) :: integer()
+  @callback new() :: t()
 
   # EIP150
   @callback selfdestruct_cost(t, keyword()) :: integer()
 
-  # EIP150
-  @callback fail_nested_operation_lack_of_gas?(t) :: boolean()
-
-  # EIP160
-  @callback exp_byte_cost(t) :: integer()
-
-  # EIP161-a
-  @callback increment_nonce_on_create?(t) :: boolean()
-
-  # EIP161-b
-  @callback empty_account_value_transfer?(t) :: boolean()
-
-  # EIP161-cd
-  @callback clean_touched_accounts?(t) :: boolean()
-
   # EIP170
   @callback limit_contract_code_size?(t, integer) :: boolean()
-
-  # EIP140
-  @callback has_revert?(t) :: boolean()
-
-  # EIP211
-  @callback support_variable_length_return_value?(t) :: boolean()
-
-  # EIP214
-  @callback has_static_call?(t) :: boolean()
-
-  # EIP196
-  @callback has_ec_add_builtin?(t) :: boolean()
-
-  # EIP196
-  @callback has_ec_mult_builtin?(t) :: boolean()
-
-  # EIP197
-  @callback has_ec_pairing_builtin?(t) :: boolean()
-
-  # EIP198
-  @callback has_mod_exp_builtin?(t) :: boolean()
-
-  # EIP658
-  @callback status_in_receipt?(t) :: boolean()
-
-  # EIP145
-  @callback has_shift_operations?(t) :: boolean()
-
-  # EIP1052
-  @callback has_extcodehash?(t) :: boolean()
-
-  # EIP1014
-  @callback has_create2?(t) :: boolean()
-
-  # EIP1283
-  @callback eip1283_sstore_gas_cost_changed?(t) :: boolean()
 
   @spec for(t) :: module()
   def for(config) do

--- a/apps/evm/lib/evm/configuration/byzantium.ex
+++ b/apps/evm/lib/evm/configuration/byzantium.ex
@@ -1,127 +1,26 @@
 defmodule EVM.Configuration.Byzantium do
-  @behaviour EVM.Configuration
-
   alias EVM.Configuration.SpuriousDragon
 
-  defstruct fallback_config: SpuriousDragon.new(),
-            has_revert: true,
-            has_static_call: true,
-            support_variable_length_return_value: true,
-            has_mod_exp_builtin: true,
-            status_in_receipt: true,
-            has_ec_add_builtin: true,
-            has_ec_mult_builtin: true,
-            has_ec_pairing_builtin: true
-
-  @type t :: %__MODULE__{}
-
-  def new do
-    %__MODULE__{}
-  end
-
-  @impl true
-  def contract_creation_cost(config) do
-    SpuriousDragon.contract_creation_cost(config.fallback_config)
-  end
-
-  @impl true
-  def has_delegate_call?(config), do: SpuriousDragon.has_delegate_call?(config.fallback_config)
-
-  @impl true
-  def max_signature_s(config), do: SpuriousDragon.max_signature_s(config.fallback_config)
-
-  @impl true
-  def fail_contract_creation_lack_of_gas?(config) do
-    SpuriousDragon.fail_contract_creation_lack_of_gas?(config.fallback_config)
-  end
-
-  @impl true
-  def extcodesize_cost(config), do: SpuriousDragon.extcodesize_cost(config.fallback_config)
-
-  @impl true
-  def extcodecopy_cost(config), do: SpuriousDragon.extcodecopy_cost(config.fallback_config)
-
-  @impl true
-  def balance_cost(config), do: SpuriousDragon.balance_cost(config.fallback_config)
-
-  @impl true
-  def sload_cost(config), do: SpuriousDragon.sload_cost(config.fallback_config)
-
-  @impl true
-  def call_cost(config), do: SpuriousDragon.call_cost(config.fallback_config)
+  use EVM.Configuration,
+    fallback_config: SpuriousDragon,
+    overrides: %{
+      has_revert: true,
+      has_static_call: true,
+      support_variable_length_return_value: true,
+      has_mod_exp_builtin: true,
+      status_in_receipt: true,
+      has_ec_add_builtin: true,
+      has_ec_mult_builtin: true,
+      has_ec_pairing_builtin: true
+    }
 
   @impl true
   def selfdestruct_cost(config, params) do
-    SpuriousDragon.selfdestruct_cost(config.fallback_config, params)
+    SpuriousDragon.selfdestruct_cost(config, params)
   end
-
-  @impl true
-  def fail_nested_operation_lack_of_gas?(config) do
-    SpuriousDragon.fail_nested_operation_lack_of_gas?(config.fallback_config)
-  end
-
-  @impl true
-  def exp_byte_cost(config), do: SpuriousDragon.exp_byte_cost(config.fallback_config)
 
   @impl true
   def limit_contract_code_size?(config, size) do
-    SpuriousDragon.limit_contract_code_size?(config.fallback_config, size)
-  end
-
-  @impl true
-  def increment_nonce_on_create?(config) do
-    SpuriousDragon.increment_nonce_on_create?(config.fallback_config)
-  end
-
-  @impl true
-  def empty_account_value_transfer?(config) do
-    SpuriousDragon.empty_account_value_transfer?(config.fallback_config)
-  end
-
-  @impl true
-  def clean_touched_accounts?(config) do
-    SpuriousDragon.clean_touched_accounts?(config.fallback_config)
-  end
-
-  @impl true
-  def has_revert?(config), do: config.has_revert
-
-  @impl true
-  def has_static_call?(config), do: config.has_static_call
-
-  @impl true
-  def support_variable_length_return_value?(config) do
-    config.support_variable_length_return_value
-  end
-
-  @impl true
-  def has_mod_exp_builtin?(config), do: config.has_mod_exp_builtin
-
-  @impl true
-  def status_in_receipt?(config), do: config.status_in_receipt
-
-  @impl true
-  def has_ec_add_builtin?(config), do: config.has_ec_add_builtin
-
-  @impl true
-  def has_ec_mult_builtin?(config), do: config.has_ec_mult_builtin
-
-  @impl true
-  def has_ec_pairing_builtin?(config), do: config.has_ec_pairing_builtin
-
-  @impl true
-  def has_shift_operations?(config) do
-    SpuriousDragon.has_shift_operations?(config.fallback_config)
-  end
-
-  @impl true
-  def has_extcodehash?(config), do: SpuriousDragon.has_extcodehash?(config.fallback_config)
-
-  @impl true
-  def has_create2?(config), do: SpuriousDragon.has_create2?(config.fallback_config)
-
-  @impl true
-  def eip1283_sstore_gas_cost_changed?(config) do
-    SpuriousDragon.eip1283_sstore_gas_cost_changed?(config.fallback_config)
+    SpuriousDragon.limit_contract_code_size?(config, size)
   end
 end

--- a/apps/evm/lib/evm/configuration/constantinople.ex
+++ b/apps/evm/lib/evm/configuration/constantinople.ex
@@ -1,125 +1,22 @@
 defmodule EVM.Configuration.Constantinople do
-  @behaviour EVM.Configuration
-
   alias EVM.Configuration.Byzantium
 
-  defstruct fallback_config: Byzantium.new(),
-            has_shift_operations: true,
-            has_extcodehash: true,
-            has_create2: true,
-            eip1283_sstore_gas_cost_changed: true
-
-  @type t :: %__MODULE__{}
-
-  def new do
-    %__MODULE__{}
-  end
-
-  @impl true
-  def contract_creation_cost(config) do
-    Byzantium.contract_creation_cost(config.fallback_config)
-  end
-
-  @impl true
-  def has_delegate_call?(config), do: Byzantium.has_delegate_call?(config.fallback_config)
-
-  @impl true
-  def max_signature_s(config), do: Byzantium.max_signature_s(config.fallback_config)
-
-  @impl true
-  def fail_contract_creation_lack_of_gas?(config) do
-    Byzantium.fail_contract_creation_lack_of_gas?(config.fallback_config)
-  end
-
-  @impl true
-  def extcodesize_cost(config), do: Byzantium.extcodesize_cost(config.fallback_config)
-
-  @impl true
-  def extcodecopy_cost(config), do: Byzantium.extcodecopy_cost(config.fallback_config)
-
-  @impl true
-  def balance_cost(config), do: Byzantium.balance_cost(config.fallback_config)
-
-  @impl true
-  def sload_cost(config), do: Byzantium.sload_cost(config.fallback_config)
-
-  @impl true
-  def call_cost(config), do: Byzantium.call_cost(config.fallback_config)
+  use EVM.Configuration,
+    fallback_config: Byzantium,
+    overrides: %{
+      has_shift_operations: true,
+      has_extcodehash: true,
+      has_create2: true,
+      eip1283_sstore_gas_cost_changed: true
+    }
 
   @impl true
   def selfdestruct_cost(config, params) do
-    Byzantium.selfdestruct_cost(config.fallback_config, params)
+    Byzantium.selfdestruct_cost(config, params)
   end
-
-  @impl true
-  def fail_nested_operation_lack_of_gas?(config) do
-    Byzantium.fail_nested_operation_lack_of_gas?(config.fallback_config)
-  end
-
-  @impl true
-  def exp_byte_cost(config), do: Byzantium.exp_byte_cost(config.fallback_config)
 
   @impl true
   def limit_contract_code_size?(config, size) do
-    Byzantium.limit_contract_code_size?(config.fallback_config, size)
-  end
-
-  @impl true
-  def increment_nonce_on_create?(config) do
-    Byzantium.increment_nonce_on_create?(config.fallback_config)
-  end
-
-  @impl true
-  def empty_account_value_transfer?(config) do
-    Byzantium.empty_account_value_transfer?(config.fallback_config)
-  end
-
-  @impl true
-  def clean_touched_accounts?(config) do
-    Byzantium.clean_touched_accounts?(config.fallback_config)
-  end
-
-  @impl true
-  def has_revert?(config), do: Byzantium.has_revert?(config.fallback_config)
-
-  @impl true
-  def has_static_call?(config), do: Byzantium.has_static_call?(config.fallback_config)
-
-  @impl true
-  def support_variable_length_return_value?(config) do
-    Byzantium.support_variable_length_return_value?(config.fallback_config)
-  end
-
-  @impl true
-  def has_mod_exp_builtin?(config), do: Byzantium.has_mod_exp_builtin?(config.fallback_config)
-
-  @impl true
-  def status_in_receipt?(config), do: Byzantium.status_in_receipt?(config.fallback_config)
-
-  @impl true
-  def has_ec_add_builtin?(config), do: Byzantium.has_ec_add_builtin?(config.fallback_config)
-
-  @impl true
-  def has_ec_mult_builtin?(config), do: Byzantium.has_ec_mult_builtin?(config.fallback_config)
-
-  @impl true
-  def has_ec_pairing_builtin?(config) do
-    Byzantium.has_ec_pairing_builtin?(config.fallback_config)
-  end
-
-  @impl true
-  def has_shift_operations?(config) do
-    config.has_shift_operations
-  end
-
-  @impl true
-  def has_extcodehash?(config), do: config.has_extcodehash
-
-  @impl true
-  def has_create2?(config), do: config.has_create2
-
-  @impl true
-  def eip1283_sstore_gas_cost_changed?(config) do
-    config.eip1283_sstore_gas_cost_changed
+    Byzantium.limit_contract_code_size?(config, size)
   end
 end

--- a/apps/evm/lib/evm/configuration/frontier.ex
+++ b/apps/evm/lib/evm/configuration/frontier.ex
@@ -3,7 +3,7 @@ defmodule EVM.Configuration.Frontier do
 
   defstruct contract_creation_cost: 21_000,
             has_delegate_call: false,
-            fail_contract_creation: false,
+            should_fail_contract_creation_lack_of_gas: false,
             max_signature_s: :secp256k1n,
             extcodesize_cost: 20,
             extcodecopy_cost: 20,
@@ -11,7 +11,7 @@ defmodule EVM.Configuration.Frontier do
             sload_cost: 50,
             call_cost: 40,
             selfdestruct_cost: 0,
-            fail_nested_operation: true,
+            should_fail_nested_operation_lack_of_gas: true,
             exp_byte_cost: 10,
             limit_contract_code_size: false,
             increment_nonce_on_create: false,
@@ -30,94 +30,12 @@ defmodule EVM.Configuration.Frontier do
             has_create2: false,
             eip1283_sstore_gas_cost_changed: false
 
-  @type t :: %__MODULE__{}
-
-  def new do
-    %__MODULE__{}
-  end
-
   @impl true
-  def contract_creation_cost(config), do: config.contract_creation_cost
-
-  @impl true
-  def has_delegate_call?(config), do: config.has_delegate_call
-
-  @impl true
-  def max_signature_s(config), do: config.max_signature_s
-
-  @impl true
-  def fail_contract_creation_lack_of_gas?(config), do: config.fail_contract_creation
-
-  @impl true
-  def extcodesize_cost(config), do: config.extcodesize_cost
-
-  @impl true
-  def extcodecopy_cost(config), do: config.extcodecopy_cost
-
-  @impl true
-  def balance_cost(config), do: config.balance_cost
-
-  @impl true
-  def sload_cost(config), do: config.sload_cost
-
-  @impl true
-  def call_cost(config), do: config.call_cost
+  def new, do: %__MODULE__{}
 
   @impl true
   def selfdestruct_cost(config, _params), do: config.selfdestruct_cost
 
   @impl true
-  def fail_nested_operation_lack_of_gas?(config), do: config.fail_nested_operation
-
-  @impl true
-  def exp_byte_cost(config), do: config.exp_byte_cost
-
-  @impl true
   def limit_contract_code_size?(config, _), do: config.limit_contract_code_size
-
-  @impl true
-  def increment_nonce_on_create?(config), do: config.increment_nonce_on_create
-
-  @impl true
-  def empty_account_value_transfer?(config), do: config.empty_account_value_transfer
-
-  @impl true
-  def clean_touched_accounts?(config), do: config.clean_touched_accounts
-
-  @impl true
-  def has_revert?(config), do: config.has_revert
-
-  @impl true
-  def has_static_call?(config), do: config.has_static_call
-
-  @impl true
-  def support_variable_length_return_value?(config),
-    do: config.support_variable_length_return_value
-
-  @impl true
-  def has_mod_exp_builtin?(config), do: config.has_mod_exp_builtin
-
-  @impl true
-  def status_in_receipt?(config), do: config.status_in_receipt
-
-  @impl true
-  def has_ec_add_builtin?(config), do: config.has_ec_add_builtin
-
-  @impl true
-  def has_ec_mult_builtin?(config), do: config.has_ec_mult_builtin
-
-  @impl true
-  def has_ec_pairing_builtin?(config), do: config.has_ec_pairing_builtin
-
-  @impl true
-  def has_shift_operations?(config), do: config.has_shift_operations
-
-  @impl true
-  def has_extcodehash?(config), do: config.has_extcodehash
-
-  @impl true
-  def has_create2?(config), do: config.has_create2
-
-  @impl true
-  def eip1283_sstore_gas_cost_changed?(config), do: config.eip1283_sstore_gas_cost_changed
 end

--- a/apps/evm/lib/evm/configuration/homestead.ex
+++ b/apps/evm/lib/evm/configuration/homestead.ex
@@ -1,121 +1,22 @@
 defmodule EVM.Configuration.Homestead do
-  @behaviour EVM.Configuration
-
   alias EVM.Configuration.Frontier
 
-  defstruct contract_creation_cost: 53_000,
-            has_delegate_call: true,
-            max_signature_s: :secp256k1n_2,
-            fail_contract_creation: true,
-            fallback_config: Frontier.new()
+  use EVM.Configuration,
+    fallback_config: Frontier,
+    overrides: %{
+      contract_creation_cost: 53_000,
+      has_delegate_call: true,
+      max_signature_s: :secp256k1n_2,
+      should_fail_contract_creation_lack_of_gas: true
+    }
 
-  @type t :: %__MODULE__{}
-
-  def new do
-    %__MODULE__{}
+  @impl true
+  def selfdestruct_cost(config, _params) do
+    config.selfdestruct_cost
   end
 
   @impl true
-  def contract_creation_cost(config), do: config.contract_creation_cost
-
-  @impl true
-  def has_delegate_call?(config), do: config.has_delegate_call
-
-  @impl true
-  def max_signature_s(config), do: config.max_signature_s
-
-  @impl true
-  def fail_contract_creation_lack_of_gas?(config), do: config.fail_contract_creation
-
-  @impl true
-  def extcodesize_cost(config), do: Frontier.extcodesize_cost(config.fallback_config)
-
-  @impl true
-  def extcodecopy_cost(config), do: Frontier.extcodecopy_cost(config.fallback_config)
-
-  @impl true
-  def balance_cost(config), do: Frontier.balance_cost(config.fallback_config)
-
-  @impl true
-  def sload_cost(config), do: Frontier.sload_cost(config.fallback_config)
-
-  @impl true
-  def call_cost(config), do: Frontier.call_cost(config.fallback_config)
-
-  @impl true
-  def selfdestruct_cost(config, params) do
-    Frontier.selfdestruct_cost(config.fallback_config, params)
-  end
-
-  @impl true
-  def fail_nested_operation_lack_of_gas?(config) do
-    Frontier.fail_nested_operation_lack_of_gas?(config.fallback_config)
-  end
-
-  @impl true
-  def exp_byte_cost(config), do: Frontier.exp_byte_cost(config.fallback_config)
-
-  @impl true
-  def limit_contract_code_size?(config, size) do
-    Frontier.limit_contract_code_size?(config.fallback_config, size)
-  end
-
-  @impl true
-  def increment_nonce_on_create?(config) do
-    Frontier.increment_nonce_on_create?(config.fallback_config)
-  end
-
-  @impl true
-  def empty_account_value_transfer?(config) do
-    Frontier.empty_account_value_transfer?(config.fallback_config)
-  end
-
-  @impl true
-  def clean_touched_accounts?(config) do
-    Frontier.clean_touched_accounts?(config.fallback_config)
-  end
-
-  @impl true
-  def has_revert?(config), do: Frontier.has_revert?(config.fallback_config)
-
-  @impl true
-  def has_static_call?(config), do: Frontier.has_static_call?(config.fallback_config)
-
-  @impl true
-  def support_variable_length_return_value?(config) do
-    Frontier.support_variable_length_return_value?(config.fallback_config)
-  end
-
-  @impl true
-  def has_mod_exp_builtin?(config), do: Frontier.has_mod_exp_builtin?(config.fallback_config)
-
-  @impl true
-  def status_in_receipt?(config), do: Frontier.status_in_receipt?(config.fallback_config)
-
-  @impl true
-  def has_ec_add_builtin?(config), do: Frontier.has_ec_add_builtin?(config.fallback_config)
-
-  @impl true
-  def has_ec_mult_builtin?(config), do: Frontier.has_ec_mult_builtin?(config.fallback_config)
-
-  @impl true
-  def has_ec_pairing_builtin?(config) do
-    Frontier.has_ec_pairing_builtin?(config.fallback_config)
-  end
-
-  @impl true
-  def has_shift_operations?(config) do
-    Frontier.has_shift_operations?(config.fallback_config)
-  end
-
-  @impl true
-  def has_extcodehash?(config), do: Frontier.has_extcodehash?(config.fallback_config)
-
-  @impl true
-  def has_create2?(config), do: Frontier.has_create2?(config.fallback_config)
-
-  @impl true
-  def eip1283_sstore_gas_cost_changed?(config) do
-    Frontier.eip1283_sstore_gas_cost_changed?(config.fallback_config)
+  def limit_contract_code_size?(config, _size) do
+    config.limit_contract_code_size
   end
 end

--- a/apps/evm/lib/evm/configuration/spurious_dragon.ex
+++ b/apps/evm/lib/evm/configuration/spurious_dragon.ex
@@ -1,122 +1,21 @@
 defmodule EVM.Configuration.SpuriousDragon do
-  @behaviour EVM.Configuration
-
   alias EVM.Configuration.TangerineWhistle
 
-  defstruct fallback_config: TangerineWhistle.new(),
-            exp_byte_cost: 50,
-            code_size_limit: 24_577,
-            increment_nonce_on_create: true,
-            empty_account_value_transfer: true,
-            clean_touched_accounts: true
-
-  @type t :: %__MODULE__{}
-
-  def new do
-    %__MODULE__{}
-  end
-
-  @impl true
-  def contract_creation_cost(config) do
-    TangerineWhistle.contract_creation_cost(config.fallback_config)
-  end
-
-  @impl true
-  def has_delegate_call?(config), do: TangerineWhistle.has_delegate_call?(config.fallback_config)
-
-  @impl true
-  def max_signature_s(config), do: TangerineWhistle.max_signature_s(config.fallback_config)
-
-  @impl true
-  def fail_contract_creation_lack_of_gas?(config) do
-    TangerineWhistle.fail_contract_creation_lack_of_gas?(config.fallback_config)
-  end
-
-  @impl true
-  def extcodesize_cost(config), do: TangerineWhistle.extcodesize_cost(config.fallback_config)
-
-  @impl true
-  def extcodecopy_cost(config), do: TangerineWhistle.extcodecopy_cost(config.fallback_config)
-
-  @impl true
-  def balance_cost(config), do: TangerineWhistle.balance_cost(config.fallback_config)
-
-  @impl true
-  def sload_cost(config), do: TangerineWhistle.sload_cost(config.fallback_config)
-
-  @impl true
-  def call_cost(config), do: TangerineWhistle.call_cost(config.fallback_config)
+  use EVM.Configuration,
+    fallback_config: TangerineWhistle,
+    overrides: %{
+      exp_byte_cost: 50,
+      code_size_limit: 24_577,
+      increment_nonce_on_create: true,
+      empty_account_value_transfer: true,
+      clean_touched_accounts: true
+    }
 
   @impl true
   def selfdestruct_cost(config, params) do
-    TangerineWhistle.selfdestruct_cost(config.fallback_config, params)
+    TangerineWhistle.selfdestruct_cost(config, params)
   end
-
-  @impl true
-  def fail_nested_operation_lack_of_gas?(config) do
-    TangerineWhistle.fail_nested_operation_lack_of_gas?(config.fallback_config)
-  end
-
-  @impl true
-  def exp_byte_cost(config), do: config.exp_byte_cost
 
   @impl true
   def limit_contract_code_size?(config, size), do: size >= config.code_size_limit
-
-  @impl true
-  def increment_nonce_on_create?(config), do: config.increment_nonce_on_create
-
-  @impl true
-  def empty_account_value_transfer?(config), do: config.empty_account_value_transfer
-
-  @impl true
-  def clean_touched_accounts?(config), do: config.clean_touched_accounts
-
-  @impl true
-  def has_revert?(config), do: TangerineWhistle.has_revert?(config.fallback_config)
-
-  @impl true
-  def has_static_call?(config), do: TangerineWhistle.has_static_call?(config.fallback_config)
-
-  @impl true
-  def support_variable_length_return_value?(config) do
-    TangerineWhistle.support_variable_length_return_value?(config.fallback_config)
-  end
-
-  @impl true
-  def has_mod_exp_builtin?(config),
-    do: TangerineWhistle.has_mod_exp_builtin?(config.fallback_config)
-
-  @impl true
-  def status_in_receipt?(config),
-    do: TangerineWhistle.status_in_receipt?(config.fallback_config)
-
-  @impl true
-  def has_ec_add_builtin?(config),
-    do: TangerineWhistle.has_ec_add_builtin?(config.fallback_config)
-
-  @impl true
-  def has_ec_mult_builtin?(config),
-    do: TangerineWhistle.has_ec_mult_builtin?(config.fallback_config)
-
-  @impl true
-  def has_ec_pairing_builtin?(config) do
-    TangerineWhistle.has_ec_pairing_builtin?(config.fallback_config)
-  end
-
-  @impl true
-  def has_shift_operations?(config) do
-    TangerineWhistle.has_shift_operations?(config.fallback_config)
-  end
-
-  @impl true
-  def has_extcodehash?(config), do: TangerineWhistle.has_extcodehash?(config.fallback_config)
-
-  @impl true
-  def has_create2?(config), do: TangerineWhistle.has_create2?(config.fallback_config)
-
-  @impl true
-  def eip1283_sstore_gas_cost_changed?(config) do
-    TangerineWhistle.eip1283_sstore_gas_cost_changed?(config.fallback_config)
-  end
 end

--- a/apps/evm/lib/evm/configuration/tangerine_whistle.ex
+++ b/apps/evm/lib/evm/configuration/tangerine_whistle.ex
@@ -1,52 +1,18 @@
 defmodule EVM.Configuration.TangerineWhistle do
-  @behaviour EVM.Configuration
-
   alias EVM.Configuration.Homestead
 
-  defstruct extcodesize_cost: 700,
-            extcodecopy_cost: 700,
-            balance_cost: 400,
-            sload_cost: 200,
-            call_cost: 700,
-            selfdestruct_cost: 5_000,
-            new_account_destruction_cost: 25_000,
-            fail_nested_operation: false,
-            fallback_config: Homestead.new()
-
-  @type t :: %__MODULE__{}
-
-  def new do
-    %__MODULE__{}
-  end
-
-  @impl true
-  def contract_creation_cost(config), do: config.fallback_config.contract_creation_cost
-
-  @impl true
-  def has_delegate_call?(config), do: config.fallback_config.has_delegate_call
-
-  @impl true
-  def max_signature_s(config), do: Homestead.max_signature_s(config.fallback_config)
-
-  @impl true
-  def fail_contract_creation_lack_of_gas?(config) do
-    config.fallback_config.fail_contract_creation
-  end
-
-  @impl true
-  def extcodesize_cost(config), do: config.extcodesize_cost
-
-  @impl true
-  def extcodecopy_cost(config), do: config.extcodecopy_cost
-
-  @impl true
-  def balance_cost(config), do: config.balance_cost
-
-  @impl true
-  def sload_cost(config), do: config.sload_cost
-
-  @impl true
-  def call_cost(config), do: config.call_cost
+  use EVM.Configuration,
+    fallback_config: Homestead,
+    overrides: %{
+      extcodesize_cost: 700,
+      extcodecopy_cost: 700,
+      balance_cost: 400,
+      sload_cost: 200,
+      call_cost: 700,
+      selfdestruct_cost: 5_000,
+      new_account_destruction_cost: 25_000,
+      should_fail_nested_operation_lack_of_gas: false
+    }
 
   @impl true
   def selfdestruct_cost(config, new_account: false), do: config.selfdestruct_cost
@@ -56,72 +22,7 @@ defmodule EVM.Configuration.TangerineWhistle do
   end
 
   @impl true
-  def fail_nested_operation_lack_of_gas?(config), do: config.fail_nested_operation
-
-  @impl true
-  def exp_byte_cost(config), do: Homestead.exp_byte_cost(config.fallback_config)
-
-  @impl true
-  def limit_contract_code_size?(config, size) do
-    Homestead.limit_contract_code_size?(config.fallback_config, size)
-  end
-
-  @impl true
-  def increment_nonce_on_create?(config) do
-    Homestead.increment_nonce_on_create?(config.fallback_config)
-  end
-
-  @impl true
-  def empty_account_value_transfer?(config) do
-    Homestead.empty_account_value_transfer?(config.fallback_config)
-  end
-
-  @impl true
-  def clean_touched_accounts?(config) do
-    Homestead.clean_touched_accounts?(config.fallback_config)
-  end
-
-  @impl true
-  def has_revert?(config), do: Homestead.has_revert?(config.fallback_config)
-
-  @impl true
-  def has_static_call?(config), do: Homestead.has_static_call?(config.fallback_config)
-
-  @impl true
-  def support_variable_length_return_value?(config) do
-    Homestead.support_variable_length_return_value?(config.fallback_config)
-  end
-
-  @impl true
-  def has_mod_exp_builtin?(config), do: Homestead.has_mod_exp_builtin?(config.fallback_config)
-
-  @impl true
-  def status_in_receipt?(config), do: Homestead.status_in_receipt?(config.fallback_config)
-
-  @impl true
-  def has_ec_add_builtin?(config), do: Homestead.has_ec_add_builtin?(config.fallback_config)
-
-  @impl true
-  def has_ec_mult_builtin?(config), do: Homestead.has_ec_mult_builtin?(config.fallback_config)
-
-  @impl true
-  def has_ec_pairing_builtin?(config) do
-    Homestead.has_ec_pairing_builtin?(config.fallback_config)
-  end
-
-  @impl true
-  def has_shift_operations?(config) do
-    Homestead.has_shift_operations?(config.fallback_config)
-  end
-
-  @impl true
-  def has_extcodehash?(config), do: Homestead.has_extcodehash?(config.fallback_config)
-
-  @impl true
-  def has_create2?(config), do: Homestead.has_create2?(config.fallback_config)
-
-  @impl true
-  def eip1283_sstore_gas_cost_changed?(config) do
-    Homestead.eip1283_sstore_gas_cost_changed?(config.fallback_config)
+  def limit_contract_code_size?(config, _size) do
+    config.limit_contract_code_size
   end
 end

--- a/apps/evm/lib/evm/functions.ex
+++ b/apps/evm/lib/evm/functions.ex
@@ -4,7 +4,7 @@ defmodule EVM.Functions do
   fit in other modules.
   """
 
-  alias EVM.{Configuration, ExecEnv, Gas, MachineCode, MachineState, Operation, Stack}
+  alias EVM.{ExecEnv, Gas, MachineCode, MachineState, Operation, Stack}
   alias EVM.Operation.Metadata
 
   @max_stack 1024
@@ -149,36 +149,36 @@ defmodule EVM.Functions do
 
       case operation_metadata.sym do
         :delegatecall ->
-          if Configuration.for(config).has_delegate_call?(config), do: operation_metadata
+          if config.has_delegate_call, do: operation_metadata
 
         :revert ->
-          if Configuration.for(config).has_revert?(config), do: operation_metadata
+          if config.has_revert, do: operation_metadata
 
         :staticcall ->
-          if Configuration.for(config).has_static_call?(config), do: operation_metadata
+          if config.has_static_call, do: operation_metadata
 
         :returndatasize ->
-          if Configuration.for(config).support_variable_length_return_value?(config),
+          if config.support_variable_length_return_value,
             do: operation_metadata
 
         :returndatacopy ->
-          if Configuration.for(config).support_variable_length_return_value?(config),
+          if config.support_variable_length_return_value,
             do: operation_metadata
 
         :shl ->
-          if Configuration.for(config).has_shift_operations?(config), do: operation_metadata
+          if config.has_shift_operations, do: operation_metadata
 
         :shr ->
-          if Configuration.for(config).has_shift_operations?(config), do: operation_metadata
+          if config.has_shift_operations, do: operation_metadata
 
         :sar ->
-          if Configuration.for(config).has_shift_operations?(config), do: operation_metadata
+          if config.has_shift_operations, do: operation_metadata
 
         :extcodehash ->
-          if Configuration.for(config).has_extcodehash?(config), do: operation_metadata
+          if config.has_extcodehash, do: operation_metadata
 
         :create2 ->
-          if Configuration.for(config).has_create2?(config), do: operation_metadata
+          if config.has_create2, do: operation_metadata
 
         _ ->
           operation_metadata

--- a/apps/evm/lib/evm/message_call.ex
+++ b/apps/evm/lib/evm/message_call.ex
@@ -315,16 +315,16 @@ defmodule EVM.MessageCall do
       address == 4 ->
         &Builtin.run_id/2
 
-      address == 5 && EVM.Configuration.for(config).has_mod_exp_builtin?(config) ->
+      address == 5 && config.has_mod_exp_builtin ->
         &Builtin.mod_exp/2
 
-      address == 6 && EVM.Configuration.for(config).has_ec_add_builtin?(config) ->
+      address == 6 && config.has_ec_add_builtin ->
         &Builtin.ec_add/2
 
-      address == 7 && EVM.Configuration.for(config).has_ec_mult_builtin?(config) ->
+      address == 7 && config.has_ec_mult_builtin ->
         &Builtin.ec_mult/2
 
-      address == 8 && EVM.Configuration.for(config).has_ec_pairing_builtin?(config) ->
+      address == 8 && config.has_ec_pairing_builtin ->
         &Builtin.ec_pairing/2
 
       true ->

--- a/apps/evm/lib/evm/operation/system.ex
+++ b/apps/evm/lib/evm/operation/system.ex
@@ -4,7 +4,6 @@ defmodule EVM.Operation.System do
 
   alias EVM.{
     Address,
-    Configuration,
     ExecEnv,
     Gas,
     MachineState,
@@ -280,7 +279,7 @@ defmodule EVM.Operation.System do
       value <= account_balance and exec_env.stack_depth < EVM.Functions.max_stack_depth()
 
     available_gas =
-      if Configuration.for(exec_env.config).fail_nested_operation_lack_of_gas?(exec_env.config) do
+      if exec_env.config.should_fail_nested_operation_lack_of_gas do
         machine_state.gas
       else
         EVM.Helpers.all_but_one_64th(machine_state.gas)

--- a/apps/evm/lib/evm/refunds/sstore.ex
+++ b/apps/evm/lib/evm/refunds/sstore.ex
@@ -6,7 +6,7 @@ defmodule EVM.Refunds.Sstore do
 
   @spec refund({integer(), integer()}, ExecEnv.t()) :: integer()
   def refund({key, new_value}, exec_env) do
-    if Configuration.for(exec_env.config).eip1283_sstore_gas_cost_changed?(exec_env.config) do
+    if exec_env.config.eip1283_sstore_gas_cost_changed do
       eip1283_sstore_refund({key, new_value}, exec_env)
     else
       basic_sstore_refund({key, new_value}, exec_env)


### PR DESCRIPTION
This is a suggested PR. If it doesn't seem like a good idea, I'd be happy to close this.

The problem
============

The EVM.Configuration files are full of repetitive implementations of functions that simply call the underlying key in a struct,

```elixir
def contract_creation_cost(config), do: config.contract_creation_cost
```

or functions that use a fallback config to call another module's
implementation,

```elixir
def extcodesize_cost(config), do: Frontier.extcodesize_cost(config.fallback_config)
```

This is a lot of duplication both in the functions we write but also in the calling code. We are doing the following a lot,

```elixir
Evm.Configuration.for(config).contrac_creation_cost(config)
```

when we could simply be doing,

```elixir
config.contract_creation_cost
```

In addition, it is currently difficult to understand the full configuration for a hardfork as a single snapshot, since a configuration like Byzantium can have SpuriousDragon's configuration nested within it, and it have TangerineWhistle nested within it, and it have Homestead, and it have Frontier:

```elixir
%Configuration.Byzantium{
 # fields
 fallback_config: %SpuriousDragon{
   # fields
   fallback_config: %TangerineWhistle{
     # fields
     fallback_config: %Homestead{
       # fields
       fallback_config: %Frontier{
         # fields
       }
     }
   }
  }
}
```

The solution
============

Since most of the configuration options are just static values, like boolean flags or some integer, we can simply use a "callback config" at the moment we are generating the structs. So for example, the `Homestead` `defstruct` definition can call `Frontier.new()` and override the values needed to generate its own struct.

This has the benefit of removing repetition in function definitions (with two exceptions), it improves ease of legibility of a configuration since we only have a single struct instead of having structs within structs within structs, and it also opens the possibility of future configurations that a user may want to define which do not match any single hardfork.

Note: with this solution we do lose the ability to have functions with `?` to help us understand whether or not the configuration returns a boolean. But with `has_` and `should_` prefixes to the configuration options to indicate that, I think we can make that tradeoff.