### PR TITLE
Update setup script to include bzip2

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -13,10 +13,10 @@ install_linux_deps() {
   echo $flavor
   case $flavor in
     debian|ubuntu)
-      sudo apt-get install -y $LINUX_DEPS libgmp-dev erlang-dev
+      sudo apt-get install -y $LINUX_DEPS libgmp-dev erlang-dev libbz2-dev
       ;;
     fedora|centos)
-      sudo yum install $LINUX_DEPS gmp-devel
+      sudo yum install $LINUX_DEPS gmp-devel bzip2 bzip2-devel
       ;;
     *)
       fancy_echo "Unrecognized distribution $flavor"


### PR DESCRIPTION
Building rocksdb was failing on my machine (Ubuntu 19.04) because of missing dependency on bzip2:

```
===> Compiling rocksdb
-- The C compiler identification is GNU 8.3.0
-- The CXX compiler identification is GNU 8.3.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Using OTP lib: /home/mosic/.asdf/installs/erlang/22.0.7/lib - found
-- Using erl_interface version: erl_interface-3.12
-- Using erts version: erts-10.4.4
-- Could NOT find BZip2 (missing: BZIP2_LIBRARIES BZIP2_INCLUDE_DIR) 
-- Found ZLIB: /usr/lib/x86_64-linux-gnu/libz.so (found version "1.2.11") 
CMake Error: The following variables are used in this project, but they are set to NOTFOUND.
Please set them or make sure they are set and tested correctly in the CMake files:
BZIP2_LIBRARY
    linked by target "erocksdb" in directory /home/mosic/mana/deps/rocksdb/c_src
```

I also added the dependency to the Fedora/CentOS build as well; I assume that it would fail with the same error there as well.