### PR TITLE
Add Warp Sync

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,7 @@ jobs:
             - apps
             - bin
             - config
+            - db/.gitkeep
             - deps
             - doc
             - mix.exs

--- a/apps/blockchain/lib/blockchain/account/storage.ex
+++ b/apps/blockchain/lib/blockchain/account/storage.ex
@@ -38,10 +38,15 @@ defmodule Blockchain.Account.Storage do
     if is_nil(result), do: nil, else: ExRLP.decode(result)
   end
 
-  @spec encode_key(integer()) :: Trie.key()
-  def encode_key(key) do
+  @spec encode_key(integer() | binary()) :: Trie.key()
+  def encode_key(key) when is_integer(key) do
     key
     |> BitHelper.encode_unsigned()
+    |> encode_key()
+  end
+
+  def encode_key(key) when is_binary(key) do
+    key
     |> BitHelper.pad(32)
     |> Keccak.kec()
   end

--- a/apps/blockchain/lib/blockchain/block.ex
+++ b/apps/blockchain/lib/blockchain/block.ex
@@ -344,11 +344,16 @@ defmodule Blockchain.Block do
     serialized_transaction =
       db
       |> Trie.new(block.header.transactions_root)
-      |> Trie.get_key(i |> ExRLP.encode())
+      |> Trie.get_key(ExRLP.encode(i))
 
     case serialized_transaction do
-      nil -> nil
-      _ -> Transaction.deserialize(serialized_transaction |> ExRLP.decode())
+      nil ->
+        nil
+
+      _ ->
+        serialized_transaction
+        |> ExRLP.decode()
+        |> Transaction.deserialize()
     end
   end
 

--- a/apps/blockchain/lib/blockchain/block_setter.ex
+++ b/apps/blockchain/lib/blockchain/block_setter.ex
@@ -18,12 +18,18 @@ defmodule Blockchain.BlockSetter do
 
       iex> Blockchain.Block.set_block_number(%Blockchain.Block{header: %Block.Header{extra_data: "hello"}}, %Blockchain.Block{header: %Block.Header{number: 32}})
       %Blockchain.Block{header: %Block.Header{number: 33, extra_data: "hello"}}
+
+      iex> Blockchain.Block.set_block_number(%Blockchain.Block{header: %Block.Header{extra_data: "hello"}}, %Blockchain.Block{header: %Block.Header{number: nil}})
+      %Blockchain.Block{header: %Block.Header{number: nil, extra_data: "hello"}}
   """
   @spec set_block_number(Block.t(), Block.t()) :: Block.t()
-  def set_block_number(block, parent_block) do
-    number = parent_block.header.number + 1
-    header = %{block.header | number: number}
-    %{block | header: header}
+  def set_block_number(block, %Block{header: %Header{number: nil}}) do
+    %{block | header: %{block.header | number: nil}}
+  end
+
+  def set_block_number(block, %Block{header: %Header{number: parent_block_number}})
+      when is_integer(parent_block_number) do
+    %{block | header: %{block.header | number: parent_block_number + 1}}
   end
 
   @doc """

--- a/apps/blockchain/lib/blockchain/blocktree.ex
+++ b/apps/blockchain/lib/blockchain/blocktree.ex
@@ -67,7 +67,7 @@ defmodule Blockchain.Blocktree do
   end
 
   @spec update_best_block(t, Block.t()) :: t
-  defp update_best_block(blocktree, block) do
+  def update_best_block(blocktree, block) do
     best_block = blocktree.best_block
 
     new_best_block =
@@ -77,7 +77,15 @@ defmodule Blockchain.Blocktree do
          do: block,
          else: best_block
 
-    %{blocktree | best_block: new_best_block}
+    # Make sure block is stored with a block hash
+    new_best_block_with_hash =
+      if new_best_block.block_hash == nil do
+        %{new_best_block | block_hash: Block.hash(new_best_block)}
+      else
+        new_best_block
+      end
+
+    %{blocktree | best_block: new_best_block_with_hash}
   end
 
   @doc """

--- a/apps/cli/lib/mix/tasks/mana.ex
+++ b/apps/cli/lib/mix/tasks/mana.ex
@@ -15,6 +15,10 @@ defmodule Mix.Tasks.Mana do
 
       mix mana --chain ropsten --discovery false --bootnodes enode://...
 
+      # Sync from a local node with warp (alpha)
+
+      mix mana --chain ropsten --discovery false --bootnodes enode://... --warp
+
       # Start main-net node
 
       mix mana --chain foundation
@@ -31,6 +35,7 @@ defmodule Mix.Tasks.Mana do
          discovery: discovery,
          sync: sync,
          bootnodes: bootnodes,
+         warp: warp,
          debug: debug
        }} ->
         :ok = Logger.warn("Starting mana chain #{Atom.to_string(chain_name)}...")
@@ -42,7 +47,8 @@ defmodule Mix.Tasks.Mana do
             chain: chain_name,
             sync: sync,
             discovery: discovery,
-            bootnodes: bootnodes
+            bootnodes: bootnodes,
+            warp: warp
           )
 
         {:ok, _} = Application.ensure_all_started(:ex_wire)

--- a/apps/cli/lib/parser/mana_parser.ex
+++ b/apps/cli/lib/parser/mana_parser.ex
@@ -7,6 +7,7 @@ defmodule CLI.Parser.ManaParser do
   @default_no_discovery false
   @default_no_sync false
   @default_bootnodes "from_chain"
+  @default_warp false
   @default_debug false
 
   @doc """
@@ -17,6 +18,7 @@ defmodule CLI.Parser.ManaParser do
     * `--no-discovery` - Perform discovery (default: false)
     * `--no-sync` - Perform syncing (default: false)
     * `--bootnodes` - Comma separated list of bootnodes (default: from_chain)
+    * `--warp` - Perform warp sync (default: false)
     * `--debug` - Add remote debugging (default: false)
 
   ## Examples
@@ -27,15 +29,17 @@ defmodule CLI.Parser.ManaParser do
         discovery: false,
         sync: false,
         bootnodes: :from_chain,
+        warp: false,
         debug: false
       }}
 
-      iex> CLI.Parser.ManaParser.mana_args(["--chain", "foundation", "--bootnodes", "enode://google.com,enode://apple.com", "--debug"])
+      iex> CLI.Parser.ManaParser.mana_args(["--chain", "foundation", "--bootnodes", "enode://google.com,enode://apple.com", "--warp", "--debug"])
       {:ok, %{
         chain_name: :foundation,
         discovery: true,
         sync: true,
         bootnodes: ["enode://google.com", "enode://apple.com"],
+        warp: true,
         debug: true
       }}
 
@@ -45,6 +49,7 @@ defmodule CLI.Parser.ManaParser do
         discovery: true,
         sync: true,
         bootnodes: :from_chain,
+        warp: false,
         debug: false
       }}
 
@@ -58,6 +63,7 @@ defmodule CLI.Parser.ManaParser do
              discovery: boolean(),
              sync: boolean(),
              bootnodes: :from_chain | list(String.t()),
+             warp: boolean(),
              debug: boolean()
            }}
           | {:error, String.t()}
@@ -69,6 +75,7 @@ defmodule CLI.Parser.ManaParser do
           no_discovery: :boolean,
           no_sync: :boolean,
           bootnodes: :string,
+          warp: :boolean,
           debug: :boolean
         ]
       )
@@ -77,6 +84,7 @@ defmodule CLI.Parser.ManaParser do
          {:ok, discovery} <- get_discovery(kw_args),
          {:ok, sync} <- get_sync(kw_args),
          {:ok, bootnodes} <- get_bootnodes(kw_args),
+         {:ok, warp} <- get_warp(kw_args),
          {:ok, debug} <- get_debug(kw_args) do
       {:ok,
        %{
@@ -84,6 +92,7 @@ defmodule CLI.Parser.ManaParser do
          discovery: discovery,
          sync: sync,
          bootnodes: bootnodes,
+         warp: warp,
          debug: debug
        }}
     end
@@ -138,6 +147,15 @@ defmodule CLI.Parser.ManaParser do
       _ ->
         {:ok, String.split(given_bootnodes, ",")}
     end
+  end
+
+  @spec get_warp(warp: boolean()) :: {:ok, boolean()} | {:error, String.t()}
+  defp get_warp(kw_args) do
+    given_warp =
+      kw_args
+      |> Keyword.get(:warp, @default_warp)
+
+    {:ok, given_warp}
   end
 
   @spec get_debug(debug: boolean()) :: {:ok, boolean()} | {:error, String.t()}

--- a/apps/ex_wire/config/config.exs
+++ b/apps/ex_wire/config/config.exs
@@ -27,10 +27,7 @@ mana_version =
 config :ex_wire,
   p2p_version: 0x04,
   protocol_version: 63,
-  # ropsten
-  network_id: 3,
-  caps: [{"eth", 62}, {"eth", 63}],
-  chain: :ropsten,
+  caps: [{"eth", 62}, {"eth", 63}, {"par", 1}],
   # TODO: This should be set and stored in a file
   private_key: :random,
   bootnodes: :from_chain,
@@ -43,7 +40,8 @@ config :ex_wire,
     port: 30_304
   ],
   db_root: db_root,
-  mana_version: mana_version
+  mana_version: mana_version,
+  warp: false
 
 config :ex_wire, :environment, Mix.env()
 import_config "#{Mix.env()}.exs"

--- a/apps/ex_wire/config/dev.exs
+++ b/apps/ex_wire/config/dev.exs
@@ -2,8 +2,8 @@ use Mix.Config
 
 config :ex_wire,
   network_adapter: {ExWire.Adapter.UDP, NetworkClient},
-  sync: true,
-  discovery: true,
+  sync: false,
+  discovery: false,
   private_key:
     <<10, 122, 189, 137, 166, 190, 127, 238, 229, 16, 211, 182, 104, 78, 138, 37, 146, 116, 90,
       68, 76, 86, 168, 24, 200, 155, 0, 99, 58, 226, 211, 30>>,

--- a/apps/ex_wire/config/test.exs
+++ b/apps/ex_wire/config/test.exs
@@ -7,8 +7,9 @@ config :ex_wire,
   node_discovery: [
     network_adapter: {ExWire.Adapter.UDP, :test_network_adapter},
     supervisor_name: ExWire.NodeDiscoverySupervisor,
-    port: 30_304
+    port: 30_399
   ],
   sync_mock: ExWire.BridgeSyncMock,
   discovery: false,
-  sync: false
+  sync: false,
+  chain: :ropsten

--- a/apps/ex_wire/lib/ex_wire/config.ex
+++ b/apps/ex_wire/lib/ex_wire/config.ex
@@ -21,13 +21,13 @@ defmodule ExWire.Config do
           | :db_root
           | :discovery
           | :mana_version
-          | :network_id
           | :node_discovery
           | :p2p_version
           | :private_key
           | :protocol_version
           | :public_ip
           | :sync
+          | :warp
 
   @doc """
   Allows application to configure ExWire before it starts.
@@ -130,11 +130,6 @@ defmodule ExWire.Config do
     get_env(given_params, :protocol_version)
   end
 
-  @spec network_id(Keyword.t()) :: integer()
-  def network_id(given_params \\ []) do
-    get_env(given_params, :network_id)
-  end
-
   @spec p2p_version(Keyword.t()) :: integer()
   def p2p_version(given_params \\ []) do
     get_env(given_params, :p2p_version)
@@ -154,6 +149,11 @@ defmodule ExWire.Config do
   @spec perform_sync?(Keyword.t()) :: boolean()
   def perform_sync?(given_params \\ []) do
     get_env(given_params, :sync)
+  end
+
+  @spec warp?(Keyword.t()) :: boolean()
+  def warp?(given_params \\ []) do
+    get_env(given_params, :warp)
   end
 
   @spec bootnodes(Keyword.t()) :: [String.t()]
@@ -180,7 +180,7 @@ defmodule ExWire.Config do
     end
   end
 
-  @spec db_name(Chain.t()) :: nonempty_charlist()
+  @spec db_name(Chain.t()) :: charlist()
   def db_name(chain) do
     db_root = get_env!([], :db_root)
     chain_db_path = Path.join(db_root, "mana-#{String.downcase(chain.name)}")

--- a/apps/ex_wire/lib/ex_wire/handshake/struct/ack_resp_v4.ex
+++ b/apps/ex_wire/lib/ex_wire/handshake/struct/ack_resp_v4.ex
@@ -24,15 +24,18 @@ defmodule ExWire.Handshake.Struct.AckRespV4 do
     [
       ack_resp.recipient_ephemeral_public_key,
       ack_resp.recipient_nonce,
-      ack_resp.recipient_version |> :binary.encode_unsigned()
+      :binary.encode_unsigned(ack_resp.recipient_version)
     ]
   end
 
   @spec deserialize(ExRLP.t()) :: t
   def deserialize(rlp) do
-    [recipient_ephemeral_public_key | rlp_tail] = rlp
-    [recipient_nonce | rlp_tail] = rlp_tail
-    [recipient_version | _tl] = rlp_tail
+    [
+      recipient_ephemeral_public_key,
+      recipient_nonce,
+      recipient_version
+      | _tl
+    ] = rlp
 
     %__MODULE__{
       recipient_ephemeral_public_key: recipient_ephemeral_public_key,

--- a/apps/ex_wire/lib/ex_wire/p2p/server.ex
+++ b/apps/ex_wire/lib/ex_wire/p2p/server.ex
@@ -110,7 +110,7 @@ defmodule ExWire.P2P.Server do
   """
   @spec get_peer(pid()) :: Peer.t()
   def get_peer(pid) do
