### PR TITLE
Connect Warp Sync to Proper Packets

### DIFF
--- a/apps/ex_wire/config/config.exs
+++ b/apps/ex_wire/config/config.exs
@@ -26,8 +26,8 @@ mana_version =
 
 config :ex_wire,
   p2p_version: 0x04,
-  protocol_version: 63,
-  caps: [{"eth", 62}, {"eth", 63}, {"par", 1}],
+  protocol_version: 62,
+  caps: [{"eth", 62}, {"par", 1}],
   # TODO: This should be set and stored in a file
   private_key: :random,
   bootnodes: :from_chain,

--- a/apps/ex_wire/lib/ex_wire/dev_p2p/session.ex
+++ b/apps/ex_wire/lib/ex_wire/dev_p2p/session.ex
@@ -65,7 +65,7 @@ defmodule ExWire.DEVp2p.Session do
   """
   @spec disconnect(t) :: t
   def disconnect(session = %__MODULE__{}) do
-    %{session | hello_sent: nil, hello_received: nil, packet_id_map: PacketIdMap.default_map()}
+    %{session | hello_sent: nil, hello_received: nil, packet_id_map: nil}
   end
 
   @doc """
@@ -100,6 +100,6 @@ defmodule ExWire.DEVp2p.Session do
   """
   @spec compatible_capabilities?(t) :: boolean()
   def compatible_capabilities?(%__MODULE__{packet_id_map: packet_id_map}) do
-    packet_id_map != PacketIdMap.default_map()
+    Map.has_key?(packet_id_map.ids_to_modules, 0x10)
   end
 end

--- a/apps/ex_wire/lib/ex_wire/packet/capability/eth.ex
+++ b/apps/ex_wire/lib/ex_wire/packet/capability/eth.ex
@@ -16,7 +16,16 @@ defmodule ExWire.Packet.Capability.Eth do
       Eth.BlockHeaders,
       Eth.GetBlockBodies,
       Eth.BlockBodies,
-      Eth.NewBlock
+      Eth.NewBlock,
+      :reserved,
+      :reserved,
+      :reserved,
+      :reserved,
+      :reserved,
+      :reserved,
+      :reserved,
+      :reserved,
+      :reserved
     ]
   }
 

--- a/apps/ex_wire/lib/ex_wire/packet/capability/mana.ex
+++ b/apps/ex_wire/lib/ex_wire/packet/capability/mana.ex
@@ -1,9 +1,11 @@
 defmodule ExWire.Packet.Capability.Mana do
   alias ExWire.Packet.Capability
   alias ExWire.Packet.Capability.Eth
+  alias ExWire.Packet.Capability.Par
 
   @our_capabilities_map %{
-    Eth.get_name() => Eth
+    Eth.get_name() => Eth,
+    Par.get_name() => Par
   }
 
   @our_capabilities @our_capabilities_map

--- a/apps/ex_wire/lib/ex_wire/packet/capability/par.ex
+++ b/apps/ex_wire/lib/ex_wire/packet/capability/par.ex
@@ -1,6 +1,7 @@
 defmodule ExWire.Packet.Capability.Par do
   alias ExWire.Config
   alias ExWire.Packet.Capability
+  alias ExWire.Packet.Capability.Eth
   alias ExWire.Packet.Capability.Par
 
   @behaviour Capability
@@ -10,10 +11,26 @@ defmodule ExWire.Packet.Capability.Par do
   @version_to_packet_types %{
     1 => [
       Par.WarpStatus,
+      Eth.NewBlockHashes,
+      Eth.Transactions,
+      Eth.GetBlockHeaders,
+      Eth.BlockHeaders,
+      Eth.GetBlockBodies,
+      Eth.BlockBodies,
+      Eth.NewBlock,
       Par.GetSnapshotManifest,
       Par.SnapshotManifest,
       Par.GetSnapshotData,
-      Par.SnapshotData
+      Par.SnapshotData,
+      :reserved,
+      :reserved,
+      :reserved,
+      :reserved,
+      :reserved,
+      :reserved,
+      :reserved,
+      :reserved,
+      :reserved
     ]
   }
 

--- a/apps/ex_wire/test/ex_wire/packet/capability/eth/new_block_test.exs
+++ b/apps/ex_wire/test/ex_wire/packet/capability/eth/new_block_test.exs
@@ -1,0 +1,5 @@
+defmodule ExWire.Packet.Capability.Eth.NewBlockTest do
+  use ExUnit.Case, async: true
+  alias ExWire.Packet.Capability.Eth.NewBlock
+  doctest NewBlock
+end


### PR DESCRIPTION
This patch connects Warp Sync to the correct packets that come back from Parity when warp syncing. There were a few issues with the algorithm for determining packet ids. It appears that each capability has a size (to allow for protocol upgrades) and we skip that many before the next protocol. These aren't documented from come by Parity's source code. Additionally, it appears that once you negotiate a protocol, you still use the offests from Pv62 but from the higher negotiated ids. It's all a bit weird, but this seems to get everything working. Finally, we had an issue with default map getting called *a lot*, so we instead opt to hard-code the value and try to pass nil around instead of default map.