-    GenServer.call(pid, :get_peer)
+    GenServer.call(pid, :get_peer, :infinity)
   end
 
   @doc """

--- a/apps/ex_wire/lib/ex_wire/packet/capability/par.ex
+++ b/apps/ex_wire/lib/ex_wire/packet/capability/par.ex
@@ -1,0 +1,49 @@
+defmodule ExWire.Packet.Capability.Par do
+  alias ExWire.Config
+  alias ExWire.Packet.Capability
+  alias ExWire.Packet.Capability.Par
+
+  @behaviour Capability
+
+  @name "par"
+
+  @version_to_packet_types %{
+    1 => [
+      Par.WarpStatus,
+      Par.GetSnapshotManifest,
+      Par.SnapshotManifest,
+      Par.GetSnapshotData,
+      Par.SnapshotData
+    ]
+  }
+
+  @available_versions Map.keys(@version_to_packet_types)
+  @configured_versions Config.caps()
+                       |> Enum.filter(fn cap -> cap.name == @name end)
+                       |> Enum.map(fn cap -> cap.version end)
+
+  @supported_versions Enum.filter(@available_versions, fn el ->
+                        Enum.member?(@configured_versions, el)
+                      end)
+
+  @impl true
+  def get_name() do
+    @name
+  end
+
+  @impl true
+  def get_supported_versions() do
+    @supported_versions
+  end
+
+  @impl true
+  def get_packet_types(version) do
+    case Map.get(@version_to_packet_types, version) do
+      nil ->
+        :unsupported_version
+
+      packet_types ->
+        packet_types
+    end
+  end
+end

--- a/apps/ex_wire/lib/ex_wire/packet/capability/par/get_snapshot_data.ex
+++ b/apps/ex_wire/lib/ex_wire/packet/capability/par/get_snapshot_data.ex
@@ -1,0 +1,76 @@
+defmodule ExWire.Packet.Capability.Par.GetSnapshotData do
+  @moduledoc """
+  Request a chunk (identified by the given hash) from a peer.
+
+  ```
+  `GetSnapshotData` [`0x13`, `chunk_hash`: B_32]
+  ```
+  """
+
+  @behaviour ExWire.Packet
+
+  @type t :: %__MODULE__{
+          chunk_hash: EVM.hash()
+        }
+
+  defstruct [
+    :chunk_hash
+  ]
+
+  @doc """
+  Returns the relative message id offset for this message.
+  This will help determine what its message ID is relative to other Packets in the same Capability.
+  """
+  @impl true
+  @spec message_id_offset() :: 0x13
+  def message_id_offset do
+    0x13
+  end
+
+  @doc """
+  Given a GetSnapshotData packet, serializes for transport over Eth Wire Protocol.
+
+  ## Examples
+
+      iex> %ExWire.Packet.Capability.Par.GetSnapshotData{chunk_hash: <<1::256>>}
+      ...> |> ExWire.Packet.Capability.Par.GetSnapshotData.serialize()
+      [<<1::256>>]
+  """
+  @impl true
+  def serialize(%__MODULE__{chunk_hash: chunk_hash}) do
+    [
+      chunk_hash
+    ]
+  end
+
+  @doc """
+  Given an RLP-encoded GetSnapshotData packet from Eth Wire Protocol,
+  decodes into a GetSnapshotData struct.
+
+  ## Examples
+
+      iex> ExWire.Packet.Capability.Par.GetSnapshotData.deserialize([<<1::256>>])
+      %ExWire.Packet.Capability.Par.GetSnapshotData{chunk_hash: <<1::256>>}
+  """
+  @impl true
+  def deserialize(rlp) do
+    [chunk_hash] = rlp
+
+    %__MODULE__{chunk_hash: chunk_hash}
+  end
+
+  @doc """
+  Handles a GetSnapshotData message. We should send our manifest
+  to the peer. For now, we'll do nothing.
+
+  ## Examples
+
+      iex> %ExWire.Packet.Capability.Par.GetSnapshotData{}
+      ...> |> ExWire.Packet.Capability.Par.GetSnapshotData.handle()
+      :ok
+  """
+  @impl true
+  def handle(_packet = %__MODULE__{}) do
+    :ok
+  end
+end

--- a/apps/ex_wire/lib/ex_wire/packet/capability/par/get_snapshot_manifest.ex
+++ b/apps/ex_wire/lib/ex_wire/packet/capability/par/get_snapshot_manifest.ex
@@ -1,0 +1,70 @@
+defmodule ExWire.Packet.Capability.Par.GetSnapshotManifest do
+  @moduledoc """
+  Request a snapshot manifest in RLP form from a peer.
+
+  ```
+  `GetSnapshotManifest` [`0x11`]
+  ```
+  """
+
+  @behaviour ExWire.Packet
+
+  @type t :: %__MODULE__{}
+
+  defstruct []
+
+  @doc """
+  Returns the relative message id offset for this message.
+  This will help determine what its message ID is relative to other Packets in the same Capability.
+  """
+  @impl true
+  @spec message_id_offset() :: 0x11
+  def message_id_offset do
+    0x11
+  end
+
+  @doc """
+  Given a GetSnapshotManifest packet, serializes for transport over Eth Wire Protocol.
+
+  ## Examples
+
+      iex> %ExWire.Packet.Capability.Par.GetSnapshotManifest{}
+      ...> |> ExWire.Packet.Capability.Par.GetSnapshotManifest.serialize()
+      []
+  """
+  @impl true
+  def serialize(_packet = %__MODULE__{}) do
+    []
+  end
+
+  @doc """
+  Given an RLP-encoded GetSnapshotManifest packet from Eth Wire Protocol,
+  decodes into a GetSnapshotManifest struct.
+
+  ## Examples
+
+      iex> ExWire.Packet.Capability.Par.GetSnapshotManifest.deserialize([])
+      %ExWire.Packet.Capability.Par.GetSnapshotManifest{}
+  """
+  @impl true
+  def deserialize(rlp) do
+    [] = rlp
+
+    %__MODULE__{}
+  end
+
+  @doc """
+  Handles a GetSnapshotManifest message. We should send our manifest
+  to the peer. For now, we'll do nothing.
+
+  ## Examples
+
+      iex> %ExWire.Packet.Capability.Par.GetSnapshotManifest{}
+      ...> |> ExWire.Packet.Capability.Par.GetSnapshotManifest.handle()
+      :ok
+  """
+  @impl true
+  def handle(_packet = %__MODULE__{}) do
+    :ok
+  end
+end

--- a/apps/ex_wire/lib/ex_wire/packet/capability/par/snapshot_data.ex
+++ b/apps/ex_wire/lib/ex_wire/packet/capability/par/snapshot_data.ex
@@ -1,0 +1,164 @@
+defmodule ExWire.Packet.Capability.Par.SnapshotData do
+  @moduledoc """
+  Respond to a GetSnapshotData message with either an empty RLP list or a
+  1-item RLP list containing the raw chunk data requested.
+
+  ```
+  `SnapshotData` [`0x14`, `chunk_data` or nothing]
+  ```
+  """
+  alias ExthCrypto.Hash.Keccak
+  alias ExWire.Packet.Capability.Par.SnapshotData.{BlockChunk, StateChunk}
+  require Logger
+
+  @behaviour ExWire.Packet
+
+  @type t :: %__MODULE__{
+          hash: EVM.hash(),
+          chunk: BlockChunk.t() | StateChunk.t() | nil
+        }
+
+  defstruct [:hash, :chunk]
+
+  @doc """
+  Returns the relative message id offset for this message.
+  This will help determine what its message ID is relative to other Packets in the same Capability.
+  """
+  @impl true
+  @spec message_id_offset() :: 0x14
+  def message_id_offset do
+    0x14
+  end
+
+  @doc """
+  Given a SnapshotData packet, serializes for transport over Eth Wire Protocol.
+
+  ## Examples
+
+      iex> %ExWire.Packet.Capability.Par.SnapshotData{
+      ...>   chunk: %ExWire.Packet.Capability.Par.SnapshotData.BlockChunk{
+      ...>     number: 5,
+      ...>     hash: <<6::256>>,
+      ...>     total_difficulty: 7,
+      ...>     block_data_list: []
+      ...>    }
+      ...> }
+      ...> |> ExWire.Packet.Capability.Par.SnapshotData.serialize()
+      [<<36, 12, 227, 5, 160, 0, 118, 1, 0, 4, 6, 7>>]
+
+      iex> %ExWire.Packet.Capability.Par.SnapshotData{
+      ...>   chunk: %ExWire.Packet.Capability.Par.SnapshotData.StateChunk{
+      ...>     account_entries: [
+      ...>       {
+      ...>         <<1::256>>,
+      ...>         %ExWire.Packet.Capability.Par.SnapshotData.StateChunk.RichAccount{
+      ...>           nonce: 2,
+      ...>           balance: 3,
+      ...>           code_flag: :has_code,
+      ...>           code: <<5::256>>,
+      ...>           storage: [{<<1::256>>, <<2::256>>}]
+      ...>         }
+      ...>       }
+      ...>     ]
+      ...>   }
+      ...> }
+      ...> |> ExWire.Packet.Capability.Par.SnapshotData.serialize()
+      [<<145, 1, 20, 248, 143, 248, 141, 160, 0, 118, 1, 0, 20, 1, 248, 106, 2, 3, 1, 126, 38, 0, 16, 5, 248, 68, 248, 66, 126, 37, 0, 130, 70, 0, 0, 2>>]
+  """
+  @impl true
+  def serialize(%__MODULE__{chunk: chunk = %{__struct__: mod}}) do
+    {:ok, res} =
+      chunk
+      |> mod.serialize()
+      |> ExRLP.encode()
+      |> :snappyer.compress()
+
+    [res]
+  end
+
+  @doc """
+  Given an RLP-encoded SnapshotData packet from Eth Wire Protocol,
+  decodes into a SnapshotData struct.
+
+  ## Examples
+
+      iex> [<<36, 12, 227, 5, 160, 0, 118, 1, 0, 4, 6, 7>>]
+      ...> |> ExWire.Packet.Capability.Par.SnapshotData.deserialize()
+      %ExWire.Packet.Capability.Par.SnapshotData{
+        chunk: %ExWire.Packet.Capability.Par.SnapshotData.BlockChunk{
+          number: 5,
+          hash: <<6::256>>,
+          total_difficulty: 7,
+          block_data_list: []
+         },
+         hash: <<221, 170, 108, 39, 117, 113, 13, 3, 231, 40, 69, 49, 126, 6,
+                 109, 164, 92, 237, 157, 243, 181, 196, 88, 128, 192, 177, 109,
+                 36, 77, 236, 86, 196>>
+      }
+
+      iex> [<<145, 1, 20, 248, 143, 248, 141, 160, 0, 118, 1, 0, 20, 1, 248,
+      ...>    106, 2, 3, 1, 126, 38, 0, 16, 5, 248, 68, 248, 66, 126, 37, 0,
+      ...>    130, 70, 0, 0, 2>>]
+      ...> |> ExWire.Packet.Capability.Par.SnapshotData.deserialize()
+      %ExWire.Packet.Capability.Par.SnapshotData{
+        chunk: %ExWire.Packet.Capability.Par.SnapshotData.StateChunk{
+          account_entries: [
+            {
+              <<1::256>>,
+              %ExWire.Packet.Capability.Par.SnapshotData.StateChunk.RichAccount{
+                nonce: 2,
+                balance: 3,
+                code_flag: :has_code,
+                code: <<5::256>>,
+                storage: [{<<1::256>>, <<2::256>>}]
+              }
+            }
+          ]
+        },
+        hash: <<8, 203, 227, 135, 24, 92, 98, 193, 28, 230, 1, 177, 51, 95,
+                135, 13, 223, 76, 129, 212, 190, 45, 44, 204, 198, 38, 249,
+                186, 174, 18, 121, 52>>
+      }
+  """
+  @impl true
+  def deserialize(rlp) do
+    [chunk_data] = rlp
+
+    hash = Keccak.kec(chunk_data)
+
+    {:ok, chunk_rlp_encoded} = :snappyer.decompress(chunk_data)
+
+    chunk_rlp = ExRLP.decode(chunk_rlp_encoded)
+
+    # Quick way to determine if chunk is a block chunk or state chunk is that
+    # state chunks start with a list element where block chunks do not.
+    chunk =
+      case chunk_rlp do
+        [] ->
+          nil
+
+        [el | _rest] when is_list(el) ->
+          StateChunk.deserialize(chunk_rlp)
+
+        _ ->
+          BlockChunk.deserialize(chunk_rlp)
+      end
+
+    %__MODULE__{chunk: chunk, hash: hash}
+  end
+
+  @doc """
+  Handles a SnapshotData message. We should send our manifest
+  to the peer. For now, we'll do nothing.
+
+  ## Examples
+
+      iex> %ExWire.Packet.Capability.Par.SnapshotData{}
+      ...> |> ExWire.Packet.Capability.Par.SnapshotData.handle()
+      :ok
+  """
+  @impl true
+  def handle(_packet = %__MODULE__{}) do
+    :ok
+  end
+end

--- a/apps/ex_wire/lib/ex_wire/packet/capability/par/snapshot_data/block_chunk.ex
+++ b/apps/ex_wire/lib/ex_wire/packet/capability/par/snapshot_data/block_chunk.ex
@@ -1,0 +1,293 @@
+defmodule ExWire.Packet.Capability.Par.SnapshotData.BlockChunk do
+  @moduledoc """
+  Block chunks contain raw block data: blocks themselves, and their transaction
+  receipts. The blocks are stored in the "abridged block" format (referred to
+  by AB), and the the receipts are stored in a list: [`receipt_1`: `P`,
+  `receipt_2`: `P`, ...] (referred to by RC).
+  """
+
+  defmodule BlockHeader do
+    @type t :: %__MODULE__{
+            # Header fields
+            author: EVM.address(),
+            state_root: EVM.hash(),
+            logs_bloom: <<_::2048>>,
+            difficulty: integer(),
+            gas_limit: integer(),
+            gas_used: integer(),
+            timestamp: integer(),
+            extra_data: integer(),
+
+            # Ommers and transactions inline
+            transactions: list(Blockchain.Transaction.t()),
+            transactions_rlp: list(ExRLP.t()),
+            ommers: list(Block.Header.t()),
+            ommers_rlp: list(ExRLP.t()),
+
+            # Seal fields
+            mix_hash: EVM.hash(),
+            nonce: <<_::64>>
+          }
+
+    defstruct [
+      :author,
+      :state_root,
+      :logs_bloom,
+      :difficulty,
+      :gas_limit,
+      :gas_used,
+      :timestamp,
+      :extra_data,
+      :transactions,
+      :transactions_rlp,
+      :ommers,
+      :ommers_rlp,
+      :mix_hash,
+      :nonce
+    ]
+  end
+
+  defmodule BlockData do
+    @type t :: %__MODULE__{
+            header: BlockHeader.t(),
+            receipts: list(Blockchain.Transaction.Receipt.t()),
+            receipts_rlp: list(ExRLP.t())
+          }
+    defstruct [
+      :header,
+      :receipts,
+      :receipts_rlp
+    ]
+  end
+
+  @type t :: %__MODULE__{
+          number: integer(),
+          hash: EVM.hash(),
+          total_difficulty: integer(),
+          block_data_list: list(BlockData.t())
+        }
+
+  defstruct number: nil,
+            hash: nil,
+            total_difficulty: nil,
+            block_data_list: []
+
+  @doc """
+  Given a `BlockChunk`, serializes for transport within a SnapshotData packet.
+
+  ## Examples
+
+      iex> %ExWire.Packet.Capability.Par.SnapshotData.BlockChunk{
+      ...>   number: 5,
+      ...>   hash: <<6::256>>,
+      ...>   total_difficulty: 7,
+      ...>   block_data_list: [
+      ...>     %ExWire.Packet.Capability.Par.SnapshotData.BlockChunk.BlockData{
+      ...>       header: %ExWire.Packet.Capability.Par.SnapshotData.BlockChunk.BlockHeader{
+      ...>         author: <<10::160>>,
+      ...>         state_root: <<11::256>>,
+      ...>         logs_bloom: <<12::2048>>,
+      ...>         difficulty: 13,
+      ...>         gas_limit: 14,
+      ...>         gas_used: 15,
+      ...>         timestamp: 16,
+      ...>         extra_data: 17,
+      ...>         transactions: [
+      ...>           %Blockchain.Transaction{nonce: 5, gas_price: 6, gas_limit: 7, to: <<1::160>>, value: 8, v: 27, r: 9, s: 10, data: "hi"}
+      ...>         ],
+      ...>         ommers: [
+      ...>           %Block.Header{parent_hash: <<1::256>>, ommers_hash: <<2::256>>, beneficiary: <<3::160>>, state_root: <<4::256>>, transactions_root: <<5::256>>, receipts_root: <<6::256>>, logs_bloom: <<>>, difficulty: 5, number: 1, gas_limit: 5, gas_used: 3, timestamp: 6, extra_data: "Hi mom", mix_hash: <<7::256>>, nonce: <<8::64>>}
+      ...>         ],
+      ...>         mix_hash: <<18::256>>,
+      ...>         nonce: <<19::64>>,
+      ...>       },
+      ...>       receipts: [
+      ...>         %Blockchain.Transaction.Receipt{state: <<1,2,3>>, cumulative_gas: 5, bloom_filter: <<2,3,4>>, logs: []}
+      ...>       ]
+      ...>     }
+      ...>   ]
+      ...> }
+      ...> |> ExWire.Packet.Capability.Par.SnapshotData.BlockChunk.serialize()
+      [
+        5,
+        <<6::256>>,
+        7,
+        [
+          [
+            <<10::160>>,
+            <<11::256>>,
+            <<12::2048>>,
+            13,
+            14,
+            15,
+            16,
+            17,
+            [[<<5>>, <<6>>, <<7>>, <<1::160>>, <<8>>, "hi", <<27>>, <<9>>, <<10>>]],
+            [[<<1::256>>, <<2::256>>, <<3::160>>, <<4::256>>, <<5::256>>, <<6::256>>, <<>>, 5, 1, 5, 3, 6, "Hi mom", <<7::256>>, <<8::64>>]],
+            <<18::256>>,
+            <<19::64>>
+          ],
+          [
+            [<<1,2,3>>, 5, <<2,3,4>>, []]
+          ]
+        ]
+      ]
+  """
+  @spec serialize(t) :: ExRLP.t()
+  def serialize(block_chunk = %__MODULE__{}) do
+    serialized_block_data =
+      for block_data <- block_chunk.block_data_list do
+        [
+          [
+            block_data.header.author,
+            block_data.header.state_root,
+            block_data.header.logs_bloom,
+            block_data.header.difficulty,
+            block_data.header.gas_limit,
+            block_data.header.gas_used,
+            block_data.header.timestamp,
+            block_data.header.extra_data,
+            Enum.map(block_data.header.transactions, &Blockchain.Transaction.serialize/1),
+            Enum.map(block_data.header.ommers, &Block.Header.serialize/1),
+            block_data.header.mix_hash,
+            block_data.header.nonce
+          ],
+          Enum.map(block_data.receipts, &Blockchain.Transaction.Receipt.serialize/1)
+        ]
+      end
+
+    [
+      block_chunk.number,
+      block_chunk.hash,
+      block_chunk.total_difficulty
+    ] ++ serialized_block_data
+  end
+
+  @doc """
+  Given an RLP-encoded `BlockChunk` from a SnapshotData packet, decodes into a
+  `BlockChunk` struct.
+
+  ## Examples
+
+      iex> [
+      ...>   <<5>>,
+      ...>   <<6::256>>,
+      ...>   <<7>>,
+      ...>   [
+      ...>     [
+      ...>       <<10::160>>,
+      ...>       <<11::256>>,
+      ...>       <<12::2048>>,
+      ...>       13,
+      ...>       14,
+      ...>       15,
+      ...>       16,
+      ...>       17,
+      ...>       [[<<5>>, <<6>>, <<7>>, <<1::160>>, <<8>>, "hi", <<27>>, <<9>>, <<10>>]],
+      ...>       [[<<1::256>>, <<2::256>>, <<3::160>>, <<4::256>>, <<5::256>>, <<6::256>>, <<>>, <<5>>, <<1>>, <<5>>, <<3>>, <<6>>, "Hi mom", <<7::256>>, <<8::64>>]],
+      ...>       <<18::256>>,
+      ...>       <<19::64>>
+      ...>     ],
+      ...>     [
+      ...>       [<<1,2,3>>, <<5>>, <<2,3,4>>, []]
+      ...>     ]
+      ...>   ]
+      ...> ]
+      ...> |> ExWire.Packet.Capability.Par.SnapshotData.BlockChunk.deserialize()
+      %ExWire.Packet.Capability.Par.SnapshotData.BlockChunk{
+        number: 5,
+        hash: <<6::256>>,
+        total_difficulty: 7,
+        block_data_list: [
+          %ExWire.Packet.Capability.Par.SnapshotData.BlockChunk.BlockData{
+            header: %ExWire.Packet.Capability.Par.SnapshotData.BlockChunk.BlockHeader{
+              author: <<10::160>>,
+              state_root: <<11::256>>,
+              logs_bloom: <<12::2048>>,
+              difficulty: 13,
+              gas_limit: 14,
+              gas_used: 15,
+              timestamp: 16,
+              extra_data: 17,
+              transactions: [
+                %Blockchain.Transaction{nonce: 5, gas_price: 6, gas_limit: 7, to: <<1::160>>, value: 8, v: 27, r: 9, s: 10, data: "hi"}
+              ],
+              transactions_rlp: [[<<5>>, <<6>>, <<7>>, <<1::160>>, <<8>>, "hi", <<27>>, <<9>>, <<10>>]],
+              ommers: [
+                %Block.Header{parent_hash: <<1::256>>, ommers_hash: <<2::256>>, beneficiary: <<3::160>>, state_root: <<4::256>>, transactions_root: <<5::256>>, receipts_root: <<6::256>>, logs_bloom: <<>>, difficulty: 5, number: 1, gas_limit: 5, gas_used: 3, timestamp: 6, extra_data: "Hi mom", mix_hash: <<7::256>>, nonce: <<8::64>>}
+              ],
+              ommers_rlp: [[<<1::256>>, <<2::256>>, <<3::160>>, <<4::256>>, <<5::256>>, <<6::256>>, <<>>, <<5>>, <<1>>, <<5>>, <<3>>, <<6>>, "Hi mom", <<7::256>>, <<8::64>>]],
+              mix_hash: <<18::256>>,
+              nonce: <<19::64>>,
+            },
+            receipts: [
+              %Blockchain.Transaction.Receipt{state: <<1,2,3>>, cumulative_gas: 5, bloom_filter: <<2,3,4>>, logs: []}
+            ],
+            receipts_rlp: [[<<1,2,3>>, <<5>>, <<2,3,4>>, []]]
+          }
+        ]
+      }
+  """
+  @spec deserialize(ExRLP.t()) :: t
+  def deserialize(rlp) do
+    [
+      number,
+      hash,
+      total_difficulty
+      | serialized_block_data
+    ] = rlp
+
+    block_data_list =
+      for block_data_rlp <- serialized_block_data do
+        [
+          [
+            author,
+            state_root,
+            logs_bloom,
+            difficulty,
+            gas_limit,
+            gas_used,
+            timestamp,
+            extra_data,
+            transactions_rlp,
+            ommers_rlp,
+            mix_hash,
+            nonce
+          ],
+          receipts_rlp
+        ] = block_data_rlp
+
+        transactions = Enum.map(transactions_rlp, &Blockchain.Transaction.deserialize/1)
+        ommers = Enum.map(ommers_rlp, &Block.Header.deserialize/1)
+        receipts = Enum.map(receipts_rlp, &Blockchain.Transaction.Receipt.deserialize/1)
+
+        %BlockData{
+          header: %BlockHeader{
+            author: author,
+            state_root: state_root,
+            logs_bloom: logs_bloom,
+            difficulty: Exth.maybe_decode_unsigned(difficulty),
+            gas_limit: Exth.maybe_decode_unsigned(gas_limit),
+            gas_used: Exth.maybe_decode_unsigned(gas_used),
+            timestamp: Exth.maybe_decode_unsigned(timestamp),
+            extra_data: extra_data,
+            transactions: transactions,
+            transactions_rlp: transactions_rlp,
+            ommers: ommers,
+            ommers_rlp: ommers_rlp,
+            mix_hash: mix_hash,
+            nonce: nonce
+          },
+          receipts: receipts,
+          receipts_rlp: receipts_rlp
+        }
+      end
+
+    %__MODULE__{
+      number: Exth.maybe_decode_unsigned(number),
+      hash: hash,
+      total_difficulty: Exth.maybe_decode_unsigned(total_difficulty),
+      block_data_list: block_data_list
+    }
+  end
+end

--- a/apps/ex_wire/lib/ex_wire/packet/capability/par/snapshot_data/state_chunk.ex
+++ b/apps/ex_wire/lib/ex_wire/packet/capability/par/snapshot_data/state_chunk.ex
@@ -1,0 +1,198 @@
+defmodule ExWire.Packet.Capability.Par.SnapshotData.StateChunk do
+  @moduledoc """
+  State chunks store the entire state of a given block. A "rich" account
+  structure is used to save space. Each state chunk consists of a list of
+  lists, each with two items: an address' sha3 hash and a rich account
+  structure correlating with it.
+  """
+
+  defmodule RichAccount do
+    @moduledoc """
+    The rich account structure encodes the usual account data such as the
+    nonce, balance, and code, as well as the full storage.
+
+    Note: `code_flag` is a single byte which will determine what the `code`
+          data will be:
+      * if 0x00, the account has no code and code is the single byte 0x80,
+                 signifying RLP empty data.
+      * if 0x01, the account has code, and code stores an arbitrary-length list
+                 of bytes containing the code.
+      * if 0x02, the account has code, and code stores a 32-byte big-endian
+                 integer which is the hash of the code. The code’s hash must be
+                 substituted if and only if another account which has a smaller
+                 account entry has the same code.
+
+    Note: `storage` is a list of the entire account’s storage, where the items
+          are RLP lists of length two – the first item being sha3(key), and the
+          second item being the storage value. This storage list must be sorted
+          in ascending order by key-hash.
+
+    Note: If `storage` is large enough that the rich account structure would
+          bring the internal size (see the Validity section) of the chunk to
+          over `CHUNK_SIZE`, only the prefix of storage that would keep the
+          internal size of the chunk within `CHUNK_SIZE` will be included. We
+          will call the unincluded remainder storage'. A new state chunk will
+          begin with an account entry of the same account, but with storage set
+          to the prefix of storage which will fit in the chunk, and so on.
+    """
+    @type code_flag :: :no_code | :has_code | :has_repeat_code
+    @type storage_tuple :: {EVM.hash(), <<_::256>>}
+
+    @type t :: %__MODULE__{
+            nonce: EVM.hash(),
+            balance: integer(),
+            code_flag: code_flag(),
+            code: binary(),
+            storage: list(storage_tuple())
+          }
+
+    defstruct [
+      :nonce,
+      :balance,
+      :code_flag,
+      :code,
+      :storage
+    ]
+
+    @spec decode_code_flag(0 | 1 | 2) :: code_flag()
+    def decode_code_flag(0), do: :no_code
+    def decode_code_flag(1), do: :has_code
+    def decode_code_flag(2), do: :has_repeat_code
+
+    @spec encode_code_flag(code_flag()) :: 0 | 1 | 2
+    def encode_code_flag(:no_code), do: 0
+    def encode_code_flag(:has_code), do: 1
+    def encode_code_flag(:has_repeat_code), do: 2
+  end
+
+  @type account_entry :: {
+          EVM.hash(),
+          RichAccount.t()
+        }
+
+  @type t() :: %__MODULE__{
+          account_entries: list(account_entry())
+        }
+
+  defstruct account_entries: []
+
+  @doc """
+  Given a `StateChunk`, serializes for transport within a SnapshotData packet.
+
+  ## Examples
+
+      iex> %ExWire.Packet.Capability.Par.SnapshotData.StateChunk{
+      ...>   account_entries: [
+      ...>     {
+      ...>       <<1::256>>,
+      ...>       %ExWire.Packet.Capability.Par.SnapshotData.StateChunk.RichAccount{
+      ...>         nonce: 2,
+      ...>         balance: 3,
+      ...>         code_flag: :has_code,
+      ...>         code: <<5::256>>,
+      ...>         storage: [{<<1::256>>, <<2::256>>}]
+      ...>       }
+      ...>     }
+      ...>   ]
+      ...> }
+      ...> |> ExWire.Packet.Capability.Par.SnapshotData.StateChunk.serialize()
+      [
+        [ <<1::256>>,
+          [
+            2,
+            3,
+            1,
+            <<5::256>>,
+            [[<<1::256>>, <<2::256>>]]
+          ]
+        ]
+      ]
+  """
+  @spec serialize(t()) :: ExRLP.t()
+  def serialize(state_chunk = %__MODULE__{}) do
+    for {hash, rich_account} <- state_chunk.account_entries do
+      [
+        hash,
+        [
+          rich_account.nonce,
+          rich_account.balance,
+          RichAccount.encode_code_flag(rich_account.code_flag),
+          rich_account.code,
+          for {key, val} <- rich_account.storage do
+            [key, val]
+          end
+        ]
+      ]
+    end
+  end
+
+  @doc """
+  Given an RLP-encoded `StateChunk` from a SnapshotData packet, decodes into a
+  `StateChunk` struct.
+
+  ## Examples
+
+      iex> [
+      ...>   [ <<1::256>>,
+      ...>     [
+      ...>       2,
+      ...>       3,
+      ...>       1,
+      ...>       <<5::256>>,
+      ...>       [[<<1::256>>, <<2::256>>]]
+      ...>     ]
+      ...>   ]
+      ...> ]
+      ...> |> ExWire.Packet.Capability.Par.SnapshotData.StateChunk.deserialize()
+      %ExWire.Packet.Capability.Par.SnapshotData.StateChunk{
+        account_entries: [
+          {
+            <<1::256>>,
+            %ExWire.Packet.Capability.Par.SnapshotData.StateChunk.RichAccount{
+              nonce: 2,
+              balance: 3,
+              code_flag: :has_code,
+              code: <<5::256>>,
+              storage: [{<<1::256>>, <<2::256>>}]
+            }
+          }
+        ]
+      }
+  """
+  @spec deserialize(ExRLP.t()) :: t()
+  def deserialize(rlp) do
+    account_entries_rlp = rlp
+
+    account_entries =
+      for [hash, rich_account_rlp] <- account_entries_rlp do
+        [
+          nonce,
+          balance,
+          encoded_code_flag,
+          code,
+          storage_rlp
+        ] = rich_account_rlp
+
+        storage =
+          for [key, val] <- storage_rlp do
+            {key, val}
+          end
+
+        {hash,
+         %RichAccount{
+           nonce: Exth.maybe_decode_unsigned(nonce),
+           balance: Exth.maybe_decode_unsigned(balance),
+           code_flag:
+             encoded_code_flag
+             |> Exth.maybe_decode_unsigned()
+             |> RichAccount.decode_code_flag(),
+           code: code,
+           storage: storage
+         }}
+      end
+
+    %__MODULE__{
+      account_entries: account_entries
+    }
+  end
+end

--- a/apps/ex_wire/lib/ex_wire/packet/capability/par/snapshot_manifest.ex
+++ b/apps/ex_wire/lib/ex_wire/packet/capability/par/snapshot_manifest.ex
@@ -1,0 +1,161 @@
+defmodule ExWire.Packet.Capability.Par.SnapshotManifest do
+  @moduledoc """
+  Respond to a GetSnapshotManifest message with either an empty RLP list or a
+  1-item RLP list containing a snapshot manifest
+
+  ```
+  `SnapshotManifest` [`0x12`, `manifest` or nothing]
+  ```
+  """
+  import Exth, only: [maybe_decode_unsigned: 1]
+
+  @behaviour ExWire.Packet
+
+  defmodule Manifest do
+    @moduledoc """
+    A Manifest from a warp-sync peer.
+
+    version: snapshot format version. Must be set to 2.
+    state_hashes: a list of all the state chunks in this snapshot
+    block_hashes: a list of all the block chunks in this snapshot
+    state_root: the root which the rebuilt state trie should have. Used to ensure validity
+    block_number: the number of the best block in the snapshot; the one which the state coordinates to.
+    block_hash: the best block in the snapshot's hash.
+    """
+
+    defstruct [
+      :version,
+      :state_hashes,
+      :block_hashes,
+      :state_root,
+      :block_number,
+      :block_hash
+    ]
+  end
+
+  @type manifest :: %Manifest{
+          version: integer(),
+          state_hashes: list(EVM.hash()),
+          block_hashes: list(EVM.hash()),
+          state_root: binary(),
+          block_number: integer(),
+          block_hash: EVM.hash()
+        }
+
+  @type t :: %__MODULE__{
+          manifest: manifest() | nil
+        }
+
+  defstruct manifest: nil
+
+  @doc """
+  Returns the relative message id offset for this message.
+  This will help determine what its message ID is relative to other Packets in the same Capability.
+  """
+  @impl true
+  @spec message_id_offset() :: 0x12
+  def message_id_offset do
+    0x12
+  end
+
+  @doc """
+  Given a SnapshotManifest packet, serializes for transport over Eth Wire Protocol.
+
+  ## Examples
+
+      iex> %ExWire.Packet.Capability.Par.SnapshotManifest{manifest: nil}
+      ...> |> ExWire.Packet.Capability.Par.SnapshotManifest.serialize()
+      []
+
+      iex> %ExWire.Packet.Capability.Par.SnapshotManifest{
+      ...>   manifest: %ExWire.Packet.Capability.Par.SnapshotManifest.Manifest{
+      ...>     version: 2,
+      ...>     state_hashes: [<<1::256>>, <<2::256>>],
+      ...>     block_hashes: [<<3::256>>, <<4::256>>],
+      ...>     state_root: <<5::256>>,
+      ...>     block_number: 6,
+      ...>     block_hash: <<7::256>>
+      ...>   }
+      ...> }
+      ...> |> ExWire.Packet.Capability.Par.SnapshotManifest.serialize()
+      [2, [<<1::256>>, <<2::256>>], [<<3::256>>, <<4::256>>], <<5::256>>, 6, <<7::256>>]
+  """
+  @impl true
+  def serialize(_packet = %__MODULE__{manifest: nil}), do: []
+
+  def serialize(_packet = %__MODULE__{manifest: manifest}) do
+    [
+      manifest.version,
+      manifest.state_hashes,
+      manifest.block_hashes,
+      manifest.state_root,
+      manifest.block_number,
+      manifest.block_hash
+    ]
+  end
+
+  @doc """
+  Given an RLP-encoded SnapshotManifest packet from Eth Wire Protocol,
+  decodes into a SnapshotManifest struct.
+
+  ## Examples
+
+      iex> ExWire.Packet.Capability.Par.SnapshotManifest.deserialize([])
+      %ExWire.Packet.Capability.Par.SnapshotManifest{manifest: nil}
+
+      iex> ExWire.Packet.Capability.Par.SnapshotManifest.deserialize([[2, [<<1::256>>, <<2::256>>], [<<3::256>>, <<4::256>>], <<5::256>>, 6, <<7::256>>]])
+      %ExWire.Packet.Capability.Par.SnapshotManifest{
+        manifest: %ExWire.Packet.Capability.Par.SnapshotManifest.Manifest{
+          version: 2,
+          state_hashes: [<<1::256>>, <<2::256>>],
+          block_hashes: [<<3::256>>, <<4::256>>],
+          state_root: <<5::256>>,
+          block_number: 6,
+          block_hash: <<7::256>>
+        }
+      }
+
+      iex> ExWire.Packet.Capability.Par.SnapshotManifest.deserialize([[3, [<<1::256>>, <<2::256>>], [<<3::256>>, <<4::256>>], <<5::256>>, 6, <<7::256>>]])
+      ** (MatchError) no match of right hand side value: 3
+  """
+  @impl true
+  def deserialize([]), do: %__MODULE__{manifest: nil}
+
+  def deserialize([rlp]) do
+    [
+      version,
+      state_hashes,
+      block_hashes,
+      state_root,
+      block_number,
+      block_hash
+    ] = rlp
+
+    %__MODULE__{
+      manifest: %Manifest{
+        version: 2 = maybe_decode_unsigned(version),
+        state_hashes: state_hashes,
+        block_hashes: block_hashes,
+        state_root: state_root,
+        block_number: maybe_decode_unsigned(block_number),
+        block_hash: block_hash
+      }
+    }
+  end
+
+  @doc """
+  Handles a SnapshotManifest message. We should send our manifest
+  to the peer. For now, we'll do nothing.
+
+  ## Examples
+
+      iex> %ExWire.Packet.Capability.Par.SnapshotManifest{}
+      ...> |> ExWire.Packet.Capability.Par.SnapshotManifest.handle()
+      :ok
+  """
+  @impl true
+  def handle(_packet = %__MODULE__{}) do
+    # TODO: Respond with empty manifest
+    :ok
+  end
+end

--- a/apps/ex_wire/lib/ex_wire/packet/capability/par/warp_status.ex
+++ b/apps/ex_wire/lib/ex_wire/packet/capability/par/warp_status.ex
@@ -1,0 +1,177 @@
+defmodule ExWire.Packet.Capability.Par.WarpStatus do
+  @moduledoc """
+  Status messages updated to handle warp details.
+
+  ```
+  **Status** [`+0x00`: `P`, `protocolVersion`: `P`, `networkId`: `P`,
+              `td`: `P`, `bestHash`: `B_32`, `genesisHash`: `B_32`,
+              `snapshot_hash`: B_32, `snapshot_number`: P]
+
+  In addition to all the fields in eth protocol version 63’s status (denoted
+  by `...`), include `snapshot_hash` and `snapshot_number` which signify the
+  snapshot manifest RLP hash and block number respectively of the peer's local
+  snapshot.
+  ```
+  """
+
+  require Logger
+
+  @behaviour ExWire.Packet
+
+  @type t :: %__MODULE__{
+          protocol_version: integer(),
+          network_id: integer(),
+          total_difficulty: integer(),
+          best_hash: binary(),
+          genesis_hash: binary(),
+          snapshot_hash: EVM.hash(),
+          snapshot_number: integer()
+        }
+
+  defstruct [
+    :protocol_version,
+    :network_id,
+    :total_difficulty,
+    :best_hash,
+    :genesis_hash,
+    :snapshot_hash,
+    :snapshot_number
+  ]
+
+  @doc """
+  Build a WarpStatus packet
+
+  Note: we are currently reflecting values based on the packet received, but
+  that should not be the case. We should provide the total difficulty of the
+  best chain found in the block header, the best hash, and the genesis hash of
+  our blockchain.
+
+  TODO: Don't parrot the same data back to sender
+  """
+  @spec new(t()) :: t()
+  def new(packet) do
+    %__MODULE__{
+      protocol_version: 1,
+      network_id: ExWire.Config.chain().params.network_id,
+      total_difficulty: packet.total_difficulty,
+      best_hash: packet.genesis_hash,
+      genesis_hash: packet.genesis_hash,
+      snapshot_hash: <<0::256>>,
+      snapshot_number: 0
+    }
+  end
+
+  @doc """
+  Returns the relative message id offset for this message.
+  This will help determine what its message ID is relative to other Packets in the same Capability.
+  """
+  @impl true
+  @spec message_id_offset() :: 0x00
+  def message_id_offset do
+    0x00
+  end
+
+  @doc """
+  Given a WarpStatus packet, serializes for transport over Eth Wire Protocol.
+
+  ## Examples
+
+      iex> %ExWire.Packet.Capability.Par.WarpStatus{
+      ...>   protocol_version: 0x63,
+      ...>   network_id: 3,
+      ...>   total_difficulty: 10,
+      ...>   best_hash: <<5>>,
+      ...>   genesis_hash: <<6::256>>,
+      ...>   snapshot_hash: <<7::256>>,
+      ...>   snapshot_number: 8,
+      ...> }
+      ...> |> ExWire.Packet.Capability.Par.WarpStatus.serialize
+      [0x63, 3, 10, <<5>>, <<6::256>>, <<7::256>>, 8]
+  """
+  @impl true
+  def serialize(packet = %__MODULE__{}) do
+    [
+      packet.protocol_version,
+      packet.network_id,
+      packet.total_difficulty,
+      packet.best_hash,
+      packet.genesis_hash,
+      packet.snapshot_hash,
+      packet.snapshot_number
+    ]
+  end
+
+  @doc """
+  Given an RLP-encoded Status packet from Eth Wire Protocol, decodes into a
+  Status packet.
+
+  ## Examples
+
+      iex> ExWire.Packet.Capability.Par.WarpStatus.deserialize([<<0x63>>, <<3>>, <<10>>, <<5>>, <<6::256>>, <<7::256>>, 8])
+      %ExWire.Packet.Capability.Par.WarpStatus{
+        protocol_version: 0x63,
+        network_id: 3,
+        total_difficulty: 10,
+        best_hash: <<5>>,
+        genesis_hash: <<6::256>>,
+        snapshot_hash: <<7::256>>,
+        snapshot_number: 8,
+      }
+  """
+  @impl true
+  def deserialize(rlp) do
+    [
+      protocol_version,
+      network_id,
+      total_difficulty,
+      best_hash,
+      genesis_hash,
+      snapshot_hash,
+      snapshot_number
+    ] = rlp
+
+    %__MODULE__{
+      protocol_version: :binary.decode_unsigned(protocol_version),
+      network_id: :binary.decode_unsigned(network_id),
+      total_difficulty: :binary.decode_unsigned(total_difficulty),
+      best_hash: best_hash,
+      genesis_hash: genesis_hash,
+      snapshot_hash: snapshot_hash,
+      snapshot_number: snapshot_number
+    }
+  end
+
+  @doc """
+  Handles a WarpStatus message.
+
+  We should decide whether or not we want to continue communicating with
+  this peer. E.g. do our network and protocol versions match?
+
+  ## Examples
+
+      iex> %ExWire.Packet.Capability.Par.WarpStatus{
+      ...>   protocol_version: 63,
+      ...>   network_id: 3,
+      ...>   total_difficulty: 10,
+      ...>   best_hash: <<4::256>>,
+      ...>   genesis_hash: <<4::256>>
+      ...> }
+      ...> |> ExWire.Packet.Capability.Par.WarpStatus.handle()
+      {:send,
+             %ExWire.Packet.Capability.Par.WarpStatus{
+               best_hash: <<4::256>>,
+               genesis_hash: <<4::256>>,
+               network_id: 3,
+               protocol_version: 1,
+               total_difficulty: 10,
+               snapshot_hash: <<0::256>>,
+               snapshot_number: 0
+             }}
+  """
+  @impl true
+  def handle(packet = %__MODULE__{}) do
+    Exth.trace(fn -> "[Packet] Got WarpStatus: #{inspect(packet)}" end)
+
+    {:send, new(packet)}
+  end
+end

--- a/apps/ex_wire/lib/ex_wire/peer_supervisor.ex
+++ b/apps/ex_wire/lib/ex_wire/peer_supervisor.ex
@@ -105,7 +105,8 @@ defmodule ExWire.PeerSupervisor do
   defp do_find_children(:random) do
     @name
     |> DynamicSupervisor.which_children()
-    |> Enum.random()
+    |> Enum.shuffle()
+    |> Enum.take(1)
     |> List.wrap()
   end
 

--- a/apps/ex_wire/lib/ex_wire/struct/warp_queue.ex
+++ b/apps/ex_wire/lib/ex_wire/struct/warp_queue.ex
@@ -1,0 +1,302 @@
+defmodule ExWire.Struct.WarpQueue do
+  @moduledoc """
+  `WarpQueue` maintains the current state of an active warp, this mean we will 
+  track the `block_chunk` hashes and `state_chunk` hashes given to us, so we
+  can request each from our connected peers. This structure is also persisted
+  during a warp sync, so that if interrupted, we can resume a warp where we
+  left off.
+
+  TODO: This will likely need to be updated to handle warping from more than
+        one direct peer.
+  """
+  require Logger
+
+  alias Blockchain.{Block, Blocktree}
+  alias Exth.Time
+  alias ExWire.Packet.Capability.Par.SnapshotManifest
+  alias MerklePatriciaTree.Trie
+
+  @type t :: %__MODULE__{
+          manifest: SnapshotManifest.manifest() | nil,
+          manifest_hashes: MapSet.t(EVM.hash()),
+          manifest_block_hashes: MapSet.t(EVM.hash()),
+          manifest_state_hashes: MapSet.t(EVM.hash()),
+          chunk_requests: MapSet.t(EVM.hash()),
+          retrieved_chunks: MapSet.t(EVM.hash()),
+          processed_chunks: MapSet.t(EVM.hash()),
+          processed_blocks: MapSet.t(integer()),
+          processed_accounts: integer(),
+          warp_start: Time.time(),
+          block_tree: Blocktree.t(),
+          state_root: EVM.hash()
+        }
+
+  defstruct [
+    :manifest,
+    :manifest_hashes,
+    :manifest_block_hashes,
+    :manifest_state_hashes,
+    :chunk_requests,
+    :retrieved_chunks,
+    :processed_chunks,
+    :processed_blocks,
+    :processed_accounts,
+    :warp_start,
+    :block_tree,
+    :state_root
+  ]
+
+  @empty_trie Trie.empty_trie_root_hash()
+
+  @doc """
+  Creates a new `WarpQueue`.
+  """
+  def new() do
+    %__MODULE__{
+      manifest: nil,
+      manifest_hashes: MapSet.new(),
+      manifest_block_hashes: MapSet.new(),
+      manifest_state_hashes: MapSet.new(),
+      chunk_requests: MapSet.new(),
+      retrieved_chunks: MapSet.new(),
+      processed_chunks: MapSet.new(),
+      processed_blocks: MapSet.new(),
+      processed_accounts: 0,
+      warp_start: Time.time_start(),
+      block_tree: Blocktree.new_tree(),
+      state_root: @empty_trie
+    }
+  end
+
+  @doc """
+  Handle receiving a new manifest from a peer. The current behaviour is to
+  ignore all but the first received manifest, but later on, we may add matching
+  manifests to track similar peers.
+  """
+  @spec new_manifest(t(), SnapshotManifest.manifest()) :: t()
+  def new_manifest(warp_queue, manifest) do
+    if warp_queue.manifest do
+      # Right now, ignore new manifests
+      warp_queue
+    else
+      manifest_block_hashes = MapSet.new(manifest.block_hashes)
+      manifest_state_hashes = MapSet.new(manifest.state_hashes)
+      manifest_hashes = MapSet.union(manifest_block_hashes, manifest_state_hashes)
+
+      %{
+        warp_queue
+        | manifest: manifest,
+          manifest_hashes: manifest_hashes,
+          manifest_block_hashes: manifest_block_hashes,
+          manifest_state_hashes: manifest_state_hashes
+      }
+    end
+  end
+
+  @doc """
+  When we receive a new block chunk, we want to remove it from requests
+  and add it to our processing queue.
+  """
+  @spec new_block_chunk(t(), EVM.hash()) :: t()
+  def new_block_chunk(warp_queue, chunk_hash) do
+    updated_chunk_requests = MapSet.delete(warp_queue.chunk_requests, chunk_hash)
+    updated_retrieved_chunks = MapSet.put(warp_queue.retrieved_chunks, chunk_hash)
+
+    %{
+      warp_queue
+      | chunk_requests: updated_chunk_requests,
+        retrieved_chunks: updated_retrieved_chunks
+    }
+  end
+
+  @doc """
+  When we receive a new state chunk, we simply add it to our queue, which we'll
+  later process.
+  """
+  @spec new_state_chunk(t(), EVM.hash()) :: t()
+  def new_state_chunk(warp_queue, chunk_hash) do
+    updated_chunk_requests = MapSet.delete(warp_queue.chunk_requests, chunk_hash)
+    updated_retrieved_chunks = MapSet.put(warp_queue.retrieved_chunks, chunk_hash)
+
+    %{
+      warp_queue
+      | chunk_requests: updated_chunk_requests,
+        retrieved_chunks: updated_retrieved_chunks
+    }
+  end
+
+  @spec get_hashes_to_request(t(), number(), number()) :: {t(), list(EVM.hash())}
+  def get_hashes_to_request(
+        warp_queue = %__MODULE__{
+          chunk_requests: chunk_requests,
+          retrieved_chunks: retrieved_chunks,
+          processed_chunks: processed_chunks
+        },
+        request_limit,
+        queue_limit
+      ) do
+    queued_count =
+      Enum.count(
+        MapSet.difference(
+          retrieved_chunks,
+          processed_chunks
+        )
+      )
+
+    allowed_by_parallelism = request_limit - MapSet.size(chunk_requests)
+    allowed_by_queue = queue_limit - queued_count
+
+    desired_requests = min(allowed_by_parallelism, allowed_by_queue)
+
+    if desired_requests > 0 do
+      unfetched_block_hashes =
+        warp_queue.manifest_block_hashes
+        |> MapSet.difference(chunk_requests)
+        |> MapSet.difference(retrieved_chunks)
+        |> MapSet.difference(processed_chunks)
+        |> MapSet.to_list()
+
+      unfetched_state_hashes =
+        warp_queue.manifest_state_hashes
+        |> MapSet.difference(chunk_requests)
+        |> MapSet.difference(retrieved_chunks)
+        |> MapSet.difference(processed_chunks)
+        |> MapSet.to_list()
+
+      total_unfetched_hashes = unfetched_block_hashes ++ unfetched_state_hashes
+      total_unfetched_count = Enum.count(total_unfetched_hashes)
+
+      if min(total_unfetched_count, desired_requests) > 0 do
+        hashes_to_request = Enum.take(total_unfetched_hashes, desired_requests)
+
+        :ok =
+          Logger.debug(fn ->
+            "[Warp] Retreiving #{Enum.count(hashes_to_request)} of #{total_unfetched_count} hash(es) needed."
+          end)
+
+        new_chunk_requests =
+          MapSet.union(
+            chunk_requests,
+            MapSet.new(hashes_to_request)
+          )
+
+        {
+          %{warp_queue | chunk_requests: new_chunk_requests},
+          hashes_to_request
+        }
+      else
+        {warp_queue, []}
+      end
+    else
+      {warp_queue, []}
+    end
+  end
+
+  @spec status(t()) :: {:pending, atom()} | :success | {:failure, atom()}
+  def status(warp_queue) do
+    cond do
+      is_nil(warp_queue.manifest) ->
+        {:pending, :no_manifest}
+
+      MapSet.size(warp_queue.chunk_requests) > 0 ->
+        {:pending, :awaiting_requests}
+
+      !MapSet.equal?(warp_queue.manifest_hashes, warp_queue.processed_chunks) ->
+        {:pending, :awaiting_processing}
+
+      is_nil(warp_queue.block_tree.best_block) ->
+        {:failure, :missing_best_block}
+
+      warp_queue.block_tree.best_block.header.number != warp_queue.manifest.block_number ->
+        :pending
+
+      warp_queue.block_tree.best_block.block_hash != warp_queue.manifest.block_hash ->
+        :ok =
+          Logger.error(fn ->
+            "[Warp] Mismatched block hash: expected: #{
+              Exth.encode_hex(warp_queue.manifest.block_hash)
+            }, got: #{Exth.encode_hex(warp_queue.block_tree.best_block.block_hash)}"
+          end)
+
+        {:failure, :mismatched_block_hash}
+
+      warp_queue.state_root != warp_queue.manifest.state_root ->
+        :ok =
+          Logger.error(fn ->
+            "[Warp] Mismatched state root: expected: #{
+              Exth.encode_hex(warp_queue.manifest.state_root)
+            }, got: #{Exth.encode_hex(warp_queue.state_root)}"
+          end)
+
+        {:failure, :mismatched_state_root}
+
+      true ->
+        :success
+    end
+  end
+
+  @spec processed_state_chunk(t(), EVM.hash(), integer(), EVM.hash()) :: t()
+  def processed_state_chunk(warp_queue, chunk_hash, processed_accounts, state_root) do
+    next_processed_accounts = warp_queue.processed_accounts + processed_accounts
+
+    # Show some stats for debugging
+    :ok =
+      Logger.debug(fn ->
+        "[Warp] Completed: #{next_processed_accounts} account(s) in #{
+          Time.elapsed(warp_queue.warp_start, :second)
+        } at #{Time.rate(next_processed_accounts, warp_queue.warp_start, "accts", :second)} with new state root #{
+          Exth.encode_hex(state_root)
+        }"
+      end)
+
+    %{
+      warp_queue
+      | processed_accounts: next_processed_accounts,
+        processed_chunks: MapSet.put(warp_queue.processed_chunks, chunk_hash),
+        state_root: state_root
+    }
+  end
+
+  @spec processed_block_chunk(
+          t(),
+          EVM.hash(),
+          Block.t(),
+          list(integer())
+        ) :: t()
+  def processed_block_chunk(warp_queue, chunk_hash, block, processed_blocks) do
+    next_processed_blocks =
+      MapSet.union(
+        warp_queue.processed_blocks,
+        MapSet.new(processed_blocks)
+      )
+
+    next_block_tree = Blocktree.update_best_block(warp_queue.block_tree, block)
+
+    # Show some stats for debugging
+    list =
+      next_processed_blocks
+      |> MapSet.to_list()
+      |> Enum.sort()
+
+    min = List.first(list)
+
+    {max, missing} =
+      Enum.reduce(Enum.drop(list, 1), {min, 0}, fn el, {last, count} ->
+        {el, count + el - last - 1}
+      end)
+
+    :ok =
+      Logger.debug(fn ->
+        "[Warp] Completed: #{min}..#{max} with #{missing} missing block(s) in #{
+          Time.elapsed(warp_queue.warp_start, :second)
+        } at #{Time.rate(Enum.count(list), warp_queue.warp_start, "blks", :second)}"
+      end)
+
+    %{
+      warp_queue
+      | processed_blocks: next_processed_blocks,
+        processed_chunks: MapSet.put(warp_queue.processed_chunks, chunk_hash),
+        block_tree: next_block_tree
+    }
+  end
+end

--- a/apps/ex_wire/lib/ex_wire/sync/warp_processor.ex
+++ b/apps/ex_wire/lib/ex_wire/sync/warp_processor.ex
@@ -1,0 +1,570 @@
+defmodule ExWire.Sync.WarpProcessor do
+  @moduledoc """
+  Server responsible for processing block and state chunks in parallel for the
+  Warp Queue. For more information about how the chunks are processed, see
+  `PowProcessor`.
+
+  State and data chunks from the warp are processed in parallel. After the
+  accounts of state chunks are extracted, we spawn a different task which
+  stores the data from those accounts into the state trie, one by one.
+  """
+  use GenServer
+
+  require Logger
+
+  alias Exth.Time
+  alias ExWire.Packet.Capability.Par.SnapshotData.{BlockChunk, StateChunk}
+  alias ExWire.Sync.WarpProcessor.PowProcessor
+  alias MerklePatriciaTree.{Trie, TrieStorage}
+
+  @type block_chunk_request :: {
+          EVM.hash(),
+          BlockChunk.t(),
+          pid()
+        }
+  @type state_chunk_request :: {
+          EVM.hash(),
+          StateChunk.t(),
+          pid()
+        }
+  @type state :: %{
+          parallelism: non_neg_integer(),
+          sup: pid(),
+          trie: Trie.t(),
+          processor_mod: module(),
+          state_root: EVM.hash(),
+          queued_block_chunks: list(block_chunk_request()),
+          queued_state_chunks: list(state_chunk_request()),
+          state_processing_task: Task.t()
+        }
+  @type processor_mod :: PowProcessor
+
+  @name __MODULE__
+
+  @doc """
+  Initializes a new WarpProcessor server.
+
+  Parallelism describes how many active tasks should run at once. That is,
+  how many block or state chunks are processed in parallel.
+
+  State root is the current state root after processing state chunks. This
+  should start as the empty trie if starting a fresh warp.
+
+  Trie should be a caching trie with the main chain as the permanent db.
+
+  Processor mod refers to the processor...
+  """
+  @spec start_link({integer(), Trie.t(), EVM.hash(), processor_mod()}, Keyword.t()) ::
+          GenServer.on_start()
+  def start_link({parallelism, trie, state_root, processor_mod}, opts \\ []) do
+    GenServer.start_link(
+      __MODULE__,
+      [
+        parallelism: parallelism,
+        trie: trie,
+        state_root: state_root,
+        processor_mod: processor_mod
+      ],
+      name: Keyword.get(opts, :name, @name)
+    )
+  end
+
+  @doc """
+  Initializes gen server with options from `start_link`.
+  """
+  @impl true
+  def init(
+        parallelism: parallelism,
+        trie: trie,
+        state_root: state_root,
+        processor_mod: processor_mod
+      ) do
+    {:ok, sup} = Task.Supervisor.start_link()
+
+    {:ok,
+     %{
+       parallelism: parallelism,
+       sup: sup,
+       trie: trie,
+       processor_mod: processor_mod,
+       state_root: state_root,
+       queued_block_chunks: [],
+       queued_state_chunks: [],
+       state_processing_task: nil,
+       queue_state_processing_tasks: []
+     }}
+  end
+
+  @impl true
+  # Called when a task completes successfully with the return
+  # value of that task.
+  def handle_info({ref, msg}, state) do
+    {:noreply, handle_task_complete(ref, {:ok, msg}, state)}
+  end
+
+  # Called when a task completes informing the supervisor that a child
+  # has terminated normally.
+  def handle_info({:DOWN, ref, :process, _pid, :normal}, state) do
+    {:noreply, handle_task_complete(ref, :down, state)}
+  end
+
+  @impl true
+  # When a task block or state chunk processing task completes, attempts to
+  # de-queue another task for processing, keeping us at our limit of
+  # parallelism.
+  def handle_cast(
+        :spawn_new_tasks,
+        state = %{
+          sup: sup,
+          trie: trie,
+          processor_mod: processor_mod,
+          parallelism: parallelism,
+          queued_block_chunks: queued_block_chunks,
+          queued_state_chunks: queued_state_chunks
+        }
+      ) do
+    {:done, next_queued_block_chunks, next_queued_state_chunks} =
+      spawn_new_tasks(
+        sup,
+        trie,
+        processor_mod,
+        parallelism,
+        queued_block_chunks,
+        queued_state_chunks
+      )
+
+    {:noreply,
+     %{
+       state
+       | queued_block_chunks: next_queued_block_chunks,
+         queued_state_chunks: next_queued_state_chunks
+     }}
+  end
+
+  # Called when we receive a new block chunk for a sync peer. Either begins
+  # processing or enqueues the task for later processing.
+  def handle_cast(
+        {:new_block_chunk, chunk_hash, block_chunk, pid},
+        state = %{sup: sup, trie: trie}
+      ) do
+    new_state = maybe_new_block_chunk_task(state, sup, chunk_hash, block_chunk, trie, pid)
+
+    {:noreply, new_state}
+  end
+
+  # Called when we receive a new state chunk for a sync peer. Either begins
+  # processing or enqueues the task for later processing.
+  def handle_cast(
+        {:new_state_chunk, chunk_hash, state_chunk, pid},
+        state = %{sup: sup, trie: trie}
+      ) do
+    new_state = maybe_new_state_chunk_task(state, sup, chunk_hash, state_chunk, trie, pid)
+
+    {:noreply, new_state}
+  end
+
+  # Called when we receive new account states that are ready to process into
+  # the state trie. If we are not currently processing a task, we will begin
+  # processing, otherwise we'll queue the state task until we've completed
+  # the current process.
+  def handle_cast(
+        {:new_account_states, chunk_hash, account_states, pid},
+        state = %{
+          sup: sup,
+          trie: trie,
+          state_root: state_root,
+          processor_mod: processor_mod,
+          state_processing_task: nil
+        }
+      ) do
+    task =
+      new_account_states_task(
+        sup,
+        chunk_hash,
+        account_states,
+        trie,
+        state_root,
+        processor_mod,
+        pid
+      )
+
+    {:noreply, %{state | state_processing_task: task}}
+  end
+
+  def handle_cast(
+        el = {:new_account_states, _chunk_hash, _account_states, _pid},
+        state = %{queue_state_processing_tasks: queue_state_processing_tasks}
+      ) do
+    {:noreply,
+     %{
+       state
+       | queue_state_processing_tasks: [el | queue_state_processing_tasks]
+     }}
+  end
+
+  # When a task completes, it may be a block or state chunk processing task,
+  # or it may be an account state task. If it's an account state task that
+  # has successfully completed, we store the new state root it generated
+  # so it can be used by the next task. If it's an account state task that
+  # has succesfully terminated, we try to pull a new task from the queue.
+  @spec handle_task_complete(term(), term(), state()) :: state()
+  defp handle_task_complete(
+         ref,
+         status,
+         state = %{
+           sup: sup,
+           trie: trie,
+           state_root: state_root,
+           processor_mod: processor_mod,
+           state_processing_task: %Task{ref: task_ref},
+           queue_state_processing_tasks: queue_state_processing_tasks
+         }
+       )
+       when ref == task_ref do
+    case status do
+      {:ok, {:next_state_root, next_state_root}} ->
+        %{state | state_root: next_state_root}
+
+      :down ->
+        {next_task, next_queue} =
+          case queue_state_processing_tasks do
+            [{:new_account_states, chunk_hash, account_states, pid} | next_queue] ->
+              task =
+                new_account_states_task(
+                  sup,
+                  chunk_hash,
+                  account_states,
+                  trie,
+                  state_root,
+                  processor_mod,
+                  pid
+                )
+
+              {task, next_queue}
+
+            _ ->
+              {nil, []}
+          end
+
+        %{state | state_processing_task: next_task, queue_state_processing_tasks: next_queue}
+    end
+  end
+
+  # An block or state chunk task completed successfully, ignore the result
+  defp handle_task_complete(_ref, {:ok, _msg}, state), do: state
+
+  # A block or state chunk task has terminated, try to spawn a new one
+  defp handle_task_complete(_ref, :down, state) do
+    GenServer.cast(self(), :spawn_new_tasks)
+
+    state
+  end
+
+  # Try and spawn more children if we have queued block or state chunks
+  # and we aren't at max parallelism.
+  @spec spawn_new_tasks(
+          pid(),
+          Trie.t(),
+          processor_mod(),
+          non_neg_integer(),
+          list(block_chunk_request()),
+          list(state_chunk_request())
+        ) :: {:done, list(block_chunk_request()), list(state_chunk_request())}
+  # When we have a queued up block chunk...
+  defp spawn_new_tasks(
+         sup,
+         trie,
+         processor_mod,
+         parallelism,
+         queued_block_chunks = [{chunk_hash, block_chunk, pid} | rest_queued_block_chunks],
+         queued_state_chunks
+       ) do
+    # TODO: We should probably keep track of children ourselves, but for now,
+    # we just query the supervisor. This actually restricts parallelism since
+    # our account state processor counts here.
+    if current_child_count(sup) <= parallelism do
+      _task = new_block_chunk_task(sup, chunk_hash, block_chunk, trie, processor_mod, pid)
+
+      spawn_new_tasks(
+        sup,
+        trie,
+        processor_mod,
+        parallelism,
+        rest_queued_block_chunks,
+        queued_state_chunks
+      )
+    else
+      {:done, queued_block_chunks, queued_state_chunks}
+    end
+  end
+
+  # When we have a queued up state chunk...
+  defp spawn_new_tasks(
+         sup,
+         trie,
+         processor_mod,
+         parallelism,
+         queued_block_chunks = [],
+         queued_state_chunks = [
+           {chunk_hash, state_chunk, pid} | rest_queued_state_chunks
+         ]
+       ) do
+    if current_child_count(sup) <= parallelism do
+      _task = new_state_chunk_task(self(), sup, chunk_hash, state_chunk, trie, processor_mod, pid)
+
+      spawn_new_tasks(
+        sup,
+        trie,
+        processor_mod,
+        parallelism,
+        queued_block_chunks,
+        rest_queued_state_chunks
+      )
+    else
+      {:done, queued_block_chunks, queued_state_chunks}
+    end
+  end
+
+  # When we have no queued up chunks...
+  defp spawn_new_tasks(_sup, _trie, _processor_mod, _parallelism, [], []) do
+    {:done, [], []}
+  end
+
+  # If we are below max parallelism, spawn a new block chunk processing task, or queue
+  # the block chunk if we've hit max parallelism.
+  @spec maybe_new_block_chunk_task(state(), pid(), EVM.hash(), BlockChunk.t(), Trie.t(), pid()) ::
+          state()
+  def maybe_new_block_chunk_task(
+        state = %{parallelism: parallelism, processor_mod: processor_mod},
+        sup,
+        chunk_hash,
+        block_chunk,
+        trie,
+        pid
+      ) do
+    if current_child_count(sup) <= parallelism do
+      _task = new_block_chunk_task(sup, chunk_hash, block_chunk, trie, processor_mod, pid)
+
+      state
+    else
+      :ok =
+        Logger.debug(fn ->
+          "[Warp] Processor block queue size: #{Enum.count(state.queued_block_chunks) + 1}"
+        end)
+
+      %{
+        state
+        | queued_block_chunks: [
+            {chunk_hash, block_chunk, pid} | state.queued_block_chunks
+          ]
+      }
+    end
+  end
+
+  # The task to process a block. When we process a block, we just verify the details
+  # about that block, store it's transactions, receipts and block data to the database,
+  # and return the processed data back to the sync process.
+  @spec new_block_chunk_task(pid(), EVM.hash(), BlockChunk.t(), Trie.t(), processor_mod(), pid()) ::
+          Task.t()
+  defp new_block_chunk_task(sup, chunk_hash, block_chunk, trie, processor_mod, pid) do
+    Task.Supervisor.async(sup, fn ->
+      start = Time.time_start()
+
+      :ok =
+        Logger.debug(fn ->
+          "[Warp] Starting to process #{Enum.count(block_chunk.block_data_list)} block(s)."
+        end)
+
+      {processed_blocks, block, next_trie} = processor_mod.process_block_chunk(block_chunk, trie)
+
+      trie_elapsed =
+        Time.elapsed(fn ->
+          TrieStorage.commit!(next_trie)
+        end)
+
+      :ok =
+        Logger.debug(fn ->
+          "[Warp] Processed #{Enum.count(processed_blocks)} block(s) in #{Time.elapsed(start)} (trie commit time: #{
+            trie_elapsed
+          })."
+        end)
+
+      :ok = GenServer.cast(pid, {:processed_block_chunk, chunk_hash, processed_blocks, block})
+
+      :ok
+    end)
+  end
+
+  # If we are below max parallelism, spawn a new state chunk processing task, or queue
+  # the state chunk if we've hit max parallelism.
+  @spec maybe_new_state_chunk_task(state(), pid(), EVM.hash(), StateChunk.t(), Trie.t(), pid()) ::
+          state()
+  defp maybe_new_state_chunk_task(
+         state = %{parallelism: parallelism, processor_mod: processor_mod},
+         sup,
+         chunk_hash,
+         state_chunk,
+         trie,
+         pid
+       ) do
+    if current_child_count(sup) <= parallelism do
+      _task = new_state_chunk_task(self(), sup, chunk_hash, state_chunk, trie, processor_mod, pid)
+
+      state
+    else
+      :ok =
+        Logger.debug(fn ->
+          "[Warp] Processor state queue size: #{Enum.count(state.queued_state_chunks) + 1}"
+        end)
+
+      %{
+        state
+        | queued_state_chunks: [
+            {chunk_hash, state_chunk, pid} | state.queued_state_chunks
+          ]
+      }
+    end
+  end
+
+  # The task to process a state chunk. When we process a state chunk, we decode the
+  # details about the included account entries. Then we pass the account state data
+  # back to this process to process into the state trie.
+  @spec new_state_chunk_task(
+          pid(),
+          pid(),
+          EVM.hash(),
+          StateChunk.t(),
+          Trie.t(),
+          processor_mod(),
+          pid()
+        ) :: Task.t()
+  defp new_state_chunk_task(processor_pid, sup, chunk_hash, state_chunk, trie, processor_mod, pid) do
+    Task.Supervisor.async(sup, fn ->
+      start = Time.time_start()
+
+      :ok =
+        Logger.debug(fn ->
+          "[Warp] Starting to process #{Enum.count(state_chunk.account_entries)} account(s)."
+        end)
+
+      {account_states, next_trie} = processor_mod.process_state_chunk(state_chunk, trie)
+
+      trie_elapsed =
+        Time.elapsed(fn ->
+          TrieStorage.commit!(next_trie)
+        end)
+
+      :ok =
+        Logger.debug(fn ->
+          "[Warp] Processed #{Enum.count(state_chunk.account_entries)} account(s) #{
+            Time.elapsed(start)
+          } (trie commit time: #{trie_elapsed})."
+        end)
+
+      GenServer.cast(processor_pid, {:new_account_states, chunk_hash, account_states, pid})
+
+      :ok
+    end)
+  end
+
+  # The task to process new account states. We iterate over the account states
+  # and store each account into a state root trie. We will later verify that
+  # state root matches the one that was given in the warp manifest.
+  @spec new_account_states_task(
+          pid(),
+          EVM.hash(),
+          list(PowProcessor.account_state()),
+          Trie.t(),
+          EVM.hash(),
+          processor_mod(),
+          pid()
+        ) :: Task.t()
+  defp new_account_states_task(
+         sup,
+         chunk_hash,
+         account_states,
+         trie,
+         state_root,
+         processor_mod,
+         pid
+       ) do
+    Task.Supervisor.async(sup, fn ->
+      start = Time.time_start()
+
+      processed_accounts = Enum.count(account_states)
+
+      :ok =
+        Logger.debug(fn ->
+          "[Warp] Starting to process #{processed_accounts} account state(s) from state root #{
+            Exth.encode_hex(state_root)
+          }."
+        end)
+
+      state_trie = TrieStorage.set_root_hash(trie, state_root)
+      next_state_trie = processor_mod.process_account_states(account_states, state_trie)
+      next_state_root = TrieStorage.root_hash(next_state_trie)
+
+      trie_elapsed =
+        Time.elapsed(fn ->
+          TrieStorage.commit!(next_state_trie)
+        end)
+
+      :ok =
+        Logger.debug(fn ->
+          "[Warp] Processed #{processed_accounts} account state(s) #{Time.elapsed(start)} (trie commit time: #{
+            trie_elapsed
+          }). New state root: #{Exth.encode_hex(next_state_root)}"
+        end)
+
+      :ok =
+        Logger.debug(fn ->
+          "[Warp] #{processed_accounts}: #{Exth.encode_hex(state_root)}->#{
+            Exth.encode_hex(next_state_root)
+          }"
+        end)
+
+      :ok =
+        GenServer.cast(
+          pid,
+          {:processed_state_chunk, chunk_hash, processed_accounts, next_state_root}
+        )
+
+      {:next_state_root, next_state_root}
+    end)
+  end
+
+  @doc """
+  Called when we receive a new block chunk from a peer to ask warp processor
+  to process the block chunk asynchronously.
+
+  Block chunks contain data about the last few thousand blocks, such as a list
+  of transactions and receipts.
+  """
+  @spec new_block_chunk(pid(), EVM.hash(), BlockChunk.t()) :: :ok
+  def new_block_chunk(pid, chunk_hash, block_chunk) do
+    GenServer.cast(pid, {:new_block_chunk, chunk_hash, block_chunk, self()})
+  end
+
+  @doc """
+  Called when we receive a new state chunk from a peer to ask warp processor
+  to process the block chunk asynchronously.
+
+  State chunks contain the account data necessary to build the state of the
+  most recent block in the warp from a blank database.
+  """
+  @spec new_state_chunk(pid(), EVM.hash(), StateChunk.t()) :: :ok
+  def new_state_chunk(pid, chunk_hash, state_chunk) do
+    GenServer.cast(pid, {:new_state_chunk, chunk_hash, state_chunk, self()})
+  end
+
+  # The child count is the total number of asynchronous tasks being run by
+  # this processor. This should be at most parallelism plus one (since we
+  # also have the account state processor, as well as the state and block
+  # chunk processors).
+  @spec current_child_count(pid()) :: non_neg_integer()
+  defp current_child_count(sup) do
+    sup
+    |> Task.Supervisor.children()
+    |> Enum.count()
+  end
+end

--- a/apps/ex_wire/lib/ex_wire/sync/warp_processor/pow_processor.ex
+++ b/apps/ex_wire/lib/ex_wire/sync/warp_processor/pow_processor.ex
@@ -1,0 +1,342 @@
+defmodule ExWire.Sync.WarpProcessor.PowProcessor do
+  @moduledoc """
+  PowProcessor helps build a proper blockchain state from the data
+  received from a warp of a proof-of-work chain.
+
+  When we receive a warp manifest from peers, it contains a list
+  of block and state chunks that contain data about the most recent
+  several thousand blocks and all of the account state data for the
+  most recently included block.
+
+  For each block chunk, we store each transaction and receipt, returning a
+  transactions root and receipts root, which we use to complete the block
+  header and store all of these (the block by hash, the transactions and the
+  receipts) to our permanent database.
+
+  For each state chunk, we have abridged data about a list of accounts. First,
+  we process those state chunks into a set of encoded account data that are
+  stored to the trie. Then, given a state root, we process each of these account
+  entries, storing them into a trie to get the state root. We will verify
+  this state root against the root given in the warp manifest to ensure we've
+  properly processed each account.
+
+  For processing the state root, there's one complication: account data may
+  be split over multiple state chunks. It would be slow to wait and merge
+  this data prior to committing any blocks, so instead we check to see if there
+  is any previous account storage prior to processing account entries which
+  may have been split up. Note: only the first or last entry in a state chunk
+  could have been split up, since the middle ones must, be definition, fit
+  properly in the state chunk.
+  """
+
+  alias Block.Header
+  alias Blockchain.Block
+  alias ExthCrypto.Hash.Keccak
+  alias ExWire.Packet.Capability.Par.SnapshotData.{BlockChunk, StateChunk}
+  alias ExWire.Packet.Capability.Par.SnapshotData.BlockChunk.BlockData
+  alias ExWire.Packet.Capability.Par.SnapshotData.StateChunk.RichAccount
+  alias MerklePatriciaTree.{Trie, TrieStorage}
+
+  @type account_state :: {EVM.hash(), binary()}
+  @empty_code_hash Keccak.kec(<<>>)
+  @empty_trie Trie.empty_trie_root_hash()
+
+  @doc """
+  Processes a block chunk, returning the block numbers which were processed,
+  the best block which was generated (which can be put in the block tree),
+  and the updated trie (which has not yet been committed). See `process_block`
+  for more information on how blocks are processed.
+  """
+  @spec process_block_chunk(BlockChunk.t(), Trie.t()) ::
+          {MapSet.t(integer()), Block.t(), Trie.t()}
+  def process_block_chunk(block_chunk, trie) do
+    {_, _, next_trie, processed_blocks, block} =
+      Enum.reduce(
+        block_chunk.block_data_list,
+        {block_chunk.number, block_chunk.hash, trie, MapSet.new(), nil},
+        fn block_data, {number, parent_hash, curr_trie, curr_processed_blocks, _} ->
+          {next_trie, block} =
+            process_block(
+              block_data,
+              parent_hash,
+              number + 1,
+              curr_trie
+            )
+
+          {
+            number + 1,
+            block.block_hash,
+            next_trie,
+            MapSet.put(curr_processed_blocks, block.header.number),
+            block
+          }
+        end
+      )
+
+    {processed_blocks, block, next_trie}
+  end
+
+  @doc """
+  Processes a state chunk, returning a list of `account_state` entries which need
+  to be placed into the state trie, as well as the trie which contains the account
+  data which should be stored. The trie has not yet been committed.
+
+  See `process_account` for more details on how we process each account entry.
+  """
+  @spec process_state_chunk(StateChunk.t(), Trie.t()) :: {list(account_state()), Trie.t()}
+  def process_state_chunk(state_chunk, trie) do
+    account_entries_count = Enum.count(state_chunk.account_entries)
+
+    {next_trie, account_states, _} =
+      Enum.reduce(state_chunk.account_entries, {trie, [], 0}, fn {address_hash, rich_account},
+                                                                 {curr_trie, curr_account_states,
+                                                                  num} ->
+        {next_trie, account_state} =
+          process_account(
+            address_hash,
+            rich_account,
+            curr_trie,
+            num == 0 || num == account_entries_count - 1
+          )
+
+        {next_trie, [account_state | curr_account_states], num + 1}
+      end)
+
+    {Enum.reverse(account_states), next_trie}
+  end
+
+  @doc """
+  Processes a single block from within a block chunk. This verifies the block
+  headers, builds stores each transaction and builds a transaction root, stores
+  each receipt and builds a receipts root, and returns the block as well as the
+  updated trie.
+
+  TODO: Validate the block headers before accepting the block.
+  """
+  @spec process_block(BlockData.t(), EVM.hash(), integer(), Trie.t()) :: {Trie.t(), Block.t()}
+  def process_block(
+        block_data,
+        parent_hash,
+        number,
+        trie
+      ) do
+    # First, we need to validate some aspect of the block, that's currently
+    # ommited.
+
+    # Next, store transactions and verify root
+    {_, trie_with_trx, transactions_root} =
+      Enum.reduce(block_data.header.transactions_rlp, {0, trie, @empty_trie}, fn trx_rlp,
+                                                                                 {i, curr_trie,
+                                                                                  curr_root} ->
+        {subtrie, updated_trie} =
+          TrieStorage.update_subtrie_key(
+            curr_trie,
+            curr_root,
+            ExRLP.encode(i),
+            ExRLP.encode(trx_rlp)
+          )
+
+        updated_root_hash = TrieStorage.root_hash(subtrie)
+
+        {i + 1, updated_trie, updated_root_hash}
+      end)
+
+    # Then, store receipts and verify root
+    {_, trie_with_trx_and_receipts, receipts_root} =
+      Enum.reduce(block_data.receipts_rlp, {0, trie_with_trx, @empty_trie}, fn receipt_rlp,
+                                                                               {i, curr_trie,
+                                                                                curr_root} ->
+        {subtrie, updated_trie} =
+          TrieStorage.update_subtrie_key(
+            curr_trie,
+            curr_root,
+            ExRLP.encode(i),
+            ExRLP.encode(receipt_rlp)
+          )
+
+        updated_root_hash = TrieStorage.root_hash(subtrie)
+
+        {i + 1, updated_trie, updated_root_hash}
+      end)
+
+    block = get_block(block_data, parent_hash, number, transactions_root, receipts_root)
+
+    # Store the block to our db, trying not to repeat encodings of our
+    # transactions and ommers. But.. we do.
+    block_encoded_rlp =
+      [
+        Header.serialize(block.header),
+        block_data.header.transactions_rlp,
+        block_data.header.ommers_rlp
+      ]
+      |> ExRLP.encode()
+
+    {
+      TrieStorage.put_raw_key!(trie_with_trx_and_receipts, block.block_hash, block_encoded_rlp),
+      block
+    }
+  end
+
+  # Returns a block struct given pieces of information compiled from data in the
+  # block chunk.
+  @spec get_block(BlockData.t(), EVM.hash(), integer(), EVM.hash(), EVM.hash()) :: Block.t()
+  defp get_block(block_data, parent_hash, number, transactions_hash, receipts_root) do
+    ommers_hash = get_ommers_hash(block_data.header.ommers_rlp)
+
+    header = %Header{
+      parent_hash: parent_hash,
+      ommers_hash: ommers_hash,
+      beneficiary: block_data.header.author,
+      state_root: block_data.header.state_root,
+      transactions_root: transactions_hash,
+      receipts_root: receipts_root,
+      logs_bloom: block_data.header.logs_bloom,
+      difficulty: block_data.header.difficulty,
+      number: number,
+      gas_limit: block_data.header.gas_limit,
+      gas_used: block_data.header.gas_used,
+      timestamp: block_data.header.timestamp,
+      extra_data: block_data.header.extra_data,
+      mix_hash: block_data.header.mix_hash,
+      nonce: block_data.header.nonce
+    }
+
+    %Block{
+      block_hash: Header.hash(header),
+      header: header,
+      transactions: block_data.header.transactions,
+      receipts: block_data.receipts,
+      ommers: block_data.header.ommers
+    }
+  end
+
+  @doc """
+  Processes a single account entry from a state chunk. We build a storage
+  root of the block from the given storage that (note: this may be added
+  to via `reprocess_account` for the first or last block of a chunk).
+  Additionally, we calculate the code hash, etc, and return the RLP-encoded
+  account data which should be stored to the trie.
+
+  If `keep_storage` is true, we return the raw storage data which is required
+  for reprocessing the block (if it may be split over multiple state chunks).
+  """
+  @spec process_account(EVM.hash(), RichAccount.t(), Trie.t(), boolean()) ::
+          {Trie.t(), {EVM.Address.t(), binary(), nil | %{}}}
+  def process_account(address_hash, rich_account, trie, keep_storage) do
+    # First, we need to put the storage values for the account into
+    # a new subtree, getting the new state root.
+    {new_trie, storage_root_hash} =
+      process_account_storage(rich_account.storage, trie, @empty_trie)
+
+    # Then, we need to put the code hash
+    {new_trie_2, code_hash} =
+      case rich_account.code_flag do
+        :no_code ->
+          {new_trie, @empty_code_hash}
+
+        :has_code ->
+          code_hash = Keccak.kec(rich_account.code)
+
+          {
+            TrieStorage.put_raw_key!(new_trie, code_hash, rich_account.code),
+            code_hash
+          }
+
+        :has_repeat_code ->
+          {new_trie, rich_account.code}
+      end
+
+    # Store the account to our db
+    account_encoded_rlp =
+      [
+        rich_account.nonce,
+        rich_account.balance,
+        storage_root_hash,
+        code_hash
+      ]
+      |> ExRLP.encode()
+
+    {new_trie_2,
+     {address_hash, account_encoded_rlp, if(keep_storage, do: rich_account.storage, else: nil)}}
+  end
+
+  # Builds an account storage root trie from a given starting hash (e.g. a blank trie),
+  # as well as a list of pre-hashed key-value pairs. Note: this will get called when
+  # the account is first processed, and may get called again in re-processing.
+  @spec process_account_storage(list({EVM.hash(), <<_::256>>}), Trie.t(), EVM.hash()) ::
+          {Trie.t(), EVM.hash()}
+  defp process_account_storage(storage, trie, root_hash) do
+    Enum.reduce(storage, {trie, root_hash}, fn {k, v}, {curr_trie, curr_root} ->
+      {subtrie, updated_trie} = TrieStorage.update_subtrie_key(curr_trie, curr_root, k, v)
+
+      updated_root_hash = TrieStorage.root_hash(subtrie)
+
+      {updated_trie, updated_root_hash}
+    end)
+  end
+
+  @doc """
+  Given a list of account states and the current state trie, returns
+  a new state trie with the accounts included. This is effectively
+  just `Enum.reduce(accounts, state_trie, &Account.put_account/1)`,
+  but more complicated due to repeat accounts and certain nuances (such
+  as the keys being pre-hashed).
+
+  We return a state trie whose root should be used for the next call
+  to `process_account_states`.
+  """
+  @spec process_account_states(list(account_state()), Trie.t()) :: Trie.t()
+  def process_account_states(account_states, state_trie) do
+    next_state_trie =
+      Enum.reduce(account_states, state_trie, fn
+        {address_hash, account_encoded_rlp, nil}, curr_state_trie ->
+          TrieStorage.update_key(curr_state_trie, address_hash, account_encoded_rlp)
+
+        {address_hash, account_encoded_rlp, storage}, curr_state_trie ->
+          existing_account_rlp = TrieStorage.get_key(curr_state_trie, address_hash)
+
+          {new_account_rlp, new_state_trie} =
+            if existing_account_rlp do
+              reprocess_account(storage, existing_account_rlp, curr_state_trie)
+            else
+              {account_encoded_rlp, curr_state_trie}
+            end
+
+          TrieStorage.update_key(new_state_trie, address_hash, new_account_rlp)
+      end)
+
+    next_state_trie
+  end
+
+  # Some later accounts may be included in different state chunks, and therefore
+  # in different "account states." For those accounts, we need to pull the existing
+  # state trie and add the storage data to that trie, versus overwriting what was
+  # already there.
+  @spec reprocess_account(list({EVM.hash(), <<_::256>>}), binary(), Trie.t()) ::
+          {binary(), Trie.t()}
+  defp reprocess_account(storage, existing_account_rlp, trie) do
+    existing_account =
+      existing_account_rlp
+      |> ExRLP.decode()
+      |> Blockchain.Account.deserialize()
+
+    {new_trie, storage_root_hash} =
+      process_account_storage(storage, trie, existing_account.storage_root)
+
+    new_account_rlp =
+      existing_account
+      |> Map.put(:storage_root, storage_root_hash)
+      |> Blockchain.Account.serialize()
+      |> ExRLP.encode()
+
+    {new_account_rlp, new_trie}
+  end
+
+  # Returns the ommers hash given the ommers RLP.
+  @spec get_ommers_hash(list(binary())) :: EVM.hash()
+  defp get_ommers_hash(ommers_rlp) do
+    ommers_rlp
+    |> ExRLP.encode()
+    |> ExthCrypto.Hash.Keccak.kec()
+  end
+end

--- a/apps/ex_wire/lib/ex_wire/sync/warp_state.ex
+++ b/apps/ex_wire/lib/ex_wire/sync/warp_state.ex
@@ -1,0 +1,57 @@
+defmodule ExWire.Sync.WarpState do
+  @moduledoc """
+  Warp may take some time, and thus we want to occasionally snapshot
+  the current state of a warp in case our process exits before the
+  warp is complete. When we restart the process, we can try and continue
+  from where the warp left off.
+
+  This module exposes functions to store and load the current state of
+  a warp in the database.
+  """
+  require Logger
+
+  alias Exth.Time
+  alias ExWire.Struct.WarpQueue
+  alias MerklePatriciaTree.DB
+
+  @key "current_warp_queue"
+
+  @doc """
+  Loads the current warp queue from database.
+  """
+  @spec load_warp_queue(DB.db()) :: WarpQueue.t()
+  def load_warp_queue(db) do
+    case DB.get(db, @key) do
+      {:ok, current_warp_queue} ->
+        warp_queue = :erlang.binary_to_term(current_warp_queue)
+
+        %{
+          warp_queue
+          | warp_start: Time.time_start()
+        }
+
+      :not_found ->
+        WarpQueue.new()
+    end
+  end
+
+  @doc """
+  Stores the current block tree into the database.
+  """
+  @spec save_warp_queue(DB.db(), WarpQueue.t()) :: :ok
+  def save_warp_queue(db, warp_queue) do
+    :ok = Logger.debug(fn -> "Saving warp queue..." end)
+
+    DB.put!(
+      db,
+      @key,
+      :erlang.term_to_binary(%{
+        warp_queue
+        | chunk_requests: MapSet.new(),
+          retrieved_chunks: MapSet.new()
+      })
+    )
+
+    :ok
+  end
+end

--- a/apps/ex_wire/mix.exs
+++ b/apps/ex_wire/mix.exs
@@ -34,7 +34,9 @@ defmodule ExWire.Mixfile do
     [
       {:ex_doc, "~> 0.16", only: :dev, runtime: false},
       {:ex_rlp, "~> 0.5.0"},
+      {:snappyer, "~> 1.2"},
       {:blockchain, in_umbrella: true},
+      {:exth, in_umbrella: true},
       {:exth_crypto, in_umbrella: true},
       {:evm, in_umbrella: true}
     ]

--- a/apps/ex_wire/test/ex_wire/packet/capability/eth/status_test.exs
+++ b/apps/ex_wire/test/ex_wire/packet/capability/eth/status_test.exs
@@ -33,9 +33,7 @@ defmodule ExWire.Packet.Capability.Eth.StatusTest do
                {:send,
                 %ExWire.Packet.Capability.Eth.Status{
                   best_hash: <<4>>,
-                  block_number: nil,
                   genesis_hash: <<4>>,
-                  manifest_hash: nil,
                   network_id: 3,
                   protocol_version: 63,
                   total_difficulty: 10
@@ -66,9 +64,7 @@ defmodule ExWire.Packet.Capability.Eth.StatusTest do
                   best_hash: best_block.block_hash,
                   network_id: 3,
                   protocol_version: 63,
-                  total_difficulty: best_block.header.difficulty,
-                  block_number: nil,
-                  manifest_hash: nil
+                  total_difficulty: best_block.header.difficulty
                 }}
     end
   end

--- a/apps/ex_wire/test/ex_wire/packet/capability/par/get_snapshot_data_test.exs
+++ b/apps/ex_wire/test/ex_wire/packet/capability/par/get_snapshot_data_test.exs
@@ -1,0 +1,4 @@
+defmodule ExWire.Packet.Capability.Par.GetSnapshotDataTest do
+  use ExUnit.Case, async: true
+  doctest ExWire.Packet.Capability.Par.GetSnapshotData
+end

--- a/apps/ex_wire/test/ex_wire/packet/capability/par/get_snapshot_manifest_test.exs
+++ b/apps/ex_wire/test/ex_wire/packet/capability/par/get_snapshot_manifest_test.exs
@@ -1,0 +1,4 @@
+defmodule ExWire.Packet.Capability.Par.GetSnapshotManifestTest do
+  use ExUnit.Case, async: true
+  doctest ExWire.Packet.Capability.Par.GetSnapshotManifest
+end

--- a/apps/ex_wire/test/ex_wire/packet/capability/par/snapshot_data/block_chunk_test.exs
+++ b/apps/ex_wire/test/ex_wire/packet/capability/par/snapshot_data/block_chunk_test.exs
@@ -1,0 +1,4 @@
+defmodule ExWire.Packet.Capability.Par.SnapshotData.BlockChunkTest do
+  use ExUnit.Case, async: true
+  doctest ExWire.Packet.Capability.Par.SnapshotData.BlockChunk
+end

--- a/apps/ex_wire/test/ex_wire/packet/capability/par/snapshot_data/state_chunk_test.exs
+++ b/apps/ex_wire/test/ex_wire/packet/capability/par/snapshot_data/state_chunk_test.exs
@@ -1,0 +1,4 @@
+defmodule ExWire.Packet.Capability.Par.SnapshotData.StateChunkTest do
+  use ExUnit.Case, async: true
+  doctest ExWire.Packet.Capability.Par.SnapshotData.StateChunk
+end

--- a/apps/ex_wire/test/ex_wire/packet/capability/par/snapshot_data_test.exs
+++ b/apps/ex_wire/test/ex_wire/packet/capability/par/snapshot_data_test.exs
@@ -1,0 +1,4 @@
+defmodule ExWire.Packet.Capability.Par.SnapshotDataTest do
+  use ExUnit.Case, async: true
+  doctest ExWire.Packet.Capability.Par.SnapshotData
+end

--- a/apps/ex_wire/test/ex_wire/packet/capability/par/snapshot_manifest_test.exs
+++ b/apps/ex_wire/test/ex_wire/packet/capability/par/snapshot_manifest_test.exs
@@ -1,0 +1,4 @@
+defmodule ExWire.Packet.Capability.Par.SnapshotManifestTest do
+  use ExUnit.Case, async: true
+  doctest ExWire.Packet.Capability.Par.SnapshotManifest
+end

--- a/apps/ex_wire/test/ex_wire/packet/capability/par/warp_status_test.exs
+++ b/apps/ex_wire/test/ex_wire/packet/capability/par/warp_status_test.exs
@@ -1,0 +1,4 @@
+defmodule ExWire.Packet.Capability.Par.WarpStatusTest do
+  use ExUnit.Case, async: true
+  doctest ExWire.Packet.Capability.Par.WarpStatus
+end

--- a/apps/ex_wire/test/ex_wire/struct/warp_queue_test.exs
+++ b/apps/ex_wire/test/ex_wire/struct/warp_queue_test.exs
@@ -1,0 +1,5 @@
+defmodule ExWire.Struct.WarpQueueTest do
+  use ExUnit.Case, async: true
+  alias ExWire.Struct.WarpQueue
+  doctest WarpQueue
+end

--- a/apps/ex_wire/test/ex_wire/sync/warp_processor/pow_processor_test.exs
+++ b/apps/ex_wire/test/ex_wire/sync/warp_processor/pow_processor_test.exs
@@ -1,0 +1,565 @@
+defmodule ExWire.Sync.WarpProcessor.PowProcessorTest do
+  use ExUnit.Case, async: true
+  alias Block.Header
+  alias Blockchain.{Account, Block, Transaction}
+  alias Blockchain.Transaction.Receipt
+  alias ExthCrypto.Hash.Keccak
+  alias ExWire.Packet.Capability.Par.SnapshotData.{BlockChunk, StateChunk}
+  alias ExWire.Sync.WarpProcessor.PowProcessor
+  alias MerklePatriciaTree.{Trie, TrieStorage}
+  doctest PowProcessor
+
+  @empty_trie Trie.empty_trie_root_hash()
+
+  describe "#process_block_chunk/2" do
+    trie =
+      MerklePatriciaTree.Test.random_ets_db()
+      |> Trie.new()
+
+    block_data_1 = %BlockChunk.BlockData{
+      header: %BlockChunk.BlockHeader{
+        author: <<1::160>>,
+        state_root: <<2::256>>,
+        logs_bloom: <<3::2048>>,
+        difficulty: 1_000_000,
+        gas_limit: 6_000_000,
+        gas_used: 10_000,
+        timestamp: 123_456_789,
+        extra_data: "cool!",
+        transactions: [],
+        transactions_rlp: [],
+        ommers: [],
+        ommers_rlp: [],
+        mix_hash: <<10::256>>,
+        nonce: <<11::64>>
+      },
+      receipts: [],
+      receipts_rlp: []
+    }
+
+    block_data_2 = %BlockChunk.BlockData{
+      header: %BlockChunk.BlockHeader{
+        author: <<2::160>>,
+        state_root: <<3::256>>,
+        logs_bloom: <<4::2048>>,
+        difficulty: 1_000_001,
+        gas_limit: 6_000_000,
+        gas_used: 20_000,
+        timestamp: 123_456_789,
+        extra_data: "cool 2x!",
+        transactions: [],
+        transactions_rlp: [],
+        ommers: [],
+        ommers_rlp: [],
+        mix_hash: <<10::256>>,
+        nonce: <<11::64>>
+      },
+      receipts: [],
+      receipts_rlp: []
+    }
+
+    block_chunk = %BlockChunk{
+      number: 500,
+      hash: <<55::256>>,
+      total_difficulty: 1_000_001,
+      block_data_list: [
+        block_data_1,
+        block_data_2
+      ]
+    }
+
+    assert {processed_blocks, block, next_trie} =
+             PowProcessor.process_block_chunk(block_chunk, trie)
+
+    assert processed_blocks == MapSet.new([501, 502])
+    assert block.header.number == 502
+  end
+
+  describe "#process_state_chunk/2" do
+    test "properly handles multiple accounts" do
+      trie =
+        MerklePatriciaTree.Test.random_ets_db()
+        |> Trie.new()
+
+      state_chunk = %StateChunk{
+        account_entries: [
+          {<<1::256>>,
+           %StateChunk.RichAccount{
+             nonce: 1,
+             balance: 1,
+             code_flag: :no_code,
+             code: <<>>,
+             storage: [{<<1::256>>, <<1::256>>}]
+           }},
+          {<<2::256>>,
+           %StateChunk.RichAccount{
+             nonce: 2,
+             balance: 2,
+             code_flag: :no_code,
+             code: <<>>,
+             storage: [{<<2::256>>, <<2::256>>}]
+           }},
+          {<<3::256>>,
+           %StateChunk.RichAccount{
+             nonce: 3,
+             balance: 3,
+             code_flag: :no_code,
+             code: <<>>,
+             storage: [{<<3::256>>, <<3::256>>}]
+           }}
+        ]
+      }
+
+      assert {[
+                {<<1::256>>, _account_1_rlp, [{<<1::256>>, <<1::256>>}]},
+                {<<2::256>>, _account_2_rlp, nil},
+                {<<3::256>>, _account_3_rlp, [{<<3::256>>, <<3::256>>}]}
+              ], _} = PowProcessor.process_state_chunk(state_chunk, trie)
+    end
+  end
+
+  describe "#process_block/5" do
+    test "given a block data, returns a proper block saved to the trie" do
+      trie =
+        MerklePatriciaTree.Test.random_ets_db()
+        |> Trie.new()
+
+      transactions = [
+        transaction = %Transaction{
+          nonce: 1,
+          gas_price: 2,
+          gas_limit: 3,
+          to: <<4::160>>,
+          value: 5,
+          v: 6,
+          r: 7,
+          s: 1,
+          init: <<>>,
+          data: <<5::256, 6::256>>
+        }
+      ]
+
+      receipts = [
+        receipt = %Receipt{
+          state: <<12::256>>,
+          cumulative_gas: 20,
+          bloom_filter: <<13::2048>>,
+          logs: []
+        }
+      ]
+
+      ommers = [
+        %Header{
+          parent_hash: <<20::256>>,
+          ommers_hash: Keccak.kec(<<>>),
+          beneficiary: <<21::160>>,
+          state_root: <<22::256>>,
+          transactions_root: <<23::256>>,
+          receipts_root: <<24::256>>,
+          logs_bloom: <<25::2048>>,
+          difficulty: 200,
+          number: 201,
+          gas_limit: 202,
+          gas_used: 203,
+          timestamp: 204,
+          extra_data: <<>>,
+          mix_hash: <<0::256>>,
+          nonce: <<0::64>>
+        }
+      ]
+
+      block_data = %BlockChunk.BlockData{
+        header: %BlockChunk.BlockHeader{
+          author: <<1::160>>,
+          state_root: <<2::256>>,
+          logs_bloom: <<3::2048>>,
+          difficulty: 1_000_000,
+          gas_limit: 6_000_000,
+          gas_used: 10_000,
+          timestamp: 123_456_789,
+          extra_data: "cool!",
+          transactions: transactions,
+          transactions_rlp: Enum.map(transactions, &Transaction.serialize/1),
+          ommers: ommers,
+          ommers_rlp: Enum.map(ommers, &Header.serialize/1),
+          mix_hash: <<10::256>>,
+          nonce: <<11::64>>
+        },
+        receipts: receipts,
+        receipts_rlp: Enum.map(receipts, &Receipt.serialize/1)
+      }
+
+      assert {next_trie, block} = PowProcessor.process_block(block_data, <<255::256>>, 201, trie)
+
+      # Make sure the block matches expectations
+      assert block == %Block{
+               block_hash:
+                 <<231, 180, 221, 248, 0, 10, 93, 194, 91, 102, 211, 37, 84, 232, 227, 204, 125,
+                   141, 30, 203, 183, 32, 105, 25, 15, 139, 192, 116, 160, 126, 146, 153>>,
+               header: %Header{
+                 parent_hash: <<255::256>>,
+                 ommers_hash:
+                   <<85, 56, 57, 222, 127, 245, 151, 250, 92, 28, 22, 12, 0, 242, 175, 102, 156,
+                     229, 75, 117, 156, 172, 159, 12, 254, 233, 104, 52, 45, 16, 153, 110>>,
+                 beneficiary: <<1::160>>,
+                 state_root: <<2::256>>,
+                 transactions_root:
+                   <<142, 251, 208, 146, 224, 3, 149, 181, 212, 219, 38, 154, 87, 163, 69, 192,
+                     25, 172, 144, 160, 89, 253, 8, 145, 206, 166, 219, 98, 4, 237, 20, 22>>,
+                 receipts_root:
+                   <<11, 58, 57, 115, 68, 41, 47, 58, 109, 82, 159, 87, 205, 177, 44, 90, 21, 244,
+                     132, 108, 152, 90, 55, 125, 62, 10, 149, 27, 132, 51, 51, 168>>,
+                 logs_bloom: <<3::2048>>,
+                 difficulty: 1_000_000,
+                 number: 201,
+                 gas_limit: 6_000_000,
+                 gas_used: 10_000,
+                 timestamp: 123_456_789,
+                 extra_data: "cool!",
+                 mix_hash: <<10::256>>,
+                 nonce: <<11::64>>
+               },
+               transactions: transactions,
+               receipts: receipts,
+               ommers: ommers
+             }
+
+      # Next, let's check that our trie has all the right data
+      assert Block.get_block(block.block_hash, next_trie) ==
+               {:ok, %{block | receipts: [], block_hash: nil}}
+
+      assert Block.get_transaction(block, 0, next_trie.db) == transaction
+      assert Block.get_transaction(block, 1, next_trie.db) == nil
+
+      assert Block.get_receipt(block, 0, next_trie.db) == receipt
+      assert Block.get_receipt(block, 1, next_trie.db) == nil
+    end
+  end
+
+  describe "#process_account/4" do
+    test "properly handles account with no code" do
+      trie =
+        MerklePatriciaTree.Test.random_ets_db()
+        |> Trie.new()
+
+      rich_account = %StateChunk.RichAccount{
+        nonce: 1,
+        balance: 1,
+        code_flag: :no_code,
+        code: <<>>,
+        storage: [{<<1::256>>, <<1::256>>}]
+      }
+
+      assert {_, {<<1::256>>, account_rlp, storage}} =
+               PowProcessor.process_account(<<1::256>>, rich_account, trie, true)
+
+      {_, expected_storage_root} =
+        process_account_storage(
+          [{<<1::256>>, <<1::256>>}],
+          trie,
+          @empty_trie
+        )
+
+      assert Account.deserialize(ExRLP.decode(account_rlp)) == %Account{
+               nonce: 1,
+               balance: 1,
+               code_hash: Keccak.kec(<<>>),
+               storage_root: expected_storage_root
+             }
+
+      assert storage == [{<<1::256>>, <<1::256>>}]
+    end
+
+    test "properly handles account with code" do
+      trie =
+        MerklePatriciaTree.Test.random_ets_db()
+        |> Trie.new()
+
+      rich_account = %StateChunk.RichAccount{
+        nonce: 1,
+        balance: 1,
+        code_flag: :has_code,
+        code: "code",
+        storage: [{<<1::256>>, <<1::256>>}]
+      }
+
+      assert {new_trie, {<<1::256>>, account_rlp, storage}} =
+               PowProcessor.process_account(<<1::256>>, rich_account, trie, true)
+
+      assert Trie.get_raw_key(new_trie, Keccak.kec("code")) == {:ok, "code"}
+
+      {_, expected_storage_root} =
+        process_account_storage(
+          [{<<1::256>>, <<1::256>>}],
+          trie,
+          @empty_trie
+        )
+
+      assert Account.deserialize(ExRLP.decode(account_rlp)) == %Account{
+               nonce: 1,
+               balance: 1,
+               code_hash: Keccak.kec("code"),
+               storage_root: expected_storage_root
+             }
+
+      assert storage == [{<<1::256>>, <<1::256>>}]
+    end
+
+    test "properly handles account with repeat code" do
+      trie =
+        MerklePatriciaTree.Test.random_ets_db()
+        |> Trie.new()
+
+      rich_account = %StateChunk.RichAccount{
+        nonce: 1,
+        balance: 1,
+        code_flag: :has_repeat_code,
+        code: Keccak.kec("code"),
+        storage: [{<<1::256>>, <<1::256>>}]
+      }
+
+      assert {new_trie, {<<1::256>>, account_rlp, storage}} =
+               PowProcessor.process_account(<<1::256>>, rich_account, trie, true)
+
+      assert Trie.get_raw_key(new_trie, Keccak.kec("code")) == :not_found
+
+      {_, expected_storage_root} =
+        process_account_storage(
+          [{<<1::256>>, <<1::256>>}],
+          trie,
+          @empty_trie
+        )
+
+      assert Account.deserialize(ExRLP.decode(account_rlp)) == %Account{
+               nonce: 1,
+               balance: 1,
+               code_hash: Keccak.kec("code"),
+               storage_root: expected_storage_root
+             }
+
+      assert storage == [{<<1::256>>, <<1::256>>}]
+    end
+
+    test "properly handles account with keep storage set to false" do
+      trie =
+        MerklePatriciaTree.Test.random_ets_db()
+        |> Trie.new()
+
+      rich_account = %StateChunk.RichAccount{
+        nonce: 1,
+        balance: 1,
+        code_flag: :has_repeat_code,
+        code: Keccak.kec("code"),
+        storage: [{<<1::256>>, <<1::256>>}]
+      }
+
+      assert {new_trie, {<<1::256>>, account_rlp, nil}} =
+               PowProcessor.process_account(<<1::256>>, rich_account, trie, false)
+
+      assert Trie.get_raw_key(new_trie, Keccak.kec("code")) == :not_found
+
+      {_, expected_storage_root} =
+        process_account_storage(
+          [{<<1::256>>, <<1::256>>}],
+          trie,
+          @empty_trie
+        )
+
+      assert Account.deserialize(ExRLP.decode(account_rlp)) == %Account{
+               nonce: 1,
+               balance: 1,
+               code_hash: Keccak.kec("code"),
+               storage_root: expected_storage_root
+             }
+    end
+  end
+
+  describe "#process_account_states/2" do
+    setup do
+      trie =
+        MerklePatriciaTree.Test.random_ets_db()
+        |> Trie.new()
+
+      blank_account =
+        %Account{}
+        |> Account.serialize()
+        |> ExRLP.encode()
+
+      first_storage = [{<<1::256>>, <<10::256>>}]
+      second_storage = [{<<2::256>>, <<10::256>>}]
+
+      {trie, root_hash_first} = process_account_storage(first_storage, trie, @empty_trie)
+
+      {trie, root_hash_second} = process_account_storage(second_storage, trie, @empty_trie)
+
+      first_account =
+        %Account{storage_root: root_hash_first}
+        |> Account.serialize()
+        |> ExRLP.encode()
+
+      second_account =
+        %Account{storage_root: root_hash_second}
+        |> Account.serialize()
+        |> ExRLP.encode()
+
+      {:ok,
+       %{
+         trie: trie,
+         blank_account: blank_account,
+         first_storage: first_storage,
+         second_storage: second_storage,
+         first_account: first_account,
+         second_account: second_account
+       }}
+    end
+
+    test "returns correct state trie for simple accounts", %{
+      trie: trie,
+      blank_account: blank_account
+    } do
+      account_states = [
+        {<<1::256>>, blank_account, nil},
+        {<<2::256>>, blank_account, nil}
+      ]
+
+      more_account_states = [
+        {<<3::256>>, blank_account, nil},
+        {<<4::256>>, blank_account, nil}
+      ]
+
+      next_trie = PowProcessor.process_account_states(account_states, trie)
+
+      assert Exth.encode_hex(TrieStorage.root_hash(next_trie)) ==
+               "0x643dbbff270e2938cf0876a8ba59cd03fb148da2ea49e34ea38697e42cbe143d"
+
+      # Encode again and verify returns the same hash
+      next_trie_2 = PowProcessor.process_account_states(account_states, trie)
+
+      assert Exth.encode_hex(TrieStorage.root_hash(next_trie_2)) ==
+               "0x643dbbff270e2938cf0876a8ba59cd03fb148da2ea49e34ea38697e42cbe143d"
+
+      # Reverse the order and encode and check returns the same hash
+      next_trie_3 = PowProcessor.process_account_states(Enum.reverse(account_states), trie)
+
+      assert Exth.encode_hex(TrieStorage.root_hash(next_trie_3)) ==
+               "0x643dbbff270e2938cf0876a8ba59cd03fb148da2ea49e34ea38697e42cbe143d"
+
+      # Run the accounts again on a previous trie and verify returns the same hash
+      next_trie_4 = PowProcessor.process_account_states(account_states, next_trie)
+
+      assert Exth.encode_hex(TrieStorage.root_hash(next_trie_4)) ==
+               "0x643dbbff270e2938cf0876a8ba59cd03fb148da2ea49e34ea38697e42cbe143d"
+
+      # Run the other account states
+      next_trie_5 = PowProcessor.process_account_states(more_account_states, next_trie)
+
+      assert Exth.encode_hex(TrieStorage.root_hash(next_trie_5)) ==
+               "0x1e0dd79b3c5b712562afa8033232817255e97f30afe80c09467dc5bd16b860f8"
+
+      # The run in the other order
+      next_trie_6 = PowProcessor.process_account_states(more_account_states, trie)
+
+      assert Exth.encode_hex(TrieStorage.root_hash(next_trie_6)) ==
+               "0x89b4a683f0769508747afb2a8452b349659fc500c86e323b493711e1e358b04d"
+
+      next_trie_7 = PowProcessor.process_account_states(account_states, next_trie_6)
+
+      # This should match next_trie_5
+      assert Exth.encode_hex(TrieStorage.root_hash(next_trie_7)) ==
+               "0x1e0dd79b3c5b712562afa8033232817255e97f30afe80c09467dc5bd16b860f8"
+    end
+
+    test "returns correct state trie with existing account", %{
+      trie: trie,
+      blank_account: blank_account,
+      first_account: first_account,
+      first_storage: first_storage,
+      second_account: second_account,
+      second_storage: second_storage
+    } do
+      account_states = [
+        {<<1::256>>, blank_account, nil},
+        {<<2::256>>, first_account, first_storage}
+      ]
+
+      more_account_states = [
+        {<<2::256>>, second_account, second_storage},
+        {<<3::256>>, blank_account, nil}
+      ]
+
+      # First, run account states
+      next_trie = PowProcessor.process_account_states(account_states, trie)
+
+      assert Exth.encode_hex(TrieStorage.root_hash(next_trie)) ==
+               "0x526935838f9214110c1b1afc3c334877d0536b985bdb8f2afd490c8431a267e2"
+
+      # Then run more_account_states on top
+      next_trie_2 = PowProcessor.process_account_states(more_account_states, next_trie)
+
+      assert Exth.encode_hex(TrieStorage.root_hash(next_trie_2)) ==
+               "0x752d3962560c5f78ddd6266d4ce78ff8771281fb6f3924f5c18fbc9c5cc0a2ca"
+
+      # Now, run more account states
+      next_trie_3 = PowProcessor.process_account_states(more_account_states, trie)
+
+      assert Exth.encode_hex(TrieStorage.root_hash(next_trie_3)) ==
+               "0xf619e70caa1e2b60bd68f52d37e64682c13f9145307026b363cabe56db123e46"
+
+      # Then run account_states on top
+      next_trie_4 = PowProcessor.process_account_states(account_states, next_trie_3)
+
+      assert Exth.encode_hex(TrieStorage.root_hash(next_trie_4)) ==
+               "0x752d3962560c5f78ddd6266d4ce78ff8771281fb6f3924f5c18fbc9c5cc0a2ca"
+    end
+
+    test "ignores existing accounts if storage not included", %{
+      trie: trie,
+      blank_account: blank_account,
+      second_account: second_account,
+      second_storage: second_storage
+    } do
+      account_states = [
+        {<<1::256>>, blank_account, nil}
+      ]
+
+      more_account_states = [
+        {<<2::256>>, second_account, second_storage},
+        {<<3::256>>, blank_account, nil}
+      ]
+
+      # First, run account states
+      next_trie = PowProcessor.process_account_states(account_states, trie)
+
+      assert Exth.encode_hex(TrieStorage.root_hash(next_trie)) ==
+               "0x69b5c560f84dde1ecb0584976f4ebbe78e34bb6f32410777309a8693424bb563"
+
+      # Then run more_account_states on top
+      next_trie_2 = PowProcessor.process_account_states(more_account_states, next_trie)
+
+      assert Exth.encode_hex(TrieStorage.root_hash(next_trie_2)) ==
+               "0x2eabd1076c70e6a47969dd85b586a1cacfa922cd1ba6d705dc90c8525df69159"
+
+      # Now, run more account states
+      next_trie_3 = PowProcessor.process_account_states(more_account_states, trie)
+
+      assert Exth.encode_hex(TrieStorage.root_hash(next_trie_3)) ==
+               "0xf619e70caa1e2b60bd68f52d37e64682c13f9145307026b363cabe56db123e46"
+
+      # Then run account_states on top
+      next_trie_4 = PowProcessor.process_account_states(account_states, next_trie_3)
+
+      assert Exth.encode_hex(TrieStorage.root_hash(next_trie_4)) ==
+               "0x2eabd1076c70e6a47969dd85b586a1cacfa922cd1ba6d705dc90c8525df69159"
+    end
+  end
+
+  defp process_account_storage(storage, trie, root_hash) do
+    Enum.reduce(storage, {trie, root_hash}, fn {k, v}, {curr_trie, curr_root} ->
+      {subtrie, updated_trie} = TrieStorage.update_subtrie_key(curr_trie, curr_root, k, v)
+
+      updated_root_hash = TrieStorage.root_hash(subtrie)
+
+      {updated_trie, updated_root_hash}
+    end)
+  end
+end

--- a/apps/ex_wire/test/ex_wire/sync/warp_processor_test.exs
+++ b/apps/ex_wire/test/ex_wire/sync/warp_processor_test.exs
@@ -1,0 +1,5 @@
+defmodule ExWire.Sync.WarpProcessorTest do
+  use ExUnit.Case, async: true
+  alias ExWire.Sync.WarpProcessor
+  doctest WarpProcessor
+end

--- a/apps/ex_wire/test/ex_wire/sync/warp_state_test.exs
+++ b/apps/ex_wire/test/ex_wire/sync/warp_state_test.exs
@@ -1,0 +1,5 @@
+defmodule ExWire.Sync.WarpStateTest do
+  use ExUnit.Case, async: true
+  alias ExWire.Sync.WarpState
+  doctest WarpState
+end

--- a/apps/ex_wire/test/ex_wire/sync_test.exs
+++ b/apps/ex_wire/test/ex_wire/sync_test.exs
@@ -1,4 +1,268 @@
 defmodule ExWire.SyncTest do
+  @moduledoc """
+  This is effectively an end-to-end test of warp sync with local blockchain
+  data from the Ethereum common tests. The tests are a little difficult to
+  work with as they don't have receipts listed, so right now we're ignoring
+  the receipts, which gives us a different block hash. Also, we do not seem
+  to be matching the state root, so those items should be looked into futher.
+  """
   use ExUnit.Case, async: true
   doctest ExWire.Sync
+
+  alias Block.Header
+  alias Blockchain.{Block, Transaction}
+  alias ExthCrypto.Hash.Keccak
+  alias ExWire.Packet.Capability.Par.{SnapshotData, SnapshotManifest}
+  alias ExWire.Packet.Capability.Par.SnapshotData.{BlockChunk, StateChunk}
+  alias ExWire.Struct.{Peer, WarpQueue}
+  alias ExWire.Sync
+  alias ExWire.Sync.WarpProcessor
+  alias ExWire.Sync.WarpProcessor.PowProcessor
+  alias MerklePatriciaTree.{Trie, TrieStorage}
+
+  @empty_trie Trie.empty_trie_root_hash()
+
+  describe "warp sync" do
+    test "ContractStoreClearsOOG_d0g0v0_Homestead" do
+      run_test(
+        "../../ethereum_common_tests/BlockchainTests/GeneralStateTests/stTransactionTest/ContractStoreClearsOOG_d0g0v0.json",
+        "ContractStoreClearsOOG_d0g0v0_Homestead",
+        :homestead_test,
+        block_hash: "0xa5c57a69d9186d7a3a70fe4fe8472a253f7de9e29deac437c4d675b1fb1dc971",
+        state_root: "0xbb80b5bd8b3b45b80eebebe47c753d1dea86ec96fbfb2c554a8f50018597f036"
+      )
+    end
+
+    test "add11_d0g0v0_Homestead" do
+      run_test(
+        "../../ethereum_common_tests/BlockchainTests/GeneralStateTests/stExample/add11_d0g0v0.json",
+        "add11_d0g0v0_Homestead",
+        :homestead_test,
+        block_hash: "0xf2e350b3f0632d360a2763df744cd3ef3b9ffb8f30a508835dc559e7a3819a4a",
+        state_root: "0x2858517a226c99034d066c582ddc45d25fc628ab0c7275bd5fb0ef0a25b3a8c2"
+      )
+    end
+  end
+
+  defp run_test(file, test, chain_id, opts) do
+    {
+      test_info,
+      blocks,
+      manifest,
+      block_snapshot_data,
+      state_snapshot_data
+    } = build_warp_from(file, test, chain_id, opts)
+
+    trie = MerklePatriciaTree.CachingTrie.new(memory_trie())
+    chain = Blockchain.Chain.load_chain(chain_id)
+
+    warp_queue =
+      WarpQueue.new()
+      |> WarpQueue.new_manifest(manifest)
+
+    {:ok, _peer_supervisor} = ExWire.PeerSupervisor.start_link([])
+
+    {:ok, _warp_processor} =
+      WarpProcessor.start_link({1, trie, @empty_trie, PowProcessor}, name: :test_warp_processor)
+
+    {:ok, sync} =
+      Sync.start_link({trie, chain, true, warp_queue},
+        name: :test_sync,
+        warp_processor: :test_warp_processor
+      )
+
+    send(sync, {:packet, block_snapshot_data, %Peer{}})
+    send(sync, {:packet, state_snapshot_data, %Peer{}})
+
+    # Give sync time to process the messages
+    Process.sleep(1_000)
+
+    # Get the warp queue
+    warp_queue = Sync.get_state(sync)[:warp_queue]
+
+    # Verify final warp queue state
+    assert warp_queue.manifest_block_hashes == MapSet.new([block_snapshot_data.hash])
+    assert warp_queue.manifest_state_hashes == MapSet.new([state_snapshot_data.hash])
+    assert warp_queue.chunk_requests == MapSet.new()
+
+    assert warp_queue.retrieved_chunks ==
+             MapSet.new([block_snapshot_data.hash, state_snapshot_data.hash])
+
+    block_numbers =
+      for block_info <- test_info["blocks"], into: MapSet.new() do
+        block_info["blockHeader"]["number"]
+        |> Exth.decode_hex()
+        |> Exth.maybe_decode_unsigned()
+      end
+
+    assert warp_queue.processed_blocks == block_numbers
+
+    # This is currently failing since we do not matching on receipts root
+    # since we don't have the receipts from the test data.
+    # assert WarpQueue.status(warp_queue, block_tree) == :success
+
+    account_hashes =
+      for {address, _} <- test_info["postState"], into: MapSet.new() do
+        Keccak.kec(Exth.decode_hex(address))
+      end
+
+    assert warp_queue.processed_accounts == MapSet.size(account_hashes)
+
+    # Verify block tree has the latest and great block
+    assert warp_queue.block_tree.best_block == List.last(blocks)
+
+    # Now, instead of inspecting the trie itself, let's query it for data
+    # that we consider relevant.
+
+    # Get all transactions
+    for block <- blocks do
+      for {transaction, i} <- Enum.with_index(block.transactions) do
+        assert transaction ==
+                 Blockchain.Block.get_transaction(block, i, TrieStorage.permanent_db(trie))
+      end
+    end
+
+    # Get receipts
+    # TODO: Since we don't have receipts
+  end
+
+  @spec build_warp_from(String.t(), String.t(), atom(), Keyword.t()) ::
+          {%{}, SnapshotManifest.manifest(), SnapshotData.t(), SnapshotData.t()}
+  defp build_warp_from(json_file, test_name, _chain_id, opts) do
+    test_info =
+      json_file
+      |> File.read!()
+      |> Jason.decode!()
+      |> Map.get(test_name)
+
+    {block_chunk, blocks} =
+      Enum.reduce(test_info["blocks"], {%BlockChunk{}, []}, fn block_json,
+                                                               {block_chunk, curr_blocks} ->
+        block =
+          block_json["rlp"]
+          |> Exth.decode_hex()
+          |> ExRLP.decode()
+          |> Block.deserialize()
+
+        # These test cases don't actually include the receipts,
+        # so either we need to actually process the blocks to generate
+        # the receipts, or we can just pretend there are none. We opt
+        # for the latter, for now.
+        block = %{
+          block
+          | header: %{
+              block.header
+              | receipts_root: MerklePatriciaTree.Trie.empty_trie_root_hash()
+            }
+        }
+
+        block = %{
+          block
+          | block_hash: Block.hash(block)
+        }
+
+        base_block_chunk =
+          if is_nil(block_chunk.number) do
+            %{block_chunk | number: block.header.number - 1, hash: block.header.parent_hash}
+          else
+            block_chunk
+          end
+
+        block_data = %BlockChunk.BlockData{
+          header: %BlockChunk.BlockHeader{
+            author: block.header.beneficiary,
+            state_root: block.header.state_root,
+            logs_bloom: block.header.logs_bloom,
+            difficulty: block.header.difficulty,
+            gas_limit: block.header.gas_limit,
+            gas_used: block.header.gas_used,
+            timestamp: block.header.timestamp,
+            extra_data: block.header.extra_data,
+            transactions: block.transactions,
+            transactions_rlp: Enum.map(block.transactions, &Transaction.serialize/1),
+            ommers: block.ommers,
+            ommers_rlp: Enum.map(block.ommers, &Header.serialize/1),
+            mix_hash: block.header.mix_hash,
+            nonce: block.header.nonce
+          },
+          receipts: [],
+          receipts_rlp: []
+        }
+
+        {%{
+           base_block_chunk
+           | total_difficulty: block.header.difficulty,
+             block_data_list: base_block_chunk.block_data_list ++ [block_data]
+         }, [block | curr_blocks]}
+      end)
+
+    block_snapshot_data = %SnapshotData{
+      chunk: block_chunk
+    }
+
+    [block_chunk_data] = SnapshotData.serialize(block_snapshot_data)
+
+    block_snapshot_data_with_hash = %{
+      block_snapshot_data
+      | hash: Keccak.kec(block_chunk_data)
+    }
+
+    post_state_account_entries =
+      for {address, account_json} <- test_info["postState"] do
+        code = Exth.decode_hex(account_json["code"])
+
+        rich_account = %StateChunk.RichAccount{
+          nonce: Exth.maybe_decode_unsigned(Exth.decode_hex(account_json["nonce"])),
+          balance: Exth.maybe_decode_unsigned(Exth.decode_hex(account_json["balance"])),
+          code_flag: if(code == <<>>, do: :no_code, else: :has_code),
+          code: Exth.decode_hex(account_json["code"]),
+          # TODO: Verify storage is sorted properly
+          storage:
+            for(
+              {k, v} <- account_json["storage"],
+              do: {Keccak.kec(Exth.decode_hex(k)), Exth.decode_hex(v)}
+            )
+            |> Enum.sort()
+        }
+
+        {Keccak.kec(Exth.decode_hex(address)), rich_account}
+      end
+
+    state_chunk = %StateChunk{
+      account_entries: post_state_account_entries
+    }
+
+    state_snapshot_data = %SnapshotData{
+      chunk: state_chunk
+    }
+
+    [state_chunk_data] = SnapshotData.serialize(state_snapshot_data)
+
+    state_snapshot_data_with_hash = %{
+      state_snapshot_data
+      | hash: Keccak.kec(state_chunk_data)
+    }
+
+    last_block_info = List.last(test_info["blocks"])
+
+    {test_info, Enum.reverse(blocks),
+     %SnapshotManifest.Manifest{
+       version: 2,
+       state_hashes: [state_snapshot_data_with_hash.hash],
+       block_hashes: [block_snapshot_data_with_hash.hash],
+       state_root:
+         Exth.decode_hex(
+           Keyword.get(opts, :state_root, last_block_info["blockHeader"]["stateRoot"])
+         ),
+       block_number:
+         Exth.maybe_decode_unsigned(Exth.decode_hex(last_block_info["blockHeader"]["number"])),
+       block_hash: Exth.decode_hex(Keyword.get(opts, :block_hash, test_info["lastblockhash"]))
+     }, block_snapshot_data_with_hash, state_snapshot_data_with_hash}
+  end
+
+  defp memory_trie() do
+    ets_db = MerklePatriciaTree.Test.random_ets_db()
+
+    MerklePatriciaTree.Trie.new(ets_db, MerklePatriciaTree.Trie.empty_trie_root_hash())
+  end
 end

--- a/apps/exth/lib/exth/time.ex
+++ b/apps/exth/lib/exth/time.ex
@@ -1,4 +1,6 @@
 defmodule Exth.Time do
+  @type time :: Time.t()
+
   @unit_abbreviations %{
     second: "s",
     millisecond: "ms",
@@ -10,12 +12,12 @@ defmodule Exth.Time do
     nanoseconds: "ns"
   }
 
-  @spec time_start() :: Time.t()
+  @spec time_start() :: time()
   def time_start() do
     Time.utc_now()
   end
 
-  @spec elapsed(fun() | Time.t(), System.time_unit()) :: String.t()
+  @spec elapsed(fun() | time(), System.time_unit()) :: String.t()
   def elapsed(start_or_fun, unit \\ :millisecond)
 
   def elapsed(fun, unit) when is_function(fun) do
@@ -30,7 +32,7 @@ defmodule Exth.Time do
     "#{total_time}#{get_unit_abbreviation(unit)}"
   end
 
-  @spec rate(non_neg_integer(), Time.t(), String.t(), System.time_unit()) :: String.t()
+  @spec rate(non_neg_integer(), time(), String.t(), System.time_unit()) :: String.t()
   def rate(count, start, desc, unit) do
     total_time = Time.diff(Time.utc_now(), start, unit)
 

--- a/mix.exs
+++ b/mix.exs
@@ -9,6 +9,7 @@ defmodule Mana.MixProject do
         :cli,
         :evm,
         :ex_wire,
+        :exth,
         :exth_crypto,
         :merkle_patricia_tree,
         :jsonrpc2

--- a/mix.lock
+++ b/mix.lock
@@ -36,6 +36,7 @@
   "progress_bar": {:hex, :progress_bar, "1.7.0", "51f45955245a257b49ef8d85528bbfe2c307c58891aefe8dd8bcf6015e6c4482", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: false]}], "hexpm"},
   "ranch": {:hex, :ranch, "1.6.2", "6db93c78f411ee033dbb18ba8234c5574883acb9a75af0fb90a9b82ea46afa00", [:rebar3], [], "hexpm"},
   "rocksdb": {:hex, :rocksdb, "0.23.3", "1e088c3870265d4c037c4ca274c4153dae739ce48d3c6536230c6b22226ff44e", [:rebar3], [], "hexpm"},
+  "snappyer": {:hex, :snappyer, "1.2.4", "6d739c534cd2339633127a2b40279be71f149e5842c5363a4d88e66efb7c1fec", [:make, :rebar, :rebar3], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.4", "f0eafff810d2041e93f915ef59899c923f4568f4585904d010387ed74988e77b", [:make, :mix, :rebar3], [], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm"},
   "websockex": {:git, "https://github.com/mana-ethereum/websockex.git", "d49cc68030179952db41d61cbcf46bfbc50094b8", [branch: "master"]},


### PR DESCRIPTION
This patch adds Warp Sync to Mana. Note: this is not fully stable yet, as there are a number of issues which can cause the sync to fail, but generally, the entire sync process is fully implemented in this patch. Sync works by returning the information about each block for the last several blocks, building a state tree from that, and then getting every single account state in chunks for the most recent block. After all of those are synced, you have the complete state going forward and can, in the background, sync the earlier parts of the chain.

    We generally code up the following modules:

    1. `ExWire.Sync` - GenServer responsible for warp and non-warp sync. This module contains the logic of how to communciate with remote peers and what to do in response to packets they send.
    2. `ExWire.WarpQueue` - Generally contains the current state of a warp (and we persist it during a warp so we can pick up where we left off). Keeps track of which block and state chunks we've processed so far and which we need to process going forward.
    3. `ExWire.WarpProcessor` - Keeps track of state and block chunks that haven't been processed and kicks off processing parallel. The parallel processing of state and block chunks is paramount to getting warp to run quickly.
    4. `ExWire.WarpProcessor.PowProcess` - The actual logic of how to process the state and block chunks for a warp. We process transaction receipts, store things to our trie, etc.

The good news is: our processing is relatively fast. We process (after a lot of optimization) around 3,000 accounts per second, which means that Ropsten with 20MM accounts takes a little over an hour to warp (I believe it's 30-40 minutes on Parity for Ropsten). These are early promising results.

The bad news is: we don't always match on the state or block trie after completing a warp, so there's still work to do. I generally sync Ellaism since it's small and easy to test with.

Also bad news: PoA chains in Parity have a different variety of warp messages, so we'll need to process them separately to support Kovan, etc.

Also bad news: Geth doesn't support warp, so we'll need to build fast sync, as well.

Finally, we didn't implement snapshotting ourselves, which we'll need to do to be a good warp peer.

References: 
  * Parity's [Warp Sync Docs](https://wiki.parity.io/Warp-Sync))
  * Parity's [Warp Sync Format](https://wiki.parity.io/Warp-Sync-Snapshot-Format.html)
  * Parity's [source for PoA sync format](https://github.com/paritytech/parity-ethereum/blob/master/ethcore/src/snapshot/consensus/authority.rs#L43)

FYI, to run the sync (you'll need to merge the other related PRs), but I copy my peer id for mana into `~/peer` and then run from mana:

`mix compile && TRACE=true iex -S mix mana --chain ropsten --no-discovery --bootnodes enode://2e0b03e3633c0a6b84da62f998c6ed9d3c05ab253a745abf0dd3866d3d8d870f3ba03f416cbe2ce28335dd7dff32c6733b86f714128cadafd479aabd95ccbe9b@127.0.0.1:30303 --warp`

For parity, I then run:

`parity --chain ropsten --no-discovery --reserved-peers ~/peer --reserved-only --logging sync,warp,network=trace`

This gives you great logs with very little noise.